### PR TITLE
reuse meta parser regexp and require a single space after //

### DIFF
--- a/src/common/consts.js
+++ b/src/common/consts.js
@@ -4,3 +4,9 @@ export const INJECT_AUTO = 'auto';
 
 export const CMD_SCRIPT_ADD = 'AddScript';
 export const CMD_SCRIPT_UPDATE = 'UpdateScript';
+
+// Allow metadata lines to start with WHITESPACE? '//' SPACE
+// Allow anything to follow the predefined text of the metaStart/End
+// The SPACE must be on the same line and specifically \x20 as \s would also match \r\n\t
+// Note: when there's no valid metablock, an empty string is matched for convenience
+export const METABLOCK_RE = /(?:^|\n)\s*\/\/\x20==UserScript==([\s\S]*?\n)\s*\/\/\x20==\/UserScript==|$/;

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -1,4 +1,4 @@
-import { INJECT_PAGE, INJECT_CONTENT } from '#/common/consts';
+import { INJECT_PAGE, INJECT_CONTENT, METABLOCK_RE } from '#/common/consts';
 import {
   getUniqId, bindEvents, attachFunction, cache2blobUrl,
 } from '../utils';
@@ -185,14 +185,9 @@ function wrapGM(script, code, cache, unsafeWindow) {
     b: val => val === 'true',
   };
   const pathMap = script.custom.pathMap || {};
-  // Allow metadata lines to start with SPACE? '//' SPACE?
-  // Allow anything to follow the predefined text of the metaStart/End
-  // The spaces must be on the same line so [\t\x20] is used as \s also matches \r\n
-  const matches = code.match(/(?:^|\n)\s*\/\/[\t\x20]*==UserScript==.*\n([\s\S]*?\n|)\s*\/\/[\t\x20]*==\/UserScript==/);
-  const metaStr = matches ? matches[1] : '';
   const gmInfo = {
     uuid: script.props.uuid,
-    scriptMetaStr: metaStr,
+    scriptMetaStr: code.match(METABLOCK_RE)[1] || '',
     scriptWillUpdate: !!script.config.shouldUpdate,
     scriptHandler: 'Violentmonkey',
     version: bridge.version,

--- a/test/background/script.test.js
+++ b/test/background/script.test.js
@@ -48,15 +48,23 @@ test('parseMeta', (t) => {
 
 test('parseMetaIrregularities', (t) => {
   t.deepEqual(parseMeta(`\
-  //    ==UserScript==============
+  // ==UserScript==============
 // @name foo
- //@namespace bar
-//==/UserScript===================
+ // @namespace bar
+// ==/UserScript===================
   `), {
     ...baseMeta,
     name: 'foo',
     namespace: 'bar',
   });
+  t.deepEqual(parseMeta(`\
+// ==UserScript==
+//@name foo
+// ==/UserScript==`), baseMeta);
+  t.deepEqual(parseMeta(`\
+//==UserScript==
+// @name foo
+//\t==/UserScript==`), baseMeta);
   t.deepEqual(parseMeta(`\
 /*
 //


### PR DESCRIPTION
* `//` + single ASCII space is apparently hardcoded in almost every userscript-related app/site as noted in the discussion that ensued in #610 after the initial PR relaxed the parser
* we'll still allow whitespace **before** `//` like TM and greasyfork.org do in the hope that other entities reconsider as indentation sometimes is added by bundlers/postprocessors wrapping the code in IIFE and anyway indentation of a comment should not be enforced, especially in a language that's not indentation-based.