### PR TITLE
Define default text colors in CSS

### DIFF
--- a/src/common/ui/style/style.css
+++ b/src/common/ui/style/style.css
@@ -11,6 +11,7 @@ html {
 body {
   font-size: 1rem;
   background: white;
+  color: black;
 }
 
 // Form elements will not inherit
@@ -76,6 +77,7 @@ svg {
 button {
   border: 1px solid #afafaf;
   background: #f4f4f4;
+  color: black;
   &:hover {
     background: #e4e4e4;
   }


### PR DESCRIPTION
So that we do not rely on unknown browser defaults and avoid a situation in which text has a similar color as the background (which has its color already defined in a stylesheet).