### PR TITLE
Fix 'browser_style' warning

### DIFF
--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -10,6 +10,7 @@ icons:
   '128': public/images/icon128.png
 default_locale: en
 browser_action:
+  browser_style: true
   default_icon:
     '19': public/images/icon19.png
     '38': public/images/icon38.png


### PR DESCRIPTION
Here's a simple fix for the warning below, which is seen in Firefox console when violentmonkey is installed:
`addons.webextension.{aecec67f-0d10-4fa7-b7c7-609a2db280cf} WARN Please specify whether you want browser_style or not in your browser_action options.`

Regards