### PR TITLE
Complete Russian localization

### DIFF
--- a/src/_locales/ru/messages.yml
+++ b/src/_locales/ru/messages.yml
@@ -3,7 +3,7 @@ extName:
   message: Violentmonkey
 extDescription:
   description: Description for this extension.
-  message: ''
+  message: Violentmonkey позволяет пользователю автоматически вводить скрипты в страницы чтобы изменять их вид или поведение.
 msgUpdated:
   description: Message shown when a script is updated/reinstalled.
   message: Скрипт обновлен.
@@ -37,22 +37,22 @@ msgCheckingForUpdate:
   message: Проверка наличия обновлений...
 msgErrorFetchingUpdateInfo:
   description: Message shown when Violentmonkey fails fetching version data of the script.
-  message: Не удается проверить обновления.
+  message: Не удается проверить наличие обновлений.
 msgNoUpdate:
   description: Message shown when there is no new version of a script.
   message: Обновления не найдены.
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
-  message: Установка скрипта
+  message: Установка скрипта...
 buttonInstallOptions:
   description: Button to show options of installation confirm page.
   message: Настройки
 installOptionClose:
   description: Option to close confirm window after installation.
-  message: Закрыть после установки
+  message: Закрыть после установки.
 installOptionTrack:
   description: Option to track the loading local file before window is closed.
-  message: 'Следить за обновлениями локального файла, пока это окно открыто'
+  message: 'Следить за обновлениями локального файла, пока открыто это окно.'
 buttonConfirmInstallation:
   description: Button to confirm installation of a script.
   message: Установить
@@ -71,13 +71,13 @@ msgLoadedData:
   message: Скрипт загружен.
 msgErrorLoadingDependency:
   description: Message shown when not all requirements are loaded successfully.
-  message: Ошибка загрузки требований.
+  message: Ошибка загрузки необходимых компонентов.
 msgLoadingDependency:
   description: Message shown on confirm page when the requirements are being downloaded.
-  message: Загрузка требований... ($1/$2)
+  message: Загрузка необходимых компонентов... ($1/$2)
 msgLoadingData:
   description: Message shown on confirm page when the script to be installed is loading.
-  message: Загружается скрипт...
+  message: Загрузка скрипта...
 sideMenuInstalled:
   description: 'Side menu: Installed scripts'
   message: Установленные скрипты
@@ -98,16 +98,16 @@ anchorGetMoreScripts:
   message: Скачать скрипты
 msgLoading:
   description: Message shown in the options page before script list is loaded.
-  message: Загрузка ...
+  message: Загрузка...
 labelSettings:
   description: Label shown on the top of settings page
   message: Настройки
 labelAutoUpdate:
   description: Option to allow automatically checking scripts for updates every 24 hours.
-  message: Ежедневно проверять обновления скриптов
+  message: Ежедневно проверять наличие обновлений скриптов.
 labelIgnoreGrant:
   description: Option to suppress no @grant warnings.
-  message: Не показывать предупреждения об отсутствии поля @grant
+  message: Не показывать предупреждения об отсутствии поля @grant.
 labelDataImport:
   description: Section title of data import.
   message: Импорт данных
@@ -131,13 +131,13 @@ buttonExportData:
   message: Экспорт в zip-файл
 labelAbout:
   description: Label shown on top of the about page.
-  message: О Violentmonkey
+  message: О расширении Violentmonkey
 labelRelated:
   description: Label of related links.
   message: 'Связанные ссылки: '
 labelDonate:
   description: Label of link to donate page.
-  message: Пожертвовать
+  message: Поддержать проект финансово
 labelFeedback:
   description: Label of link to feedback page.
   message: Обратная связь
@@ -146,13 +146,13 @@ labelAuthor:
   message: 'Автор: '
 anchorAuthor:
   description: Author shown on about tab.
-  message: ''
+  message: '<a href=mailto:i@gerald.top>Gerald</a>'
 labelTranslator:
   description: Label of translator.
-  message: 'Переводчик: '
+  message: 'Переводчики: '
 anchorTranslator:
   description: Translator shown on about tab.
-  message: softovikk
+  message: 'softovikk, <a href=https://github.com/alexesprit>alexesprit</a>, <a href=https://github.com/bershan2>bershan2</a>'
 labelCurrentLang:
   description: Label of current language.
   message: 'Текущий язык: '
@@ -164,7 +164,7 @@ labelName:
   message: 'Название:'
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Выполнить:'
+  message: 'Выполнять:'
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (по умолчанию)
@@ -179,16 +179,16 @@ labelDownloadURL:
   message: 'Источник загрузки:'
 labelInclude:
   description: Label of @include rules.
-  message: 'Задействовать на (правила включений include):'
+  message: 'Задействовать на (правила включений @include):'
 labelMatch:
   description: Label of @match rules.
-  message: 'Задействовать на (правила совпадений match):'
+  message: 'Задействовать на (правила совпадений @match):'
 labelExclude:
   description: Label of @exclude rules.
-  message: 'Не задействовать на (правила исключений exclude):'
+  message: 'Не задействовать на (правила исключений @exclude):'
 labelExcludeMatch:
   description: Label of @exclude-match rules.
-  message: ''
+  message: 'Не задействовать на (правила исключений @exclude-match):'
 labelAllowUpdate:
   description: Option to allow checking updates for a script.
   message: Разрешить обновление
@@ -209,7 +209,7 @@ buttonEnable:
   message: Включить
 buttonEdit:
   description: Button to edit a script.
-  message: Изменить
+  message: Редактировать
 buttonRemove:
   description: Button to remove a script.
   message: Удалить
@@ -220,10 +220,10 @@ msgImported:
   description: >-
     Message shown after import. There is an argument referring to the count of
     scripts imported.
-  message: $1 скрипт(ов) импортировано.
+  message: $1 скрипт(a/ов) импортировано.
 hintUseDownloadURL:
   description: Shown as a place holder for @updateURL when it is not assigned
-  message: Use @downloadURL
+  message: Использовать @downloadURL
 confirmNotSaved:
   description: Confirm message shown when there are unsaved script modifications.
   message: |-
@@ -234,37 +234,37 @@ buttonVacuuming:
   message: Очистка данных кэша...
 buttonVacuumed:
   description: Message shown when data is vacuumed.
-  message: Сбросить кэш
+  message: Кэш очищен
 hintVacuum:
   description: Hint for vacuuming data.
-  message: Сбросить избыточность кэша и попробовать подгрузить недостающие ресурсы
+  message: Сбросить избыточный кэш и попробовать подгрузить недостающие ресурсы.
 menuFindScripts:
   description: Menu item to find scripts for a site.
   message: Найти скрипты для сайта
 menuScriptEnabled:
   description: 'Menu item showing the status of Violentmonkey, when enabled.'
-  message: Включить скрипты
+  message: Скрипты включены
 menuScriptDisabled:
   description: 'Menu item showing the status of Violentmonkey, when disabled.'
-  message: ''
+  message: Скрипты отключены
 menuCommands:
   description: Menu item to list script commands.
   message: Команды скриптов
 labelSearch:
   description: Label for search input in search box.
-  message: 'Найти для: '
+  message: 'Найти: '
 labelReplace:
   description: Label for replace input in search box.
   message: 'Заменить на: '
 buttonReplace:
   description: Button to replace the current match.
-  message: Заменять
+  message: Заменить
 buttonReplaceAll:
   description: Button to replace all matches.
-  message: Заменить всё
+  message: Заменить все
 labelAutoReloadCurrentTab:
   description: Option to reload current tab after a script is switched on or off from menu.
-  message: Обновить текущую вкладку после включения/выключения скрипта
+  message: Обновить текущую вкладку после включения/отключения скрипта.
 hintInputURL:
   description: Hint for a prompt box to input URL of a user script.
   message: 'Введите URL:'
@@ -273,123 +273,125 @@ buttonInstallFromURL:
   message: Установить по ссылке
 labelSync:
   description: Label for sync options.
-  message: ''
+  message: Синхронизация с облачным  хранилищем
 lastSync:
   description: Label for last sync timestamp.
-  message: ''
+  message: 'Последняя синхронизация: '
 msgSyncInit:
   description: Message shown when sync service is initializing.
-  message: ''
+  message: Установление соединения...
 msgSyncInitError:
   description: Message shown when sync fails in initialization.
-  message: ''
+  message: Ошибка инициализации синхронизации.
 msgSyncReady:
   description: Message shown when sync will start soon.
-  message: ''
+  message: Синхронизация скоро начнется...
 msgSyncing:
   description: Message shown when sync is in progress.
-  message: ''
+  message: Синхронизация...
 msgSyncError:
   description: Message shown when sync failed.
-  message: ''
+  message: Ошибка синхронизации.
 msgNamespaceConflict:
   description: >-
     Message shown when namespace of the new script conflicts with an existent
     one.
-  message: ''
+  message: Конфликт пространства имен скриптов. Измените @name и @namespace.
 msgInvalidScript:
   description: Message shown when script is invalid.
-  message: ''
+  message: Неверный скрипт.
 labelShowBadge:
   description: Option to show number of running scripts on the badge.
-  message: ''
+  message: Показывать количество активных скриптов на значке.
 labelLineNumber:
   description: Label for line number jumper.
-  message: ''
+  message: Номер строки:
 labelBlacklist:
   description: Label for global blacklist settings in security section.
-  message: ''
+  message: Чёрный список
 descBlacklist:
   description: HTML Description for the global blacklist.
-  message: ''
+  message: Скрипты не будут вводиться в документы, URL адреса которых совпадают с правилами в этом списке.
 buttonSaveBlacklist:
   description: Button to save global blacklist.
-  message: ''
+  message: Сохранить
 msgSavedBlacklist:
   description: Message shown when blacklist are saved.
-  message: ''
+  message: Чёрный список сохранён.
 labelGeneral:
   description: Label for general settings.
-  message: ''
+  message: Общие настройки
 labelSyncScriptStatus:
   description: Label for option to sync script status.
-  message: ''
+  message: Синхронизировать статус скриптов.
 labelSyncDisabled:
   description: Label for option to disable sync service.
-  message: ''
+  message: ничем
 labelSyncService:
   description: Label for sync service select.
-  message: ''
+  message: Синхронизировать с
 labelSyncAuthorize:
   description: Label for button to authorize a service.
-  message: ''
+  message: Подключить
 labelSyncRevoke:
   description: Label for button to revoke authorization for a service.
-  message: ''
+  message: Отключить
 labelSyncAuthorizing:
   description: Label for button when authorization is in progress.
-  message: ''
+  message: Авторизация...
 msgSavedCustomCSS:
   description: Message shown when custom CSS is saved.
-  message: ''
+  message: Пользовотельские стили CSS сохранены.
 labelCustomCSS:
   description: Label for custom CSS section.
-  message: ''
+  message: Пользовотельские стили CSS
 descCustomCSS:
   description: Description of custom CSS section.
-  message: ''
+  message: >-
+    Пользовательские стили CSS для страницы Настройки и страницы установки скриптов. 
+    Если Вы не знаете что это такое, пожалуйста не редактируйте этот текст.
 buttonSaveCustomCSS:
   description: Label for button to save custom CSS.
-  message: ''
+  message: Сохранить
 menuDashboard:
   description: Label for menu item to open dashboard.
-  message: ''
+  message: Панель управления
 menuMatchedScripts:
   description: Label for menu listing matched scripts.
-  message: ''
+  message: Совпадающие скрипты
 buttonOK:
   description: OK button on dialog.
-  message: ''
+  message: OK
 buttonCancel:
   description: Cancel button on dialog.
-  message: ''
+  message: Отмена
 labelImportSettings:
   description: Label for option to import settings from zip file.
-  message: ''
+  message: Импортировать настройки.
 learnBlacklist:
   description: Refers to a link to introduce blacklist patterns.
-  message: ''
+  message: Подробнее о чёрных списках.
 editNavCode:
   description: Label of code tab in script editor.
-  message: ''
+  message: Код
 editNavSettings:
   description: Label of settings tab in script editor.
-  message: ''
+  message: Настройки
 editLabelSettings:
   description: Settings section in settings tab of script editor.
-  message: ''
+  message: Настройки скрипта
 editLabelMeta:
   description: Metadata section in settings tab of script editor.
   message: Пользовательские meta-данные
 labelKeepOriginal:
   description: Option to keep the original match or ignore rules.
-  message: Использовать оригинальные правила
+  message: Использовать оригинальные правила.
 titleScriptUpdated:
   description: Notification title for script updates.
-  message: ''
+  message: Обновление
 msgScriptUpdated:
   description: Notification message for script updates.
-  message: ''
+  message: 'Скрипт [$1] обновлён!'
 labelNotifyUpdates:
   description: Option to show notification when script is updated.
-  message: ''
+  message: Уведомлять об обновлениях скриптов.


### PR DESCRIPTION
Completed Russian localization with context of each sentence in mind:
0. All items have a translation now;
1. Factually correct, e.g., prior translation had "Включить скрипты" ("Turn scripts on") instead of "Скрипты включены" ("Scripts are on");
2. Proper punctuation, e.g., check-boxes and tool tips terminate with punctuation, while buttons and headings do not;
3. Native Russian sentence structure and word choice instead of English-induced translation;

## Warning:
**In the translators list I included links to GitHub accounts.** See comment in the text box. This should not be a security issue, but I want to inform you about this.