### PR TITLE
Greasy fork find scripts /by-site/

### DIFF
--- a/src/popup/app.js
+++ b/src/popup/app.js
@@ -40,15 +40,6 @@ browser.tabs.query({ currentWindow: true, active: true })
   if (/^https?:\/\//i.test(currentTab.url)) {
     const matches = currentTab.url.match(/:\/\/([^/]*)/);
     const domain = matches[1];
-    const topLevelDomain = tld.getDomain(domain) || domain;
-    let domains = [topLevelDomain];
-    if (domain !== topLevelDomain) {
-      domains = domain.slice(0, -topLevelDomain.length - 1).split('.')
-      .reduceRight(
-        (res, part) => [`${part}.${res[0]}`, ...res],
-        domains,
-      );
-    }
-    store.domains = domains;
+    store.domain = tld.getDomain(domain) || domain;
   }
 });

--- a/src/popup/utils/index.js
+++ b/src/popup/utils/index.js
@@ -2,5 +2,5 @@
 export const store = {
   scripts: [],
   commands: [],
-  domain: "",
+  domain: '',
 };

--- a/src/popup/utils/index.js
+++ b/src/popup/utils/index.js
@@ -2,5 +2,5 @@
 export const store = {
   scripts: [],
   commands: [],
-  domains: [],
+  domain: "",
 };

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -114,7 +114,7 @@ export default {
     },
     onFindScripts({ name: domain }) {
       browser.tabs.create({
-        url: `https://greasyfork.org/scripts/search?q=${encodeURIComponent(domain)}`,
+        url: `https://greasyfork.org/scripts/by-site/${encodeURIComponent(domain)}`,
       });
     },
     onCommand(item) {

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -13,8 +13,8 @@
         <span v-text="i18n('menuDashboard')"></span>
       </div>
     </div>
-    <div class="menu">
-      <div class="menu-item" @click="onClickDomain">
+    <div class="menu" v-show="store.domain">
+      <div class="menu-item" @click="onFindSameDomainScripts">
         <icon name="search"></icon>
         <span v-text="i18n('menuFindScripts')"></span>
       </div>
@@ -100,9 +100,9 @@ export default {
       browser.runtime.openOptionsPage();
       window.close();
     },
-    onFindScripts({ name: domain }) {
+    onFindSameDomainScripts() {
       browser.tabs.create({
-        url: `https://greasyfork.org/scripts/by-site/${encodeURIComponent(domain)}`,
+        url: `https://greasyfork.org/scripts/by-site/${encodeURIComponent(this.store.domain)}`,
       });
     },
     onCommand(item) {
@@ -128,9 +128,6 @@ export default {
     },
     checkReload() {
       if (options.get('autoReload')) browser.tabs.reload(this.store.currentTab.id);
-    },
-    onClickDomain() {
-      this.onFindScripts(this.store.domain);
     },
   },
 };

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -13,16 +13,10 @@
         <span v-text="i18n('menuDashboard')"></span>
       </div>
     </div>
-    <div class="menu menu-domains" v-show="domains.length" :class="{expand: activeMenu === 'domains'}">
-      <div class="menu-item" @click="onClickDomains">
+    <div class="menu">
+      <div class="menu-item" @click="onClickDomain">
         <icon name="search"></icon>
-        <icon v-if="domains.length > 1" name="more" class="icon-right icon-collapse"></icon>
         <span v-text="i18n('menuFindScripts')"></span>
-      </div>
-      <div class="submenu">
-        <div class="menu-item" v-for="item in domains" @click="onFindScripts(item)">
-          <span v-text="item.name"></span>
-        </div>
       </div>
     </div>
     <div class="menu menu-commands" v-show="commands.length" :class="{expand: activeMenu === 'commands'}">
@@ -78,12 +72,6 @@ export default {
     };
   },
   computed: {
-    domains() {
-      return this.store.domains.map(item => ({
-        name: item,
-        data: item,
-      }));
-    },
     commands() {
       return this.store.commands.map(item => ({
         name: item[0],
@@ -141,12 +129,8 @@ export default {
     checkReload() {
       if (options.get('autoReload')) browser.tabs.reload(this.store.currentTab.id);
     },
-    onClickDomains() {
-      if (this.domains.length === 1) {
-        this.onFindScripts(this.domains[0]);
-      } else {
-        this.toggleMenu('domains');
-      }
+    onClickDomain() {
+      this.onFindScripts(this.store.domain);
     },
   },
 };


### PR DESCRIPTION
Hello @gera2ld.

- My first commit (abd734f23d320576d3a3c8f292aa0070d2295755) changes non‐working search URL like https://greasyfork.org/scripts?q=jasrac.or.jp into https://greasyfork.org/scripts/by-site/jasrac.or.jp
- Then my second commit (6f6029c2d74dea74604f66b932b9536d8f43d3cb) tries to remove the multiple domains sub menu as the search in Greasyfork is always by domain, never including sub‐domains (since JasonBarnabe/greasyfork#113)

I don’t know how to debug Chrome extensions so, please, if you have some time, test this and merge if you like it. :)
Or tell me what should be done if it does not work.