### PR TITLE
speedup: script injection

### DIFF
--- a/src/background/utils/cache.js
+++ b/src/background/utils/cache.js
@@ -1,5 +1,5 @@
 import initCache from '#/common/cache';
 
 export default initCache({
-  lifetime: 10 * 1000,
+  lifetime: 5 * 60 * 1000,
 });

--- a/src/background/utils/tester.js
+++ b/src/background/utils/tester.js
@@ -81,6 +81,16 @@ export function testScript(url, script) {
   return ok;
 }
 
+function testRegExp(re, text) {
+  const key = `re-test:${re.source}:${text}`;
+  let res = cache.get(key);
+  if (!res) {
+    res = re.test(text) ? 1 : -1;
+    cache.put(key, res);
+  }
+  return res === 1;
+}
+
 function mergeLists(...args) {
   return args.reduce((res, item) => (item ? res.concat(item) : res), []);
 }
@@ -109,7 +119,7 @@ function autoReg(str) {
     };
   }
   const re = new RegExp(`^${reStr}$`); // String with wildcards
-  return { test: tstr => re.test(tstr) };
+  return { test: tstr => testRegExp(re, tstr) };
 }
 
 function matchScheme(rule, data) {
@@ -168,7 +178,7 @@ function pathMatcher(rule) {
     else strRe = `^${strRe}(?:#|$)`;
   }
   const reRule = new RegExp(strRe);
-  return data => reRule.test(data);
+  return data => testRegExp(reRule, data);
 }
 function matchTester(rule) {
   let test;

--- a/src/background/utils/tester.js
+++ b/src/background/utils/tester.js
@@ -30,15 +30,14 @@ let blCacheSize = 0;
  * Test glob rules like `@include` and `@exclude`.
  */
 export function testGlob(url, rules) {
-  const lifetime = 60 * 1000;
   return rules.some((rule) => {
     const key = `re:${rule}`;
     let re = cache.get(key);
     if (re) {
-      cache.hit(key, lifetime);
+      cache.hit(key);
     } else {
       re = autoReg(rule);
-      cache.put(key, re, lifetime);
+      cache.put(key, re);
     }
     return re.test(url);
   });
@@ -48,15 +47,14 @@ export function testGlob(url, rules) {
  * Test match rules like `@match` and `@exclude_match`.
  */
 export function testMatch(url, rules) {
-  const lifetime = 60 * 1000;
   return rules.some((rule) => {
     const key = `match:${rule}`;
     let matcher = cache.get(key);
     if (matcher) {
-      cache.hit(key, lifetime);
+      cache.hit(key);
     } else {
       matcher = matchTester(rule);
-      cache.put(key, matcher, lifetime);
+      cache.put(key, matcher);
     }
     return matcher.test(url);
   });

--- a/src/common/cache.js
+++ b/src/common/cache.js
@@ -1,10 +1,14 @@
-const defaults = {
-  lifetime: 3000,
-};
+const DEFAULT_LIFETIME = 3000;
 
-export default function initCache(options) {
-  const cache = {};
-  const { lifetime: defaultLifetime } = options || defaults;
+export default function initCache({
+  lifetime: defaultLifetime = DEFAULT_LIFETIME,
+} = {}) {
+  let cache = {};
+  // setTimeout call is very expensive when done frequently,
+  // 1000 calls performed for 50 scripts consume 50ms on each tab load,
+  // so we'll schedule trim() just once per event loop cycle,
+  // and then trim() will trim the cache and reschedule itself to the earliest expiry time.
+  let timer;
   return {
     get, put, del, has, hit, destroy,
   };
@@ -12,29 +16,48 @@ export default function initCache(options) {
     const item = cache[key];
     return item ? item.value : def;
   }
-  function put(key, value, lifetime) {
-    del(key);
+  function put(key, value, lifetime = defaultLifetime) {
     if (value) {
       cache[key] = {
         value,
-        timer: setTimeout(del, lifetime || defaultLifetime, key),
+        expiry: lifetime + performance.now(),
       };
-    }
-  }
-  function del(key) {
-    const item = cache[key];
-    if (item) {
-      if (item.timer) clearTimeout(item.timer);
+      if (!timer) timer = setTimeout(trim);
+    } else {
       delete cache[key];
     }
   }
-  function has(key) {
-    return !!cache[key];
+  function del(key) {
+    delete cache[key];
   }
-  function hit(key, lifetime) {
-    put(key, get(key), lifetime);
+  function has(key) {
+    return Object.hasOwnProperty.call(cache, key);
+  }
+  function hit(key, lifetime = defaultLifetime) {
+    const entry = cache[key];
+    if (entry) {
+      entry.expiry = performance.now() + lifetime;
+      if (!timer) timer = setTimeout(trim);
+    }
   }
   function destroy() {
-    Object.keys(cache).forEach(del);
+    clearTimeout(timer);
+    timer = 0;
+    cache = {};
+  }
+  function trim() {
+    const now = performance.now();
+    let closest = Number.MAX_SAFE_INTEGER;
+    for (const key in cache) {
+      if (Object.hasOwnProperty.call(cache, key)) {
+        const { expiry } = cache[key];
+        if (expiry < now) {
+          delete cache[key];
+        } else if (expiry < closest) {
+          closest = expiry;
+        }
+      }
+    }
+    timer = closest === Number.MAX_SAFE_INTEGER ? 0 : setTimeout(trim, closest - now);
   }
 }

--- a/src/common/cache.js
+++ b/src/common/cache.js
@@ -1,7 +1,5 @@
-const DEFAULT_LIFETIME = 3000;
-
 export default function initCache({
-  lifetime: defaultLifetime = DEFAULT_LIFETIME,
+  lifetime: defaultLifetime = 3000,
 } = {}) {
   let cache = {};
   // setTimeout call is very expensive when done frequently,

--- a/test/mock/polyfill.js
+++ b/test/mock/polyfill.js
@@ -16,3 +16,5 @@ global.browser = {
     },
   },
 };
+
+global.performance = { now: () => Date.now() };


### PR DESCRIPTION
* `getScriptsByURL` before: ~90ms every time

  ![Clip643](https://user-images.githubusercontent.com/1310400/65910358-2fbc8780-e3d3-11e9-84ea-bf0855b6010f.png)

* `getScriptsByURL` after: ~40ms first run, 2-20ms subsequent runs

# Changes:

1. only one `setTimeout` call per event loop cycle is used now in most cases, could be more if cacing items with progressively diminishing `lifetime` parameter, but we don't do that in bulk.

    DOM timers are relatively expensive: ~50ms out of ~90ms was wasted on set/clearTimeout when there are many matches/globs (e.g. Handy Image userscript), and lots of cache items are generated by tester.js

2. `getScriptsByURL` is pre-calculated in webRequest.onHeadersReceived for main_frame/sub_frame and http/https URLs so when the content script sends GetInjected we already have the data.

3. All background cache lifetime was extended to 5 minutes.

Now userscripts run after ~20ms since the real document_start.
We can make it even faster, see https://github.com/violentmonkey/violentmonkey/issues/420#issuecomment-536465527