### PR TITLE
fix: avoid page jumps when setClipboard in Firefox

### DIFF
--- a/src/background/utils/clipboard.js
+++ b/src/background/utils/clipboard.js
@@ -1,17 +1,14 @@
-const textarea = document.createElement('textarea');
-document.body.appendChild(textarea);
-
 let clipboardData;
 function onCopy(e) {
+  document.removeEventListener("copy", onCopy, true);
+  e.stopImmediatePropagation();
   e.preventDefault();
   const { type, data } = clipboardData;
   e.clipboardData.setData(type || 'text/plain', data);
 }
-document.addEventListener('copy', onCopy, false);
-
 export default function setClipboard(data) {
   clipboardData = data;
-  textarea.focus();
+  document.addEventListener("copy", onCopy, true);
   const ret = document.execCommand('copy', false, null);
   if (!ret && process.env.DEBUG) {
     console.warn('Copy failed!');

--- a/src/injected/content/clipboard.js
+++ b/src/injected/content/clipboard.js
@@ -1,15 +1,8 @@
-let textarea;
 let clipboardData;
 
-function init() {
-  textarea = document.createElement('textarea');
-  textarea.style.position = 'absolute';
-  textarea.style.width = 0;
-  textarea.style.height = 0;
-  textarea.style.left = '-20px';
-}
-
 function onCopy(e) {
+  document.removeEventListener("copy", onCopy, true);
+  e.stopImmediatePropagation();
   e.preventDefault();
   const { type, data } = clipboardData;
   e.clipboardData.setData(type || 'text/plain', data);
@@ -17,13 +10,8 @@ function onCopy(e) {
 
 export default function setClipboard({ type, data }) {
   clipboardData = { type, data };
-  if (!textarea) init();
-  document.addEventListener('copy', onCopy, false);
-  document.documentElement.appendChild(textarea);
-  textarea.focus();
+  document.addEventListener("copy", onCopy, true);
   const ret = document.execCommand('copy', false, null);
-  document.documentElement.removeChild(textarea);
-  document.removeEventListener('copy', onCopy, false);
   if (!ret && process.env.DEBUG) {
     console.warn('Copy failed!');
   }


### PR DESCRIPTION
User reports from https://bbs.kafan.cn/thread-2106491-5-1.html.
Testcase:
```
// ==UserScript==
// @name New Script
// @namespace Violentmonkey Scripts
// @match *://*/*
// @grant					GM_setClipboard
// ==/UserScript==
GM_setClipboard("test", "text");
```

Ref: https://github.com/mdn/webextensions-examples/blob/master/context-menu-copy-link-with-types/clipboard-helper.js. I hope this code does not have a license issue.

I don't understand the usage of `src/background/utils/clipboard.js`, so there is no test.