### PR TITLE
allow customCSS to reorder/hide disabled scripts in popup

### DIFF
--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -37,7 +37,7 @@ footer {
     background: cornflowerblue;
     color: white;
   }
-  &.disabled {
+  .disabled & {
     color: gray;
     &:hover {
       color: silver;

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -37,7 +37,7 @@ footer {
     background: cornflowerblue;
     color: white;
   }
-  .disabled & {
+  .disabled > & {
     color: gray;
     &:hover {
       color: silver;

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -53,11 +53,11 @@
         <div
           v-for="(item, index) in scripts"
           :key="index"
+          :class="{ disabled: !item.data.config.enabled }"
           @mouseenter="message = item.name"
           @mouseleave="message = ''">
           <div
             class="menu-item menu-area"
-            :class="{ disabled: !item.data.config.enabled }"
             @click="onToggleScript(item)">
             <icon :name="getSymbolCheck(item.data.config.enabled)"></icon>
             <div class="flex-auto ellipsis" v-text="item.name" />


### PR DESCRIPTION
With this PR customCSS can reorder/hide disabled scripts in popup by setting `flex` on `.submenu` and `order` or `display` on `.submenu .disabled`.

Ideally I would like to implement this as a user option in the dashboard but you seem to prefer the minimalistic built-in set of options, right?