### PR TITLE
Skip injection of injected-web if there are no scripts to run

### DIFF
--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -54,20 +54,27 @@ export default function initialize(contentId, webId) {
     if (handle) handle(req.data, src);
   });
 
-  sendMessage({ cmd: 'GetInjected', data: window.location.href })
+  return sendMessage({ cmd: 'GetInjected', data: window.location.href })
   .then(data => {
+    let needInject = false;
     if (data.scripts) {
       data.scripts.forEach(script => {
         ids.push(script.props.id);
-        if (script.config.enabled) badge.number += 1;
+        if (script.config.enabled) {
+          badge.number += 1;
+          needInject = true;
+        }
       });
     }
-    bridge.ready.then(() => {
-      bridge.post({ cmd: 'LoadScripts', data });
-    });
+    if (needInject) {
+      bridge.ready.then(() => {
+        bridge.post({ cmd: 'LoadScripts', data });
+      });
+    }
     badge.ready = true;
     getPopup();
     setBadge();
+    return needInject;
   });
 }
 

--- a/src/injected/index.js
+++ b/src/injected/index.js
@@ -10,6 +10,14 @@ import initialize from './content';
   function initBridge() {
     const contentId = getUniqId();
     const webId = getUniqId();
+    initialize(contentId, webId).then(needInject => {
+      if (needInject) {
+        doInject(contentId, webId);
+      }
+    });
+  }
+
+  function doInject(contentId, webId) {
     const props = {};
     [
       Object.getOwnPropertyNames(window),
@@ -22,9 +30,9 @@ import initialize from './content';
       JSON.stringify(contentId),
       JSON.stringify(Object.keys(props)),
     ];
-    initialize(contentId, webId);
     inject(`(${window.VM_initializeWeb.toString()}())(${args.join(',')})`);
   }
+
   initBridge();
 
   // For installation


### PR DESCRIPTION
If we’re not going to run any scripts in the webpage, we may as well not inject the initializer either, right? This saves a bit of work, and avoids unnecessary Firefox CSP errors, on pages with no matched scripts.