### PR TITLE
[WIP] Icons on buttons in scripts list

### DIFF
--- a/src/options/views/script-item.vue
+++ b/src/options/views/script-item.vue
@@ -2,8 +2,10 @@
   <div class="script" :class="{disabled:!script.enabled}" draggable="true" @dragstart.prevent="onDragStart">
     <img class="script-icon" :src="safeIcon">
     <div class="script-info flex">
-      <a class="script-name ellipsis" target="_blank" :href="homepageURL"
-      v-text="script.custom.name || getLocaleString('name')"></a>
+      <a class="script-name ellipsis" v-text="script.custom.name || getLocaleString('name')"></a>
+      <a class="script-support" v-if="homepageURL" target=_blank :href="homepageURL">
+        <icon name="question"></icon>
+      </a>
       <a class="script-support" v-if="script.meta.supportURL" target=_blank :href="script.meta.supportURL">
         <icon name="question"></icon>
       </a>


### PR DESCRIPTION
# PLEASE DO NOT MERGE THIS IN YET!
**I opened this pull request for discussion** instead of opening an issue to (1) keep discussion and code changes in one place and (2) avoid opening a duplicate issue that would point to a pull request that I would open later.

Hi, I think it is a great idea to use icons on the buttons instead of text. However, I think this should be done consistently. I tried to replace the buttons on the items in the list of scripts, but I'm not sure which icons you want to see there. Thus I have a few questions:
- Which icons do you want to see there?
  - "Edit" button:
     Do you want to use the Cog (cog.svg)? I feel like a [pencil](http://www.flaticon.com/free-icon/pencil_25688#term=pencil&page=1&position=2) or a [pair of brackets](http://www.flaticon.com/free-icon/code_25185) from the same icon set would look better...
 - "Disable"/"Enable" button:
    Do you want the cross (remove.svg) as "Disabled" and check mark (check.svg) as "Enabled", like on the popup interface? Also, 
 - "Remove" button:
    If cross (remove.svg) is taken for "Disabled", there is no icon for "Remove". How about a [trashcan](http://www.flaticon.com/free-icon/trash_25214#term=trash&page=1&position=1) from the same icon set?

Currently the commit is in its very early stages, so there is nothing interesting.