### PR TITLE
blob url should be allowed in GM_openInTab

### DIFF
--- a/src/common/index.js
+++ b/src/common/index.js
@@ -223,6 +223,7 @@ export function getFullUrl(url, base) {
     'https:',
     'ftp:',
     'data:',
+    'blob:',
   ].includes(obj.protocol)) obj.protocol = 'http:';
   return obj.href;
 }


### PR DESCRIPTION
After I confused by `data:` url not supported by Firefox. I found out that `blob:` url is the best choice for me. But it seems broken in VM on Chrome. It seems that this commit should fix it. Hope it can be published asap, since one of my script is relaying on this feature. many thx.