### PR TITLE
Fix multi-line options in side menu of Dashboard

### DIFF
--- a/src/options/style.css
+++ b/src/options/style.css
@@ -147,7 +147,8 @@ aside img {
 }
 .sidemenu > a {
   display: block;
-  line-height: 2.5rem;
+  padding-top: 0.6rem;
+  padding-bottom: 0.6rem;
   font-size: 1rem;
   font-weight: bold;
   text-decoration: none;


### PR DESCRIPTION
This issue popped up in Russian translation of Violentmonkey, so screenshots are in Russian:
![violentmonkey](https://user-images.githubusercontent.com/22861096/27430839-bc2b9178-570f-11e7-9e55-3c60e14efa85.png)

The problem arises from incorrectly used `line-height` to set the distance between options: `line-height` makes it look like the two-line options are in fact different options. `padding-top` and `padding-bottom` give the same distance between the menus, but keep default distance between lines of the same menu.