### PR TITLE
speed up sandbox initialization up to ~33%

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -14,4 +14,7 @@ module.exports = {
       useBuiltIns: false,
     }],
   ],
+  plugins: [
+    'transform-function-bind',
+  ],
 };

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -8,6 +8,8 @@ module.exports = {
       exclude: [
         // for Firefox 52, see babel/babel#8204
         'transform-regenerator',
+        // all features of this transform are natively supported since Chrome 49, Firefox 52
+        'transform-parameters',
       ],
       useBuiltIns: false,
     }],

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.6.0",
+    "babel-plugin-transform-function-bind": "^6.22.0",
     "codemirror": "^5.48.4",
     "core-js": "^3.2.1",
     "tldjs": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-uglify": "^3.0.2",
     "husky": "^3.0.5",
+    "jsdom": "^15.1.1",
     "js-yaml": "^3.13.1",
     "plugin-error": "^1.0.0",
     "tape": "^4.11.0",

--- a/src/injected/content/clipboard.js
+++ b/src/injected/content/clipboard.js
@@ -1,19 +1,26 @@
+import { addEventListener, warn } from '../utils/helpers';
+
+const { execCommand } = Document.prototype;
+const { setData } = DataTransfer.prototype;
+const getClipboardData = Object.getOwnPropertyDescriptor(ClipboardEvent.prototype, 'clipboardData').get;
+const { preventDefault, removeEventListener, stopImmediatePropagation } = EventTarget.prototype;
+
 let clipboardData;
 
 function onCopy(e) {
-  e.stopImmediatePropagation();
-  e.preventDefault();
+  e::stopImmediatePropagation();
+  e::preventDefault();
   const { type, data } = clipboardData;
-  e.clipboardData.setData(type || 'text/plain', data);
+  e::getClipboardData::setData(type || 'text/plain', data);
 }
 
 export default function setClipboard({ type, data }) {
   clipboardData = { type, data };
-  document.addEventListener('copy', onCopy, false);
-  const ret = document.execCommand('copy', false, null);
-  document.removeEventListener('copy', onCopy, false);
+  document::addEventListener('copy', onCopy, false);
+  const ret = document::execCommand('copy', false, null);
+  document::removeEventListener('copy', onCopy, false);
   clipboardData = null;
   if (process.env.DEBUG && !ret) {
-    console.warn('Copy failed!');
+    warn('Copy failed!');
   }
 }

--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -140,14 +140,11 @@ function checkInjectable() {
 }
 
 function injectScripts(contentId, webId, data, scriptLists) {
-  let props = [];
+  const props = [];
   // combining directly to avoid GC due to a big intermediate object
   const addUniqProp = key => !props.includes(key) && props.push(key);
-  const windowProps = Object.getOwnPropertyNames(window);
-  // buggy Firefox may list duplicate props
-  if (isFirefox) windowProps.forEach(addUniqProp);
-  else props = windowProps;
-  Object.getOwnPropertyNames(global).forEach(addUniqProp);
+  // some browsers may list duplicate props within one window object!
+  [window, global].forEach(wnd => Object.getOwnPropertyNames(wnd).forEach(addUniqProp));
   const args = [
     webId,
     contentId,

--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -140,9 +140,14 @@ function checkInjectable() {
 }
 
 function injectScripts(contentId, webId, data, scriptLists) {
-  const props = Object.getOwnPropertyNames(window);
-  // combining directly to avoid GC due to a big intermediate object as there are thousands of props
-  Object.getOwnPropertyNames(global).forEach(key => !props.includes(key) && props.push(key));
+  let props = [];
+  // combining directly to avoid GC due to a big intermediate object
+  const addUniqProp = key => !props.includes(key) && props.push(key);
+  const windowProps = Object.getOwnPropertyNames(window);
+  // buggy Firefox may list duplicate props
+  if (isFirefox) windowProps.forEach(addUniqProp);
+  else props = windowProps;
+  Object.getOwnPropertyNames(global).forEach(addUniqProp);
   const args = [
     webId,
     contentId,

--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -131,29 +131,25 @@ function injectScripts(contentId, webId, data, scriptLists) {
   const injectContent = scriptLists[INJECT_CONTENT];
   if (injectContent.length) {
     VMInitInjection()(...args, INJECT_CONTENT);
-    bridge.ready.then(() => {
-      bridge.post({
-        cmd: 'LoadScripts',
-        data: {
-          ...data,
-          mode: INJECT_CONTENT,
-          scripts: injectContent,
-        },
-      });
+    bridge.post({
+      cmd: 'LoadScripts',
+      data: {
+        ...data,
+        mode: INJECT_CONTENT,
+        scripts: injectContent,
+      },
     });
   }
   if (injectPage.length) {
     // Avoid using Function::apply in case it is shimmed
     inject(`(${VMInitInjection.toString()}())(${args.map(arg => JSON.stringify(arg)).join(',')})`);
-    bridge.ready.then(() => {
-      bridge.post({
-        cmd: 'LoadScripts',
-        data: {
-          ...data,
-          mode: INJECT_PAGE,
-          scripts: injectPage,
-        },
-      });
+    bridge.post({
+      cmd: 'LoadScripts',
+      data: {
+        ...data,
+        mode: INJECT_PAGE,
+        scripts: injectPage,
+      },
     });
   }
 }
@@ -165,9 +161,6 @@ const handlers = {
   Inject: injectScript,
   TabOpen: tabOpen,
   TabClose: tabClose,
-  Ready() {
-    bridge.ready = Promise.resolve();
-  },
   UpdateValue(data) {
     sendMessage({ cmd: 'UpdateValue', data });
   },
@@ -221,10 +214,6 @@ const handlers = {
     });
   },
 };
-
-bridge.ready = new Promise((resolve) => {
-  handlers.Ready = resolve;
-});
 
 function onHandle(req) {
   const handle = handlers[req.cmd];

--- a/src/injected/content/notifications.js
+++ b/src/injected/content/notifications.js
@@ -3,20 +3,20 @@ import bridge from './bridge';
 
 const notifications = {};
 
-export function onNotificationCreate(options) {
+export function onNotificationCreate(options, realm) {
   sendMessage({ cmd: 'Notification', data: options })
-  .then((nid) => { notifications[nid] = options.id; });
+  .then((nid) => { notifications[nid] = { id: options.id, realm }; });
 }
 
 export function onNotificationClick(nid) {
-  const id = notifications[nid];
-  if (id) bridge.post({ cmd: 'NotificationClicked', data: id });
+  const { id, realm } = notifications[nid] || {};
+  if (id) bridge.post({ cmd: 'NotificationClicked', data: id, realm });
 }
 
 export function onNotificationClose(nid) {
-  const id = notifications[nid];
+  const { id, realm } = notifications[nid] || {};
   if (id) {
-    bridge.post({ cmd: 'NotificationClosed', data: id });
+    bridge.post({ cmd: 'NotificationClosed', data: id, realm });
     delete notifications[nid];
   }
 }

--- a/src/injected/content/requests.js
+++ b/src/injected/content/requests.js
@@ -3,20 +3,21 @@ import bridge from './bridge';
 
 const requests = {};
 
-export function getRequestId() {
+export function getRequestId(_, realm) {
   sendMessage({ cmd: 'GetRequestId' })
   .then((id) => {
-    requests[id] = 1;
-    bridge.post({ cmd: 'GotRequestId', data: id });
+    requests[id] = realm;
+    bridge.post({ cmd: 'GotRequestId', data: id, realm });
   });
 }
 export function httpRequest(details) {
   sendMessage({ cmd: 'HttpRequest', data: details });
 }
 export function httpRequested(data) {
-  if (requests[data.id]) {
+  const realm = requests[data.id];
+  if (realm) {
     if (data.type === 'loadend') delete requests[data.id];
-    bridge.post({ cmd: 'HttpRequested', data });
+    bridge.post({ cmd: 'HttpRequested', data, realm });
   }
 }
 export function abortRequest(id) {

--- a/src/injected/content/tabs.js
+++ b/src/injected/content/tabs.js
@@ -4,13 +4,15 @@ import bridge from './bridge';
 
 const tabIds = {};
 const tabKeys = {};
+const realms = {};
 
-export function tabOpen({ key, data }) {
+export function tabOpen({ key, data }, realm) {
   data.url = getFullUrl(data.url, window.location.href);
   sendMessage({ cmd: 'TabOpen', data })
   .then(({ id }) => {
     tabIds[key] = id;
     tabKeys[id] = key;
+    realms[id] = realm;
   });
 }
 
@@ -23,9 +25,11 @@ export function tabClose(key) {
 
 export function tabClosed(id) {
   const key = tabKeys[id];
+  const realm = realms[id];
+  delete realms[id];
   delete tabKeys[id];
   delete tabIds[key];
   if (key) {
-    bridge.post({ cmd: 'TabClosed', data: key });
+    bridge.post({ cmd: 'TabClosed', data: key, realm });
   }
 }

--- a/src/injected/content/util.js
+++ b/src/injected/content/util.js
@@ -1,20 +1,11 @@
-import { getUniqId } from '#/common';
-
-function removeElement(id) {
-  const el = document.querySelector(`#${id}`);
-  if (el) {
-    el.parentNode.removeChild(el);
-    return true;
-  }
-}
-
 export function inject(code, sourceUrl) {
   const script = document.createElement('script');
-  const id = getUniqId('VM-');
-  script.id = id;
-  const sourceComment = sourceUrl ? `\n//# sourceURL=${sourceUrl}` : '';
-  script.textContent = `(${removeElement.toString()})(${JSON.stringify(id)});${code}${sourceComment}`;
+  // avoid string concatenation of |code| as it can be extremely long
+  script.append(
+    'document.currentScript.remove();',
+    ...typeof code === 'string' ? [code] : code,
+    ...sourceUrl ? ['\n//# sourceURL=', sourceUrl] : [],
+  );
   document.documentElement.appendChild(script);
-  // in case the script is blocked by CSP
-  removeElement(id);
+  script.remove();
 }

--- a/src/injected/content/util.js
+++ b/src/injected/content/util.js
@@ -1,11 +1,15 @@
+import { append, createElement } from '../utils/helpers';
+
+const { remove } = Element.prototype;
+
 export function inject(code, sourceUrl) {
-  const script = document.createElement('script');
+  const script = document::createElement('script');
   // avoid string concatenation of |code| as it can be extremely long
-  script.append(
+  script::append(
     'document.currentScript.remove();',
     ...typeof code === 'string' ? [code] : code,
     ...sourceUrl ? ['\n//# sourceURL=', sourceUrl] : [],
   );
-  document.documentElement.appendChild(script);
-  script.remove();
+  document.documentElement::append(script);
+  script::remove();
 }

--- a/src/injected/index.js
+++ b/src/injected/index.js
@@ -4,7 +4,8 @@ import initialize from './content';
 (function main() {
   // Avoid running repeatedly due to new `document.documentElement`
   const VM_KEY = '__Violentmonkey';
-  if (window[VM_KEY]) return;
+  // Literal `1` guards against <html id="__Violentmonkey">, more info in browser.js
+  if (window[VM_KEY] === 1) return;
   window[VM_KEY] = 1;
 
   function initBridge() {

--- a/src/injected/index.js
+++ b/src/injected/index.js
@@ -19,7 +19,7 @@ import initialize from './content';
 
   const { go } = History.prototype;
   const { querySelector } = Document.prototype;
-  const { get: readyState } = Object.getOwnPropertyDescriptor(Document.prototype, 'readyState');
+  const { get: getReadyState } = Object.getOwnPropertyDescriptor(Document.prototype, 'readyState');
   // For installation
   // Firefox does not support `onBeforeRequest` for `file:`
   function checkJS() {
@@ -40,7 +40,7 @@ import initialize from './content';
     }
   }
   if (window.location.pathname::match(/\.user\.js$/)) {
-    if (document::readyState() === 'complete') checkJS();
+    if (document::getReadyState() === 'complete') checkJS();
     else window::addEventListener('load', checkJS, { once: true });
   }
 }());

--- a/src/injected/index.js
+++ b/src/injected/index.js
@@ -1,4 +1,5 @@
 import { getUniqId, sendMessage } from './utils';
+import { addEventListener, match } from './utils/helpers';
 import initialize from './content';
 
 (function main() {
@@ -16,10 +17,13 @@ import initialize from './content';
 
   initBridge();
 
+  const { go } = History.prototype;
+  const { querySelector } = Document.prototype;
+  const { get: readyState } = Object.getOwnPropertyDescriptor(Document.prototype, 'readyState');
   // For installation
   // Firefox does not support `onBeforeRequest` for `file:`
   function checkJS() {
-    if (!document.querySelector('title')) {
+    if (!document::querySelector('title')) {
       // plain text
       sendMessage({
         cmd: 'ConfirmInstall',
@@ -30,13 +34,13 @@ import initialize from './content';
         },
       })
       .then(() => {
-        if (window.history.length > 1) window.history.go(-1);
+        if (window.history.length > 1) window.history::go(-1);
         else sendMessage({ cmd: 'TabClose' });
       });
     }
   }
-  if (/\.user\.js$/.test(window.location.pathname)) {
-    if (document.readyState === 'complete') checkJS();
-    else window.addEventListener('load', checkJS, false);
+  if (window.location.pathname::match(/\.user\.js$/)) {
+    if (document::readyState() === 'complete') checkJS();
+    else window::addEventListener('load', checkJS, { once: true });
   }
 }());

--- a/src/injected/utils/helpers.js
+++ b/src/injected/utils/helpers.js
@@ -9,9 +9,8 @@ export const {
 } = global;
 
 export const {
-  filter, forEach, indexOf, join, map, push,
+  filter, forEach, includes, indexOf, join, map, push,
   // arraySlice, // to differentiate from String::slice which we use much more often
-  includes = function _(item) { return this::indexOf(item) >= 0; },
 } = Array.prototype;
 
 export const { keys: objectKeys, defineProperty, defineProperties } = Object;
@@ -27,7 +26,7 @@ export const { createElement } = Document.prototype;
 
 export const isArray = obj => (
   // ES3 way, not reliable if prototype is modified
-  // Object's toString(obj) === '[object Array]'
+  // Object.prototype.toString.call(obj) === '[object Array]'
   // #565 steamcommunity.com has overridden `Array.prototype`
   // support duck typing
   obj && typeof obj.length === 'number' && typeof obj.splice === 'function'

--- a/src/injected/utils/index.js
+++ b/src/injected/utils/index.js
@@ -1,25 +1,24 @@
 import { getUniqId } from '#/common';
-import { jsonDump, jsonLoad } from './helpers';
+import { jsonDump, jsonLoad, addEventListener } from './helpers';
 
 export { getUniqId, jsonDump };
 export {
   sendMessage, request, throttle, cache2blobUrl,
 } from '#/common';
-export { setJsonDump } from './helpers';
 
 const { CustomEvent } = global;
-const { dispatchEvent, addEventListener } = EventTarget.prototype;
+const { dispatchEvent } = EventTarget.prototype;
 
 export function postData(destId, data, asString) {
   // Firefox issue: data must be stringified to avoid cross-origin problem
   const detail = asString ? jsonDump(data) : data;
   const e = new CustomEvent(destId, { detail });
-  dispatchEvent.call(document, e);
+  document::dispatchEvent(e);
 }
 
 /** @returns {PostDataFunction} */
 export function bindEvents(srcId, destId, handle) {
-  addEventListener.call(document, srcId, ({ detail }) => {
+  document::addEventListener(srcId, ({ detail }) => {
     // we use bridge.post() to send an object with cmd and data, never a literal string,
     // so |detail| being a string means it was sent from another context/realm (Firefox only)
     const data = typeof detail === 'string' ? jsonLoad(detail) : detail;

--- a/src/injected/utils/index.js
+++ b/src/injected/utils/index.js
@@ -1,25 +1,36 @@
 import { getUniqId } from '#/common';
-import { CustomEvent, jsonDump, jsonLoad } from './helpers';
+import { jsonDump, jsonLoad } from './helpers';
 
-export { getUniqId };
+export { getUniqId, jsonDump };
 export {
   sendMessage, request, throttle, cache2blobUrl,
 } from '#/common';
+export { setJsonDump } from './helpers';
 
-export function postData(destId, data) {
+const { CustomEvent } = global;
+const { dispatchEvent, addEventListener } = EventTarget.prototype;
+
+export function postData(destId, data, asString) {
   // Firefox issue: data must be stringified to avoid cross-origin problem
-  const e = new CustomEvent(destId, { detail: jsonDump(data) });
-  document.dispatchEvent(e);
+  const detail = asString ? jsonDump(data) : data;
+  const e = new CustomEvent(destId, { detail });
+  dispatchEvent.call(document, e);
 }
 
+/** @returns {PostDataFunction} */
 export function bindEvents(srcId, destId, handle) {
-  document.addEventListener(srcId, (e) => {
-    const data = jsonLoad(e.detail);
+  addEventListener.call(document, srcId, ({ detail }) => {
+    // we use bridge.post() to send an object with cmd and data, never a literal string,
+    // so |detail| being a string means it was sent from another context/realm (Firefox only)
+    const data = typeof detail === 'string' ? jsonLoad(detail) : detail;
     handle(data);
-  }, false);
-  return (data) => { postData(destId, data); };
+  });
+  // let post.asString be configurable by the calling code
+  const post = data => postData(destId, data, post.asString);
+  return post;
 }
 
+// it's injected as a string so only the page functions can be used
 export function attachFunction(id, cb) {
   Object.defineProperty(window, id, {
     value(...args) {
@@ -29,3 +40,11 @@ export function attachFunction(id, cb) {
     configurable: true,
   });
 }
+
+/**
+ * @typedef {Function} PostDataFunction
+ * @property {boolean} asString -
+ *   true = stringify data sent via CustomEvent,
+ *   required in Firefox when sending between realms
+ *   (page context vs content script context)
+ */

--- a/src/injected/web/download.js
+++ b/src/injected/web/download.js
@@ -1,5 +1,6 @@
 import { downloadBlob } from '#/common/download';
 import { onRequestCreate } from './requests';
+import { Blob, Error } from '../utils/helpers';
 
 export function onDownload(arg1, arg2) {
   let options;

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -32,7 +32,6 @@ export default function initialize(
     // Load scripts after being handled by listeners in web page
     Promise.resolve().then(bridge.load);
   }, false);
-  bridge.post({ cmd: 'Ready' });
 }
 
 const store = {

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -3,8 +3,9 @@ import {
   getUniqId, bindEvents, attachFunction, cache2blobUrl,
 } from '../utils';
 import {
-  includes, forEach, map, push, utf8decode, jsonDump, jsonLoad,
-  Promise, console,
+  includes, forEach, map, push, join, concat, filter, Boolean, utf8decode, jsonDump, jsonLoad, atob,
+  Promise, console, assign, objectKeys, setTimeout, Error, defineProperty, defineProperties,
+  stringLastIndexOf, stringMatch, stringSlice, stringStarts, noop,
 } from '../utils/helpers';
 import bridge from './bridge';
 import { onRequestCreate, onRequestStart, onRequestCallback } from './requests';
@@ -18,20 +19,35 @@ import { onDownload } from './download';
 
 let state = 0;
 
+// rarely used so we'll do an explicit .call() later to reduce init time now
+const { addEventListener } = EventTarget.prototype;
+const { getElementById } = Document.prototype;
+const readyStateGet = Object.getOwnPropertyDescriptor(Document.prototype, 'readyState').get;
+
 export default function initialize(
   webId,
   contentId,
   props,
-  mode = INJECT_PAGE,
+  isFirefox,
+  invokeHost,
 ) {
+  let invokeGuest;
   bridge.props = props;
-  bridge.mode = mode;
-  bridge.post = bindEvents(webId, contentId, onHandle);
-  document.addEventListener('DOMContentLoaded', () => {
+  if (invokeHost) {
+    bridge.mode = INJECT_CONTENT;
+    bridge.post = msg => invokeHost(msg, INJECT_CONTENT);
+    invokeGuest = onHandle;
+  } else {
+    bridge.mode = INJECT_PAGE;
+    bridge.post = bindEvents(webId, contentId, onHandle);
+    bridge.post.asString = isFirefox;
+  }
+  addEventListener.call(document, 'DOMContentLoaded', () => {
     state = 1;
     // Load scripts after being handled by listeners in web page
     Promise.resolve().then(bridge.load);
-  }, false);
+  }, { once: true });
+  return invokeGuest;
 }
 
 const store = {
@@ -39,6 +55,18 @@ const store = {
   values: {},
   callbacks: {},
 };
+
+const wrapperInfo = {
+  [INJECT_CONTENT]: { unsafeWindow: global },
+  [INJECT_PAGE]: { unsafeWindow: window },
+  // store the initial eval now (before the page scripts run) just in case
+  eval: {
+    [INJECT_CONTENT]: global.eval, // eslint-disable-line no-eval
+    [INJECT_PAGE]: window.eval, // eslint-disable-line no-eval
+  },
+};
+
+let gmApi;
 
 const handlers = {
   LoadScripts: onLoadScripts,
@@ -54,8 +82,7 @@ const handlers = {
   HttpRequested: onRequestCallback,
   TabClosed: onTabClosed,
   UpdatedValues(updates) {
-    Object.keys(updates)
-    .forEach((id) => {
+    forEach(objectKeys(updates), (id) => {
       if (store.values[id]) store.values[id] = updates[id];
     });
   },
@@ -93,8 +120,9 @@ function onLoadScripts(data) {
   }
   // reset load and checkLoad
   bridge.load = () => {
+    bridge.load = noop;
     run(end);
-    setTimeout(run, 0, idle);
+    setTimeout(runIdle);
   };
   const listMap = {
     'document-start': start,
@@ -110,83 +138,80 @@ function onLoadScripts(data) {
     });
     run(start);
   }
-  if (!state && includes(['interactive', 'complete'], document.readyState)) {
+  if (!state && includes(['interactive', 'complete'], readyStateGet.call(document))) {
     state = 1;
   }
   if (state) bridge.load();
 
   function buildCode(script) {
-    const requireKeys = script.meta.require || [];
     const pathMap = script.custom.pathMap || {};
+    const requireKeys = script.meta.require || [];
+    const requires = filter(map(requireKeys, key => data.require[pathMap[key] || key]), Boolean);
     const code = data.code[script.props.id] || '';
-    const unsafeWindow = bridge.mode === INJECT_CONTENT ? global : window;
-    const { wrapper, thisObj, keys } = wrapGM(script, code, data.cache, unsafeWindow);
+    const { wrapper, thisObj, keys } = wrapGM(script, code, data.cache);
     const id = getUniqId('VMin');
     const fnId = getUniqId('VMfn');
-    const wrapperInit = map(keys, name => `this["${name}"]=${name}`).join(';');
     const codeSlices = [
-      `${wrapperInit};with(this)((define,module,exports)=>{`,
-    ];
-    forEach(requireKeys, (key) => {
-      const requireCode = data.require[pathMap[key] || key];
-      if (requireCode) {
-        push(
-          codeSlices,
-          requireCode,
-          // Add `;` to a new line in case script ends with comment lines
-          ';',
-        );
-      }
-    });
-    push(
-      codeSlices,
+      `function(${
+        join(keys, ',')
+      }){${
+        join(map(keys, name => `this["${name}"]=${name};`), '')
+      }with(this)((define,module,exports)=>{`,
+      // 1. trying to avoid string concatenation of potentially huge code slices
+      // 2. adding `;` on a new line in case some required script ends with a line comment
+      ...concat([], ...map(requires, req => [req, '\n;'])),
       '(()=>{',
       code,
-      '})()})();',
-    );
-    const codeConcat = `function(${keys.join(',')}){${codeSlices.join('\n')}}`;
+      // adding a new line in case the code ends with a line comment
+      '\n})()})()}',
+    ];
     const name = script.custom.name || script.meta.name || script.props.id;
     const args = map(keys, key => wrapper[key]);
     attachFunction(fnId, () => {
       const func = window[id];
-      if (func) runCode(name, func, args, thisObj, codeConcat);
+      if (func) runCode(name, func, args, thisObj);
     });
-    bridge.post({ cmd: 'Inject', data: [id, codeConcat, fnId, bridge.mode, script.props.id] });
+    return [id, codeSlices, fnId, bridge.mode, script.props.id];
   }
   function run(list) {
-    while (list.length) buildCode(list.shift());
+    bridge.post({ cmd: 'InjectMulti', data: map(list, buildCode) });
+    list.length = 0;
+  }
+  async function runIdle() {
+    for (const script of idle) {
+      bridge.post({ cmd: 'Inject', data: buildCode(script) });
+      await new Promise(setTimeout);
+    }
+    // let GC sweep the no longer necessary stuff
+    gmApi = null;
+    idle.length = 0;
   }
 }
 
-function wrapGM(script, code, cache, unsafeWindow) {
+function wrapGM(script, code, cache) {
+  const { unsafeWindow } = wrapperInfo[bridge.mode];
   // Add GM functions
   // Reference: http://wiki.greasespot.net/Greasemonkey_Manual:API
   const gm = {};
   const grant = script.meta.grant || [];
-  const urls = {};
   let thisObj = gm;
   if (!grant.length || (grant.length === 1 && grant[0] === 'none')) {
     // @grant none
     grant.pop();
     gm.window = unsafeWindow;
   } else {
-    thisObj = getWrapper(unsafeWindow);
+    thisObj = getWrapper();
     gm.window = thisObj;
   }
-  if (!includes(grant, 'unsafeWindow')) push(grant, 'unsafeWindow');
-  if (!includes(grant, 'GM_info')) push(grant, 'GM_info');
-  if (includes(grant, 'window.close')) gm.window.close = () => { bridge.post({ cmd: 'TabClose' }); };
+  if (includes(grant, 'window.close')) {
+    gm.window.close = () => {
+      bridge.post({ cmd: 'TabClose' });
+    };
+  }
   const resources = script.meta.resources || {};
-  const dataDecoders = {
-    o: val => jsonLoad(val),
-    // deprecated
-    n: val => Number(val),
-    b: val => val === 'true',
-  };
-  const pathMap = script.custom.pathMap || {};
   const gmInfo = {
     uuid: script.props.uuid,
-    scriptMetaStr: code.match(METABLOCK_RE)[1] || '',
+    scriptMetaStr: stringMatch(code, METABLOCK_RE)[1] || '',
     scriptWillUpdate: !!script.config.shouldUpdate,
     scriptHandler: 'Violentmonkey',
     version: bridge.version,
@@ -198,7 +223,7 @@ function wrapGM(script, code, cache, unsafeWindow) {
       matches: [...script.meta.match],
       name: script.meta.name || '',
       namespace: script.meta.namespace || '',
-      resources: Object.keys(resources).map(name => ({
+      resources: map(objectKeys(resources), name => ({
         name,
         url: resources[name],
       })),
@@ -207,201 +232,207 @@ function wrapGM(script, code, cache, unsafeWindow) {
       version: script.meta.version || '',
     },
   };
-  const gmFunctions = {
-    unsafeWindow: { value: unsafeWindow },
-    GM_info: { value: gmInfo },
-    GM_deleteValue: {
-      value(key) {
-        const value = loadValues();
-        delete value[key];
-        dumpValue(key);
-      },
+  const grantedProps = {
+    unsafeWindow: propertyFromValue(unsafeWindow),
+    GM_info: propertyFromValue(gmInfo),
+  };
+  let selfData;
+  if (!gmApi) gmApi = createGmApiProps();
+  forEach(grant, (name) => {
+    let prop = gmApi.boundProps[name];
+    if (prop) {
+      const gmFunction = prop.value;
+      prop = assign({}, prop);
+      prop.value = (...args) => gmFunction.apply(selfData, args);
+      selfData = true;
+    } else {
+      prop = gmApi.props[name];
+    }
+    if (prop) grantedProps[name] = prop;
+  });
+  if (selfData) {
+    selfData = {
+      cache,
+      script,
+      resources,
+      id: script.props.id,
+      pathMap: script.custom.pathMap || {},
+      urls: {},
+    };
+  }
+  return {
+    thisObj,
+    wrapper: defineProperties(gm, grantedProps),
+    keys: objectKeys(grantedProps),
+  };
+}
+
+function createGmApiProps() {
+  const dataDecoders = {
+    o: val => jsonLoad(val),
+    // deprecated
+    n: val => Number(val),
+    b: val => val === 'true',
+  };
+
+  // these are bound to script data that we pass via |this|
+
+  const boundProps = {
+    GM_deleteValue(key) {
+      const value = loadValues(this);
+      delete value[key];
+      dumpValue(this, key);
     },
-    GM_getValue: {
-      value(key, def) {
-        const value = loadValues();
-        const raw = value[key];
-        if (raw) {
-          const type = raw[0];
-          const handle = dataDecoders[type];
-          let val = raw.slice(1);
-          try {
-            if (handle) val = handle(val);
-          } catch (e) {
-            if (process.env.DEBUG) log('warn', 'GM_getValue', e);
+    GM_getValue(key, def) {
+      const value = loadValues(this);
+      const raw = value[key];
+      if (raw) {
+        const type = raw[0];
+        const handle = dataDecoders[type];
+        let val = stringSlice(raw, 1);
+        try {
+          if (handle) val = handle(val);
+        } catch (e) {
+          if (process.env.DEBUG) log('warn', 'GM_getValue', e);
+        }
+        return val;
+      }
+      return def;
+    },
+    GM_listValues() {
+      return objectKeys(loadValues(this));
+    },
+    GM_setValue(key, val) {
+      const dumped = jsonDump(val);
+      const raw = dumped ? `o${dumped}` : null;
+      const value = loadValues(this);
+      value[key] = raw;
+      dumpValue(this, key, raw);
+    },
+    GM_getResourceText(name) {
+      if (name in this.resources) {
+        const key = this.resources[name];
+        const raw = this.cache[this.pathMap[key] || key];
+        if (!raw) return;
+        const i = stringLastIndexOf(raw, ',');
+        const lastPart = i < 0 ? raw : stringSlice(raw, i + 1);
+        return utf8decode(atob(lastPart));
+      }
+    },
+    GM_getResourceURL(name) {
+      if (name in this.resources) {
+        const key = this.resources[name];
+        let blobUrl = this.urls[key];
+        if (!blobUrl) {
+          const raw = this.cache[this.pathMap[key] || key];
+          if (raw) {
+            blobUrl = cache2blobUrl(raw);
+            this.urls[key] = blobUrl;
+          } else {
+            blobUrl = key;
           }
-          return val;
         }
-        return def;
-      },
+        return blobUrl;
+      }
     },
-    GM_listValues: {
-      value() {
-        return Object.keys(loadValues());
-      },
+    GM_log(...args) {
+      log('log', [this.script.meta.name || 'No name'], ...args);
     },
-    GM_setValue: {
-      value(key, val) {
-        const dumped = jsonDump(val);
-        const raw = dumped ? `o${dumped}` : null;
-        const value = loadValues();
-        value[key] = raw;
-        dumpValue(key, raw);
-      },
+    GM_registerMenuCommand(cap, func) {
+      const { id } = this;
+      const key = `${id}:${cap}`;
+      store.commands[key] = func;
+      bridge.post({ cmd: 'RegisterMenu', data: [id, cap] });
     },
-    GM_getResourceText: {
-      value(name) {
-        if (name in resources) {
-          const key = resources[name];
-          const raw = cache[pathMap[key] || key];
-          const text = raw && utf8decode(window.atob(raw.split(',').pop()));
-          return text;
-        }
-      },
-    },
-    GM_getResourceURL: {
-      value(name) {
-        if (name in resources) {
-          const key = resources[name];
-          let blobUrl = urls[key];
-          if (!blobUrl) {
-            const raw = cache[pathMap[key] || key];
-            if (raw) {
-              blobUrl = cache2blobUrl(raw);
-              urls[key] = blobUrl;
-            } else {
-              blobUrl = key;
-            }
-          }
-          return blobUrl;
-        }
-      },
-    },
-    GM_addStyle: {
-      value(css) {
-        let el = false;
-        const callbackId = registerCallback((styleId) => {
-          el = document.getElementById(styleId);
-        });
-        bridge.post({ cmd: 'AddStyle', data: { css, callbackId } });
-        // Mock a Promise without the need for polyfill
-        // It's not actually necessary because DOM messaging is synchronous
-        // but we keep it for compatibility with VM's 2017-2019 behavior
-        // https://github.com/violentmonkey/violentmonkey/issues/217
-        el.then = callback => callback(el);
-        return el;
-      },
-    },
-    GM_log: {
-      value(...args) {
-        log('log', [script.meta.name || 'No name'], ...args);
-      },
-    },
-    GM_openInTab: {
-      value(url, options) {
-        const data = options && typeof options === 'object' ? options : {
-          active: !options,
-        };
-        data.url = url;
-        return onTabCreate(data);
-      },
-    },
-    GM_registerMenuCommand: {
-      value(cap, func) {
-        const { id } = script.props;
-        const key = `${id}:${cap}`;
-        store.commands[key] = func;
-        bridge.post({ cmd: 'RegisterMenu', data: [id, cap] });
-      },
-    },
-    GM_unregisterMenuCommand: {
-      value(cap) {
-        const { id } = script.props;
-        const key = `${id}:${cap}`;
-        delete store.commands[key];
-        bridge.post({ cmd: 'UnregisterMenu', data: [id, cap] });
-      },
-    },
-    GM_xmlhttpRequest: {
-      value: onRequestCreate,
-    },
-    GM_download: {
-      value: onDownload,
-    },
-    GM_notification: {
-      value(text, title, image, onclick) {
-        const options = typeof text === 'object' ? text : {
-          text,
-          title,
-          image,
-          onclick,
-        };
-        if (!options.text) {
-          throw new Error('GM_notification: `text` is required!');
-        }
-        onNotificationCreate(options);
-      },
-    },
-    GM_setClipboard: {
-      value(data, type) {
-        bridge.post({
-          cmd: 'SetClipboard',
-          data: { type, data },
-        });
-      },
+    GM_unregisterMenuCommand(cap) {
+      const { id } = this;
+      const key = `${id}:${cap}`;
+      delete store.commands[key];
+      bridge.post({ cmd: 'UnregisterMenu', data: [id, cap] });
     },
   };
-  const keys = [];
-  forEach(grant, (name) => {
-    const prop = gmFunctions[name];
-    if (prop) {
-      push(keys, name);
-      addProperty(name, prop, gm);
-    }
+
+  const props = {
+    GM_addStyle(css) {
+      let el = false;
+      const callbackId = registerCallback((styleId) => {
+        el = getElementById.call(document, styleId);
+      });
+      bridge.post({ cmd: 'AddStyle', data: { css, callbackId } });
+      // Mock a Promise without the need for polyfill
+      // It's not actually necessary because DOM messaging is synchronous
+      // but we keep it for compatibility with VM's 2017-2019 behavior
+      // https://github.com/violentmonkey/violentmonkey/issues/217
+      el.then = callback => callback(el);
+      return el;
+    },
+    GM_openInTab(url, options) {
+      const data = options && typeof options === 'object' ? options : {
+        active: !options,
+      };
+      data.url = url;
+      return onTabCreate(data);
+    },
+    GM_xmlhttpRequest: onRequestCreate,
+    GM_download: onDownload,
+    GM_notification(text, title, image, onclick) {
+      const options = typeof text === 'object' ? text : {
+        text,
+        title,
+        image,
+        onclick,
+      };
+      if (!options.text) {
+        throw new Error('GM_notification: `text` is required!');
+      }
+      onNotificationCreate(options);
+    },
+    GM_setClipboard(data, type) {
+      bridge.post({
+        cmd: 'SetClipboard',
+        data: { type, data },
+      });
+    },
+  };
+  // convert to object property descriptors
+  forEach([props, boundProps], target => {
+    forEach(objectKeys(target), k => {
+      target[k] = propertyFromValue(target[k]);
+    });
   });
-  return { thisObj, wrapper: gm, keys };
-  function loadValues() {
-    return store.values[script.props.id];
+  return { props, boundProps };
+
+  function loadValues({ id }) {
+    return store.values[id];
   }
-  function propertyToString() {
-    return '[Violentmonkey property]';
-  }
-  function addProperty(name, prop, obj) {
-    if ('value' in prop) prop.writable = false;
-    prop.configurable = false;
-    Object.defineProperty(obj, name, prop);
-    if (typeof obj[name] === 'function') obj[name].toString = propertyToString;
-  }
-  function dumpValue(key, value) {
+  function dumpValue({ id }, key, value) {
     bridge.post({
       cmd: 'UpdateValue',
       data: {
-        id: script.props.id,
+        id,
         update: { key, value },
       },
     });
   }
 }
 
-/**
- * @desc Wrap helpers to prevent unexpected modifications.
- */
-function getWrapper(unsafeWindow) {
-  // http://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects
-  // http://developer.mozilla.org/docs/Web/API/Window
-  const wrapper = {};
-  // Block special objects
-  forEach([
-    'browser',
-  ], (name) => {
-    wrapper[name] = undefined;
-  });
-  forEach([
-    // `eval` should be called directly so that it is run in current scope
-    'eval',
-  ], (name) => {
-    wrapper[name] = unsafeWindow[name];
-  });
+function propertyFromValue(value) {
+  const prop = {
+    writable: false,
+    configurable: false,
+    value,
+  };
+  if (typeof value === 'function') value.toString = propertyToString;
+  return prop;
+}
+
+function propertyToString() {
+  return '[Violentmonkey property]';
+}
+
+function createWrapperMethods(info) {
+  const { unsafeWindow } = info;
+  const methods = {};
   forEach([
     // 'uneval',
     'isFinite',
@@ -452,13 +483,36 @@ function getWrapper(unsafeWindow) {
   ], (name) => {
     const method = unsafeWindow[name];
     if (method) {
-      wrapper[name] = (...args) => method.apply(unsafeWindow, args);
+      methods[name] = (...args) => method.apply(unsafeWindow, args);
     }
   });
+  info.methods = methods;
+}
+
+/**
+ * @desc Wrap helpers to prevent unexpected modifications.
+ */
+function getWrapper() {
+  const info = wrapperInfo[bridge.mode];
+  const { unsafeWindow } = info;
+  if (!info.methods) createWrapperMethods(info);
+  // http://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects
+  // http://developer.mozilla.org/docs/Web/API/Window
+  const wrapper = {
+    // Block special objects
+    browser: undefined,
+    // `eval` should be called directly so that it is run in current scope
+    eval: wrapperInfo.eval[bridge.mode],
+    ...info.methods,
+  };
+  if (!info.propsToWrap) {
+    info.propsToWrap = filter(bridge.props, p => !(p in wrapper));
+    bridge.props = null;
+  }
   function defineProtectedProperty(name) {
     let modified = false;
     let value;
-    Object.defineProperty(wrapper, name, {
+    defineProperty(wrapper, name, {
       get() {
         if (!modified) value = unsafeWindow[name];
         return value === unsafeWindow ? wrapper : value;
@@ -470,7 +524,7 @@ function getWrapper(unsafeWindow) {
     });
   }
   function defineReactedProperty(name) {
-    Object.defineProperty(wrapper, name, {
+    defineProperty(wrapper, name, {
       get() {
         const value = unsafeWindow[name];
         return value === unsafeWindow ? wrapper : value;
@@ -481,9 +535,11 @@ function getWrapper(unsafeWindow) {
     });
   }
   // Wrap properties
-  forEach(bridge.props, (name) => {
-    if (name in wrapper) return;
-    if (name.slice(0, 2) === 'on') defineReactedProperty(name);
+  // A major GC may hit here no matter how we define props
+  // all at once, in batches of 10, 100, 500, or one by one.
+  // TODO: try Proxy API if userscripts wouldn't notice the difference
+  forEach(info.propsToWrap, (name) => {
+    if (stringStarts(name, 'on')) defineReactedProperty(name);
     else defineProtectedProperty(name);
   });
   return wrapper;
@@ -492,7 +548,7 @@ function getWrapper(unsafeWindow) {
 function log(level, tags, ...args) {
   const tagList = ['Violentmonkey'];
   if (tags) push(tagList, ...tags);
-  const prefix = tagList.map(tag => `[${tag}]`).join('');
+  const prefix = join(map(tagList, tag => `[${tag}]`), '');
   console[level](prefix, ...args);
 }
 
@@ -514,12 +570,12 @@ function exposeVM() {
       delete checking[callback];
     }
   };
-  Object.defineProperty(Violentmonkey, 'getVersion', {
+  defineProperty(Violentmonkey, 'getVersion', {
     value: () => Promise.resolve({
       version: bridge.version,
     }),
   });
-  Object.defineProperty(Violentmonkey, 'isInstalled', {
+  defineProperty(Violentmonkey, 'isInstalled', {
     value: (name, namespace) => new Promise((resolve) => {
       key += 1;
       const callback = key;
@@ -534,7 +590,7 @@ function exposeVM() {
       });
     }),
   });
-  Object.defineProperty(window.external, 'Violentmonkey', {
+  defineProperty(window.external, 'Violentmonkey', {
     value: Violentmonkey,
   });
 }

--- a/src/injected/web/requests.js
+++ b/src/injected/web/requests.js
@@ -1,6 +1,6 @@
 import {
-  includes, push, shift, encodeBody, jsonLoad, Uint8Array, Blob, warn,
-  stringSlice, stringMatch, stringCharCodeAt,
+  atob, forEach, includes, push, jsonDump, jsonLoad, objectToString, Blob, Uint8Array, warn,
+  charCodeAt, fromCharCode, match, slice, setAttribute,
 } from '../utils/helpers';
 import bridge from './bridge';
 
@@ -9,9 +9,9 @@ const queue = [];
 
 const NS_HTML = 'http://www.w3.org/1999/xhtml';
 
-// rarely used so we'll do an explicit .call() later to reduce init time now
+const { shift } = Array.prototype;
+const { toLowerCase } = String.prototype;
 const { createElementNS } = Document.prototype;
-const { setAttribute } = Element.prototype;
 const hrefGet = Object.getOwnPropertyDescriptor(HTMLAnchorElement.prototype, 'href').get;
 
 export function onRequestCreate(details) {
@@ -22,13 +22,13 @@ export function onRequestCreate(details) {
     },
   };
   details.url = getFullUrl(details.url);
-  push(queue, req);
+  queue::push(req);
   bridge.post({ cmd: 'GetRequestId' });
   return req.req;
 }
 
 export function onRequestStart(id) {
-  const req = shift(queue);
+  const req = queue::shift();
   if (req) start(req, id);
 }
 
@@ -46,14 +46,14 @@ function parseData(req, details) {
     // blob or arraybuffer
     const { response } = req.data;
     if (response) {
-      const matches = stringMatch(response, /^data:([^;,]*);base64,/);
+      const matches = response::match(/^data:([^;,]*);base64,/);
       if (!matches) {
         // invalid
         req.data.response = null;
       } else {
-        const raw = atob(stringSlice(response, matches[0].length));
+        const raw = atob(response::slice(matches[0].length));
         const arr = new Uint8Array(raw.length);
-        for (let i = 0; i < raw.length; i += 1) arr[i] = stringCharCodeAt(raw, i);
+        for (let i = 0; i < raw.length; i += 1) arr[i] = raw::charCodeAt(i);
         if (details.responseType === 'blob') {
           // blob
           return new Blob([arr], { type: matches[1] });
@@ -102,9 +102,9 @@ function start(req, id) {
   map[id] = req;
   const { responseType } = details;
   if (responseType) {
-    if (includes(['arraybuffer', 'blob'], responseType)) {
+    if (['arraybuffer', 'blob']::includes(responseType)) {
       payload.responseType = 'arraybuffer';
-    } else if (!includes(['json', 'text'], responseType)) {
+    } else if (!['json', 'text']::includes(responseType)) {
       warn(`[Violentmonkey] Unknown responseType "${responseType}", see https://violentmonkey.github.io/api/gm/#gm_xmlhttprequest for more detail.`);
     }
   }
@@ -119,7 +119,68 @@ function start(req, id) {
 }
 
 function getFullUrl(url) {
-  const a = createElementNS.call(document, NS_HTML, 'a');
-  setAttribute.call(a, 'href', url);
-  return hrefGet.call(a);
+  const a = document::createElementNS(NS_HTML, 'a');
+  a::setAttribute('href', url);
+  return a::hrefGet();
+}
+
+function encodeBody(body) {
+  const cls = getType(body);
+  let result;
+  if (cls === 'formdata') {
+    // FormData#keys is supported in Chrome >= 50
+    if (!body.keys) return {};
+    const promises = [];
+    const iterator = body.keys();
+    while (1) { // eslint-disable-line no-constant-condition
+      const item = iterator.next();
+      if (item.done) break;
+      const key = item.value;
+      const promise = Promise.all(body.getAll(key)::map(encodeBody))
+      .then(values => ({ key, values }));
+      promises::push(promise);
+    }
+    result = Promise.all(promises)
+    .then((items) => {
+      const res = {};
+      items::forEach((item) => {
+        res[item.key] = item.values;
+      });
+      return res;
+    })
+    .then(value => ({ cls, value }));
+  } else if (['blob', 'file']::includes(cls)) {
+    result = new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        // In Firefox, Uint8Array cannot be sliced if its data is read by FileReader
+        const array = new Uint8Array(reader.result);
+        let value = '';
+        for (let i = 0; i < array.length; i += 1) {
+          value += fromCharCode(array[i]);
+        }
+        resolve({
+          cls,
+          value,
+          type: body.type,
+          name: body.name,
+          lastModified: body.lastModified,
+        });
+      };
+      reader.readAsArrayBuffer(body);
+    });
+  } else if (body) {
+    result = {
+      cls,
+      value: jsonDump(body),
+    };
+  }
+  return Promise.resolve(result);
+}
+
+function getType(obj) {
+  const type = typeof obj;
+  if (type !== 'object') return type;
+  const typeString = obj::objectToString(); // [object TYPENAME]
+  return typeString::slice(8, -1)::toLowerCase();
 }

--- a/src/injected/web/requests.js
+++ b/src/injected/web/requests.js
@@ -12,7 +12,7 @@ const NS_HTML = 'http://www.w3.org/1999/xhtml';
 const { shift } = Array.prototype;
 const { toLowerCase } = String.prototype;
 const { createElementNS } = Document.prototype;
-const hrefGet = Object.getOwnPropertyDescriptor(HTMLAnchorElement.prototype, 'href').get;
+const getHref = Object.getOwnPropertyDescriptor(HTMLAnchorElement.prototype, 'href').get;
 
 export function onRequestCreate(details) {
   const req = {
@@ -121,7 +121,7 @@ function start(req, id) {
 function getFullUrl(url) {
   const a = document::createElementNS(NS_HTML, 'a');
   a::setAttribute('href', url);
-  return a::hrefGet();
+  return a::getHref();
 }
 
 const { keys, getAll } = FormData.prototype;

--- a/src/injected/web/requests.js
+++ b/src/injected/web/requests.js
@@ -1,10 +1,10 @@
 import {
-  atob, includes, join, push, jsonDump, jsonLoad, objectToString, Promise, Blob, Uint8Array,
+  atob, includes, join, map, push, jsonDump, jsonLoad, objectToString, Promise, Blob, Uint8Array,
   setAttribute, warn, charCodeAt, fromCharCode, match, slice,
 } from '../utils/helpers';
 import bridge from './bridge';
 
-const map = {};
+const idMap = {};
 const queue = [];
 
 const NS_HTML = 'http://www.w3.org/1999/xhtml';
@@ -33,7 +33,7 @@ export function onRequestStart(id) {
 }
 
 export function onRequestCallback(res) {
-  const req = map[res.id];
+  const req = idMap[res.id];
   if (req) callback(req, res);
 }
 
@@ -82,7 +82,7 @@ function callback(req, res) {
     res.data.context = req.details.context;
     cb(res.data);
   }
-  if (res.type === 'loadend') delete map[req.id];
+  if (res.type === 'loadend') delete idMap[req.id];
 }
 
 function start(req, id) {
@@ -99,7 +99,7 @@ function start(req, id) {
     overrideMimeType: details.overrideMimeType,
   };
   req.id = id;
-  map[id] = req;
+  idMap[id] = req;
   const { responseType } = details;
   if (responseType) {
     if (['arraybuffer', 'blob']::includes(responseType)) {

--- a/test/mock/polyfill.js
+++ b/test/mock/polyfill.js
@@ -1,4 +1,5 @@
 import tldRules from 'tldjs/rules.json';
+import { JSDOM } from 'jsdom';
 
 global.window = global;
 
@@ -17,4 +18,8 @@ global.browser = {
   },
 };
 
-global.performance = { now: () => Date.now() };
+const domProps = Object.getOwnPropertyDescriptors(new JSDOM('').window);
+for (const k of Object.keys(domProps)) {
+  if (k.endsWith('Storage') || k in global) delete domProps[k];
+}
+Object.defineProperties(global, domProps);


### PR DESCRIPTION
### Performance improvements

Averaged numbers on www.google.com and nine scripts of various complexity/size.  
Six were running on `start`, two on `end`, and one on `idle`.

run-at | start | end | idle | total
---------|------|-----|------|---
Before, ms | 34 | 17 | 18 | 69
After, ms | 23 | 12 | 16 | 51
speedup %  | 33% | 30% | 10% | 25%

The most important improvement is `document-start` because it's the one that delays the page UI.

Measured using the simpler `JavaScript Profiler` in Chrome's devtools as it applies less overhead. Note that now document-start block in the flamechart is single (contiguous), but previously it consisted of two blocks due to `bridge.ready` which is now removed (see notes below).

![image](https://user-images.githubusercontent.com/1310400/65976188-72846b00-e478-11e9-970d-1a8bc94cf6cf.png)

### Changes in behavior:

* each `document-idle` script runs in its own setTimeout to prevent long pauses due to a lot of scripts running at once. Unfortunately we can't do it for other types of `run-at` as they kinda sorta guarantee the execution moment.

### Trivial but noteworthy changes:

* `transform-parameters` is disabled so that `(...args) => {}` is preserved. All features of this transform are natively supported since Chrome 49, Firefox 52. Maybe it's a Babel bug as its transpiled code needlessly creates an intermediate array copy of the `arguments` object.
* `bridge.ready` is removed because scripts created using textContent run synchronously
* `CustomEvent.detail` won't be serialized in Chrome
* `onLoadScripts` will reuse gmApi descriptors and registers in bulk using Object.defineProperties
* `<html id="__Violentmonkey">` won't fool us anymore

P.S. I like how Violentmonkey splits script creation by `run-at` stages. Whereas TM creates all sandboxes at once, and it produces a very long delay (up to 100ms) at every page start with my userscripts.