### PR TITLE
More common monospace fonts for editor CodeMirror

### DIFF
--- a/src/common/ui/style/style.css
+++ b/src/common/ui/style/style.css
@@ -180,7 +180,7 @@ button {
 .editor-code .CodeMirror {
   height: 100%;
   /* Use `Courier New` to ensure `&nbsp;` has the same width as an original space. */
-  font-family: Courier New, Courier, monospace;
+  font-family: "Fira Code", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", Courier, monospace;
 }
 
 .vl-dropdown-menu {


### PR DESCRIPTION
[Add]
+ "Fira Code" is a great font for coding thanks to new font technologies.
+ Others are shipped with modern OSes. The list is borrowed from the CSS of Github website.