### PR TITLE
fix: update routes on 'popstate'

### DIFF
--- a/src/common/router.js
+++ b/src/common/router.js
@@ -12,17 +12,21 @@ function parse(pathInfo) {
 }
 
 export const route = {};
-export const lastRoute = {};
+
+Object.defineProperties(route, {
+  stack: { value: [] },
+  last: { get: () => route.stack[route.stack.length - 1] || {} },
+});
 
 updateRoute();
 
 function updateRoute() {
-  Object.assign(lastRoute, route);
   Object.assign(route, parse(window.location.hash.slice(1)));
 }
 
+// popstate should be the first to ensure hashchange listeners see the correct route.last
+window.addEventListener('popstate', () => route.stack.pop());
 window.addEventListener('hashchange', updateRoute, false);
-window.addEventListener('popstate', updateRoute, false);
 
 export function setRoute(hash, replace) {
   let hashString = `${hash}`;
@@ -30,6 +34,7 @@ export function setRoute(hash, replace) {
   if (replace) {
     window.history.replaceState('', null, hashString);
   } else {
+    route.stack.push(Object.assign({}, route));
     window.history.pushState('', null, hashString);
   }
   updateRoute();

--- a/src/common/router.js
+++ b/src/common/router.js
@@ -21,8 +21,8 @@ function updateRoute() {
   Object.assign(route, parse(window.location.hash.slice(1)));
 }
 
-// popstate should be the first to ensure hashchange listeners see the correct route.last
-window.addEventListener('popstate', () => route.stack.pop());
+// popstate should be the first to ensure hashchange listeners see the correct lastRoute
+window.addEventListener('popstate', () => stack.pop());
 window.addEventListener('hashchange', updateRoute, false);
 
 export function setRoute(hash, replace) {

--- a/src/common/router.js
+++ b/src/common/router.js
@@ -22,6 +22,7 @@ function updateRoute() {
 }
 
 window.addEventListener('hashchange', updateRoute, false);
+window.addEventListener('popstate', updateRoute, false);
 
 export function setRoute(hash, replace) {
   let hashString = `${hash}`;

--- a/src/common/router.js
+++ b/src/common/router.js
@@ -13,10 +13,7 @@ function parse(pathInfo) {
 
 const stack = [];
 export const route = {};
-
-Object.defineProperty(route, {
-  last: { get: () => stack[stack.length - 1] || {} },
-});
+export const lastRoute = () => stack[stack.length - 1] || {};
 
 updateRoute();
 

--- a/src/common/router.js
+++ b/src/common/router.js
@@ -11,11 +11,11 @@ function parse(pathInfo) {
   return { pathname, query, paths };
 }
 
+const stack = [];
 export const route = {};
 
-Object.defineProperties(route, {
-  stack: { value: [] },
-  last: { get: () => route.stack[route.stack.length - 1] || {} },
+Object.defineProperty(route, {
+  last: { get: () => stack[stack.length - 1] || {} },
 });
 
 updateRoute();
@@ -34,7 +34,7 @@ export function setRoute(hash, replace) {
   if (replace) {
     window.history.replaceState('', null, hashString);
   } else {
-    route.stack.push(Object.assign({}, route));
+    stack.push(Object.assign({}, route));
     window.history.pushState('', null, hashString);
   }
   updateRoute();

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -109,7 +109,7 @@ import SettingCheck from '#/common/ui/setting-check';
 import hookSetting from '#/common/hook-setting';
 import Icon from '#/common/ui/icon';
 import LocaleGroup from '#/common/ui/locale-group';
-import { setRoute } from '#/common/router';
+import { setRoute, lastRoute } from '#/common/router';
 import ScriptItem from './script-item';
 import Edit from './edit';
 import { store, showMessage } from '../utils';
@@ -298,7 +298,7 @@ export default {
     },
     onEditScript(id) {
       const pathname = ['scripts', id].filter(Boolean).join('/');
-      if (!id && pathname === this.store.route.last.pathname) {
+      if (!id && pathname === lastRoute().pathname) {
         window.history.back();
       } else {
         setRoute(pathname);

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -109,7 +109,7 @@ import SettingCheck from '#/common/ui/setting-check';
 import hookSetting from '#/common/hook-setting';
 import Icon from '#/common/ui/icon';
 import LocaleGroup from '#/common/ui/locale-group';
-import { setRoute, lastRoute } from '#/common/router';
+import { setRoute } from '#/common/router';
 import ScriptItem from './script-item';
 import Edit from './edit';
 import { store, showMessage } from '../utils';
@@ -298,7 +298,7 @@ export default {
     },
     onEditScript(id) {
       const pathname = ['scripts', id].filter(Boolean).join('/');
-      if (!id && pathname === lastRoute.pathname) {
+      if (!id && pathname === this.store.route.last.pathname) {
         window.history.back();
       } else {
         setRoute(pathname);


### PR DESCRIPTION
This is a follow-up for #621: now that the state is not replaced we also need to observe `popstate` event on history back/forward.

Bug repro in the current master branch:
1. close all VM tabs
2. click '+' in the popup
3. click "Close" button in the editor
4. press the history back button/key in the browser
5. click "Close" button in the editor

Expected: the editor is closed and the script list is shown
Observed: nothing happens