### PR TITLE
Fix grammar of labelNoScripts.message string

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -287,7 +287,7 @@ labelNoName:
   message: No Name
 labelNoScripts:
   description: Message shown when no script is installed.
-  message: 'Oops, you haven''t got any script yet.'
+  message: 'Oops, you haven’t got any scripts yet.'
 labelNoSearchScripts:
   description: Message shown when no script is found in search results.
   message: No script is found.


### PR DESCRIPTION
When there are zero of something, you refer to it with the plural.

Also, I replaced the straight single quote with the actual apostrophe character (which is the same character as a closing curly single quote).

### Before

<img width="802" alt="1 before" src="https://user-images.githubusercontent.com/79168/57573767-603b5f00-73fb-11e9-822b-9edda9114197.png">

### After

This is just a mockup made with the Inspector. I didn’t actually rebuild the extension.

<img width="802" alt="2 after (mockup)" src="https://user-images.githubusercontent.com/79168/57573768-629db900-73fb-11e9-8469-e83e69ec6286.png">
