### PR TITLE
preload CustomCSS to avoid FOUC and white flash during page load

### DIFF
--- a/scripts/plaid.conf.js
+++ b/scripts/plaid.conf.js
@@ -1,4 +1,5 @@
 const { isProd } = require('@gera2ld/plaid/util');
+const { defaultOptions } = require('@gera2ld/plaid-webpack/util');
 
 /**
  * For each entry, `key` is the chunk name, `value` has following properties:
@@ -59,4 +60,8 @@ exports.optimization = {
       },
     },
   },
+};
+exports.htmlOptions = {
+  ...defaultOptions.htmlOptions,
+  template: require.resolve('./template.html'),
 };

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -2,17 +2,51 @@
 <html>
 <head>
 <meta charset="UTF-8">
+<% Object.entries(htmlWebpackPlugin.options.meta || {}).forEach(([ name, content ]) => { %>
+<meta name="<%= name %>" content="<%= content %>">
+<% }) %>
 <title><%= htmlWebpackPlugin.options.title %></title>
-<%
-if (htmlWebpackPlugin.options.manifest) {
-%><link rel="manifest" href="<%= htmlWebpackPlugin.options.manifest %>"><%
-}
-htmlWebpackPlugin.options.css.forEach(url => {
-%><link rel="stylesheet" href="<%= url %>"><%
-});
-htmlWebpackPlugin.options.js.forEach(url => {
-%><script src="<%= url %>"></script><%
-});
-%></head>
-<body></body>
+<% if (htmlWebpackPlugin.options.manifest) { %>
+<link rel="manifest" href="<%= htmlWebpackPlugin.options.manifest %>">
+<% } %>
+<% htmlWebpackPlugin.options.css.forEach(({ href, content }) => { %>
+<% if (href) { %>
+<link rel="stylesheet" href="<%= href %>">
+<% } else { %>
+<style><%= content %></style>
+<% } %>
+<% }); %>
+<% htmlWebpackPlugin.files.css.forEach(file => { %>
+<% if (htmlWebpackPlugin.options.inlineSource) { %>
+<style><%= compilation.assets[file.slice(htmlWebpackPlugin.files.publicPath.length)].source() %></style>
+<% } else { %>
+<link rel="stylesheet" href="<%= file %>">
+<% } %>
+<% }); %>
+<% htmlWebpackPlugin.options.js.forEach(({ src, content }) => { %>
+<% if (src) { %>
+<script src="<%= src %>"></script>
+<% } else { %>
+<script><%= content %></script>
+<% } %>
+<% }); %>
+<% htmlWebpackPlugin.files.js.forEach(file => { %>
+<% if (htmlWebpackPlugin.options.inlineSource) { %>
+<script><%= htmlWebpackPlugin.options.util.escapeScript(compilation.assets[file.slice(htmlWebpackPlugin.files.publicPath.length)].source()) %></script>
+<% } else { %>
+<script src="<%= file %>"></script>
+<% } %>
+<% }); %>
+</head>
+<!--
+All scripts should be loaded in HEAD so they run before DOMContentLoaded
+otherwise there'll be an empty white frame shown during page load
+which is a big nuisance with dark CSS themes.
+
+In your code make sure to wait for document.body either via MutationObserver
+or simply by accessing it inside an asynchronous event callback that runs
+in a separate event loop cycle e.g. any callback from extensions API.
+-->
+<body>
+</body>
 </html>

--- a/src/background/utils/clipboard.js
+++ b/src/background/utils/clipboard.js
@@ -1,5 +1,5 @@
 const textarea = document.createElement('textarea');
-document.body.appendChild(textarea);
+setTimeout(() => document.body.appendChild(textarea));
 
 let clipboardData;
 function onCopy(e) {

--- a/src/background/utils/options.js
+++ b/src/background/utils/options.js
@@ -2,6 +2,9 @@ import { initHooks, debounce, normalizeKeys } from '#/common';
 import { objectGet, objectSet } from '#/common/object';
 import { register } from './init';
 
+// make usable with browser.extension.getBackgroundPage()
+Object.assign(global, { getOption });
+
 const defaults = {
   isApplied: true,
   autoUpdate: true,

--- a/src/common/ui/style/index.js
+++ b/src/common/ui/style/index.js
@@ -3,14 +3,25 @@ import './style.css';
 
 let style;
 options.hook((changes) => {
-  if ('customCSS' in changes) {
-    const { customCSS } = changes;
-    if (customCSS && !style) {
-      style = document.createElement('style');
-      document.head.appendChild(style);
-    }
-    if (customCSS || style) {
-      style.textContent = customCSS;
-    }
-  }
+  if ('customCSS' in changes) setStyle(changes.customCSS);
 });
+
+try {
+  // apply customCSS early to avoid FOUC during page load
+  setStyle(browser.extension.getBackgroundPage().getOption('customCSS'));
+} catch (e) {
+  // let options.hook() handle it
+}
+
+function setStyle(css) {
+  if (css && !style) {
+    // Adding on documentElement puts it after <head> so it'll follow our own styles
+    // which is important to ensure customCSS wins in cases of equal CSS specificity.
+    // Note, DOM spec allows any elements under documentElement
+    // https://dom.spec.whatwg.org/#node-trees
+    style = document.documentElement.appendChild(document.createElement('style'));
+  }
+  if (style && style.textContent !== css) {
+    style.textContent = css;
+  }
+}

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -10,12 +10,13 @@ tld.initTLD();
 
 Vue.prototype.i18n = i18n;
 
-const el = document.createElement('div');
-document.body.appendChild(el);
-new Vue({
-  render: h => h(App),
-})
-.$mount(el);
+waitForBody()
+.then((body) => {
+  new Vue({
+    render: h => h(App),
+  })
+  .$mount(body.appendChild(document.createElement('div')));
+});
 
 Object.assign(handlers, {
   SetPopup(data, src) {
@@ -50,3 +51,14 @@ browser.tabs.query({ currentWindow: true, active: true })
     store.domain = tld.getDomain(domain) || domain;
   }
 });
+
+function waitForBody() {
+  return Promise.resolve(document.body || new Promise((resolve) => {
+    new MutationObserver(((_mutations, observer) => {
+      if (document.body) {
+        observer.disconnect();
+        resolve(document.body);
+      }
+    })).observe(document.documentElement, { childList: true });
+  }));
+}


### PR DESCRIPTION
Fixes the white flash and FOUC (flash of unstyled content) during page load to enable the use of `customCSS` option in ViolentMonkey with a dark theme without being blinded by the flash.

Here's the [theme itself](https://gist.github.com/tophf/cc109b0ba5cb98353c9ea51579c85ae2) (very early WIP I mocked in devtools).

Fixed by putting scripts into `<head>` in the webpack's html template, see https://github.com/violentmonkey/violentmonkey/pull/612#issuecomment-536225835 for more info.

<details><summary>outdated initial take</summary>

This is the first time I deal with WebPack/Vue so don't freak out too much if I messed up something. At least `yarn build` completes successfully!

This solution uses a small separate CSS preloader that directly accesses the background page (if possible) that exposes `getOption` function. It may seem hackish but I see no other way around it after trying various things. Looks like the main code takes too long to initialize so Chrome's renderer loses patience and draws an intermediate white frame.

Added a fixup - do nothing if customCSS is not set.~~
</details>

![image](https://user-images.githubusercontent.com/1310400/65594852-35ae0500-df9c-11e9-87cb-385acb15cdb7.png)

With this PR the intermediate frame is styled; no FOUC occurs:

![image](https://user-images.githubusercontent.com/1310400/65593947-4e1d2000-df9a-11e9-8fb5-39f4bead8116.png)
