### PR TITLE
speed up setting icon data in Chrome

### DIFF
--- a/src/background/utils/icon.js
+++ b/src/background/utils/icon.js
@@ -51,7 +51,9 @@ browser.tabs.onRemoved.addListener((id) => {
 });
 
 browser.tabs.onUpdated.addListener((tabId, info, tab) => {
-  if (info.status === 'loading') {
+  if (info.status === 'loading'
+      // at least about:newtab in Firefox may open without 'loading' status
+      || info.favIconUrl && tab.url.startsWith('about:')) {
     updateState(tab, info.url);
   }
 });


### PR DESCRIPTION
Chrome extracts the icon data via Canvas API from each icon size specified and it wastes up to 40ms in our background page context (hence, blocking it for our code) each time a tab is opened that has a blacklisted or noninjectable state. The most frequent abuser is the default new tab page in Chrome.

This PR adds an explicit cache for imageData obtained via Canvas API.