### PR TITLE
Russian localization for the search box

### DIFF
--- a/src/_locales/ru/messages.yml
+++ b/src/_locales/ru/messages.yml
@@ -282,7 +282,7 @@ labelSync:
   message: Синхронизация с облачным  хранилищем
 lastSync:
   description: Label for last sync timestamp.
-  message: 'Последняя синхронизация: '
+  message: Последняя синхронизация в $1.
 msgSyncInit:
   description: Message shown when sync service is initializing.
   message: Установление соединения...
@@ -406,10 +406,10 @@ labelNotifyUpdates:
   message: Уведомлять об обновлениях скриптов.
 installFrom:
   description: Label for button to install script from a userscript site.
-  message: ''
+  message: Установить с $1
 labelSearchScript:
   description: Placeholder for script search box.
-  message: ''
+  message: Посик скриптов...
 labelNoSearchScripts:
   description: Message shown when no script is found in search results.
-  message: ''
+  message: Скрипты не найдены.


### PR DESCRIPTION
Russian localization of recently added messages appearing in the search interface. Also, fix for the missing sync timestamp bug (caused by my earlier commit 'Complete Russian localization' 8f0b353341dfbf306310da002355a351c19e52cd).