### PR TITLE
fix: avoid FOUC

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,6 +64,7 @@ async function jsDev() {
 async function jsProd() {
   return require('@gera2ld/plaid-webpack/bin/build')({
     api: true,
+    keep: true,
   });
 }
 
@@ -137,6 +138,6 @@ const pack = gulp.parallel(manifest, copyFiles, copyI18n);
 
 exports.clean = clean;
 exports.dev = gulp.series(gulp.parallel(pack, jsDev), watch);
-exports.build = gulp.parallel(pack, jsProd);
+exports.build = gulp.series(clean, gulp.parallel(pack, jsProd));
 exports.i18n = updateI18n;
 exports.check = checkI18n;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@babel/register": "^7.6.0",
     "@gera2ld/plaid": "~1.4.12",
     "@gera2ld/plaid-vue": "~1.4.9",
-    "@gera2ld/plaid-webpack": "~1.4.12",
+    "@gera2ld/plaid-webpack": "~1.5.0",
     "cross-env": "^6.0.0",
     "del": "^5.1.0",
     "fancy-log": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.11.2",
   "scripts": {
     "dev": "gulp dev",
-    "prebuild": "yarn lint && gulp clean",
+    "prebuild": "yarn lint",
     "build": "cross-env NODE_ENV=production gulp build",
     "build:firefox": "cross-env TARGET=firefox yarn build",
     "analyze": "cross-env RUN_ENV=analyze npm run build",

--- a/scripts/plaid.conf.js
+++ b/scripts/plaid.conf.js
@@ -6,11 +6,20 @@ const { isProd } = require('@gera2ld/plaid/util');
  * - value.html: options object passed to HtmlWebpackPlugin.
  * - value.html.inlineSource: if true, JS and CSS files will be inlined in HTML.
  */
+const injectTo = item => {
+  if ([
+    '../browser.js',
+    '../common.js',
+  ].includes(item.attributes.src)) {
+    return 'head';
+  }
+};
 const htmlFactory = extra => options => ({
   ...options,
   title: 'Violentmonkey',
   ...extra,
   chunks: ['browser', ...options.chunks],
+  injectTo,
 });
 exports.pages = {
   'browser': {

--- a/src/common/ui/style/index.js
+++ b/src/common/ui/style/index.js
@@ -2,15 +2,25 @@ import options from '../../options';
 import './style.css';
 
 let style;
+const CACHE_KEY = 'cacheCustomCSS';
+
+const setStyle = (css) => {
+  if (css && !style) {
+    style = document.createElement('style');
+    document.head.appendChild(style);
+  }
+  if (css || style) {
+    css = css || '';
+    style.textContent = css;
+    localStorage.setItem(CACHE_KEY, css);
+  }
+};
+
+setStyle(localStorage.getItem(CACHE_KEY));
+
 options.hook((changes) => {
   if ('customCSS' in changes) {
     const { customCSS } = changes;
-    if (customCSS && !style) {
-      style = document.createElement('style');
-      document.head.appendChild(style);
-    }
-    if (customCSS || style) {
-      style.textContent = customCSS;
-    }
+    setStyle(customCSS);
   }
 });

--- a/src/common/ui/style/index.js
+++ b/src/common/ui/style/index.js
@@ -7,16 +7,26 @@ const CACHE_KEY = 'cacheCustomCSS';
 const setStyle = (css) => {
   if (css && !style) {
     style = document.createElement('style');
-    document.head.appendChild(style);
+    document.documentElement.appendChild(style);
   }
   if (css || style) {
     css = css || '';
     style.textContent = css;
-    localStorage.setItem(CACHE_KEY, css);
+    try {
+      localStorage.setItem(CACHE_KEY, css);
+    } catch {
+      // ignore
+    }
   }
 };
 
-setStyle(localStorage.getItem(CACHE_KEY));
+// In some versions of Firefox, `localStorage` is not allowed to be accessed
+// in Private Browsing mode.
+try {
+  setStyle(localStorage.getItem(CACHE_KEY));
+} catch {
+  // ignore
+}
 
 options.hook((changes) => {
   if ('customCSS' in changes) {

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -43,6 +43,9 @@ permissions:
   - unlimitedStorage
   - clipboardWrite
 
+minimum_chrome_version: '55.0'
+
 browser_specific_settings:
   gecko:
     id: '{aecec67f-0d10-4fa7-b7c7-609a2db280cf}'
+    strict_min_version: '52.0'

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import {
   sendMessage, i18n, getLocaleString, cache2blobUrl,
 } from '#/common';
-import options from '#/common/options';
 import handlers from '#/common/handlers';
 import loadZip from '#/common/zip';
 import '#/common/ui/style';
@@ -22,14 +21,11 @@ initialize();
 
 function initialize() {
   initMain();
-  options.ready.then(() => {
-    const el = document.createElement('div');
-    document.body.appendChild(el);
-    new Vue({
-      render: h => h(App),
-    })
-    .$mount(el);
-  });
+  const vm = new Vue({
+    render: h => h(App),
+  })
+  .$mount();
+  document.body.append(vm.$el);
   loadZip()
   .then((zip) => {
     store.zip = zip;

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -10,12 +10,11 @@ tld.initTLD();
 
 Vue.prototype.i18n = i18n;
 
-const el = document.createElement('div');
-document.body.appendChild(el);
-new Vue({
+const vm = new Vue({
   render: h => h(App),
 })
-.$mount(el);
+.$mount();
+document.body.append(vm.$el);
 
 Object.assign(handlers, {
   SetPopup(data, src) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,10 +834,10 @@
     vue-loader "^15.7.1"
     vue-template-compiler "^2.6.10"
 
-"@gera2ld/plaid-webpack@~1.4.12":
-  version "1.4.12"
-  resolved "https://registry.yarnpkg.com/@gera2ld/plaid-webpack/-/plaid-webpack-1.4.12.tgz#c9d563abcd3195f8573c1bd940b38b463b1ebc76"
-  integrity sha1-ydVjq80xlfhXPBvZQLOLRjsevHY=
+"@gera2ld/plaid-webpack@~1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@gera2ld/plaid-webpack/-/plaid-webpack-1.5.0.tgz#b6dfa4a3ef58c742c61195144a70aad70aa92b72"
+  integrity sha512-K1F5r/mxTEN+AT3z0PSNe91LcRrQoFYeBzT+u1jUuTbufu+sX6N/NeartL2MBmFw8XcRZvvcoB8aU09Sz4TO0g==
   dependencies:
     babel-loader "^8.0.6"
     css-loader "^3.2.0"


### PR DESCRIPTION
- Move scripts except `index.js` to `<head>` but keep `index.js` in `<body>` so that we don't have to check if `body` is ready everywhere. When `index.js` runs synchronously, first paint won't trigger because `<body>` is empty (except for `<script>`s).

```html
<head>
<script src="browser.js"></script>
<script src="common.js"></script>
</head>
<body>
<script src="index.js"></script>
</body>
```

- Load custom CSS from cache (`localStorage`) for the first time to avoid first paint with empty style.

When `DOMContentLoaded` is triggered after `index.js` runs, the custom style should have been attached to `<head>` and the main UI should have been rendered by Vue synchronously. So FOUC is avoided.