### PR TITLE
Faster initial loading of script editor and settings/about

### DIFF
--- a/src/common/router.js
+++ b/src/common/router.js
@@ -12,9 +12,12 @@ function parse(pathInfo) {
 }
 
 export const route = {};
+export const lastRoute = {};
+
 updateRoute();
 
 function updateRoute() {
+  Object.assign(lastRoute, route);
   Object.assign(route, parse(window.location.hash.slice(1)));
 }
 

--- a/src/options/views/app.vue
+++ b/src/options/views/app.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="page-options flex h-100">
-    <aside :class="{ 'show-aside': aside }">
+    <aside :class="{ 'show-aside': aside }" v-if="canRenderAside">
       <div v-if="aside" class="aside-backdrop visible-sm" @click="aside = false" />
       <div class="aside-content">
         <img src="/public/images/icon128.png">
@@ -53,8 +53,12 @@ export default {
     Icon,
   },
   data() {
+    const [tab, tabFunc] = store.route.paths;
     return {
       aside: false,
+      // Speedup and deflicker for initial page load:
+      // skip rendering the aside when starting in the editor for a new script.
+      canRenderAside: tab !== 'scripts' || (tabFunc !== '_new' && !Number(tabFunc)),
       store,
     };
   },
@@ -71,6 +75,10 @@ export default {
   watch: {
     'store.title'(title) {
       document.title = title ? `${title} - ${extName}` : extName;
+    },
+    'store.route.paths'() {
+      // First time showing the aside we need to tell v-if to keep it forever
+      this.canRenderAside = true;
     },
   },
 };

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -109,7 +109,7 @@ import SettingCheck from '#/common/ui/setting-check';
 import hookSetting from '#/common/hook-setting';
 import Icon from '#/common/ui/icon';
 import LocaleGroup from '#/common/ui/locale-group';
-import { setRoute } from '#/common/router';
+import { setRoute, lastRoute } from '#/common/router';
 import ScriptItem from './script-item';
 import Edit from './edit';
 import { store, showMessage } from '../utils';
@@ -297,7 +297,12 @@ export default {
       this.menuNewActive = active;
     },
     onEditScript(id) {
-      setRoute(['scripts', id].filter(Boolean).join('/'), true);
+      const pathname = ['scripts', id].filter(Boolean).join('/');
+      if (!id && pathname === lastRoute.pathname) {
+        window.history.back();
+      } else {
+        setRoute(pathname);
+      }
     },
     onHashChange() {
       const [tab, id] = this.store.route.paths;

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -178,10 +178,7 @@ export default {
     search: 'updateLater',
     'filters.sort.value': 'updateLater',
     showRecycle: 'onUpdate',
-    scripts() {
-      this.onUpdate();
-      this.onHashChange();
-    },
+    scripts: 'refreshUI',
     'store.route.paths.1': 'onHashChange',
   },
   computed: {
@@ -202,6 +199,10 @@ export default {
     },
   },
   methods: {
+    refreshUI() {
+      this.onUpdate();
+      this.onHashChange();
+    },
     onUpdate() {
       const { search, filters: { sort }, showRecycle } = this;
       const lowerSearch = (search || '').toLowerCase();
@@ -342,7 +343,12 @@ export default {
   },
   created() {
     this.debouncedUpdate = debounce(this.onUpdate, 200);
-    this.onUpdate();
+  },
+  mounted() {
+    // Ensure the correct UI is shown when mounted:
+    // * on subsequent navigation via history back/forward;
+    // * on first initialization in some weird case the scripts got loaded early.
+    if (!store.loading) this.refreshUI();
   },
 };
 </script>


### PR DESCRIPTION
### Use cases
* Loading directly into the editor - when clicking the new/edit button in the popup
* Loading directly into the other tabs (settings, about)
* Also on manual reload of the options page via <kbd>F5</kbd> etc, for whatever reason.

### Problems
* Slow page load in case there are many scripts (100, for example)
* Flicker of the temporarily shown header element when loading into the editor.

### Solution
`v-if` is used to postpone rendering of the script list and the header.
Once eventually rendered, `v-if` is pinned in its enabled state to avoid re-rendering.
Basically it's like `{once: true}` in DOM messaging.

### Collateral bugfix
<details><summary>Repro:</summary>

1. click "settings" or "about" sub-page
2. click "Installed scripts"
3. click to edit a script
4. press the browser's history back button/key
5. press the browser's history forward button/key

Expected:
the editor is opened

Observed:
the script list is opened, but the URL points to a script's id so if you click the edit button on the same script again nothing will occur as the router will think everything's fine.
</details>
Solved by a) calling setRoute in pushState mode instead of replaceState on *opening* the editor and b) remembering the last route so we can use `history.back()` on *closing* the editor in case the last route was 'scripts'.