### PR TITLE
improvement: auto-updatable default script template

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -6,7 +6,7 @@ import {
   getRequestId, httpRequest, abortRequest, confirmInstall,
   newScript, parseMeta,
   setClipboard, checkUpdate,
-  getOption, getDefaultOption, setOption, hookOptions, getAllOptions,
+  getOption, setOption, hookOptions, getAllOptions,
   initialize, sendMessageOrIgnore,
 } from './utils';
 import { tabOpen, tabClose } from './utils/tabs';
@@ -22,15 +22,13 @@ import {
   setValueStore, updateValueStore, resetValueOpener, addValueOpener,
 } from './utils/values';
 import { setBadge } from './utils/icon';
+import { SCRIPT_TEMPLATE, resetScriptTemplate } from './utils/template-hook';
 
 const VM_VER = browser.runtime.getManifest().version;
 
 hookOptions((changes) => {
   if ('autoUpdate' in changes) autoUpdate();
-  const SCRIPT_TEMPLATE = 'scriptTemplate';
-  if (SCRIPT_TEMPLATE in changes && !changes[SCRIPT_TEMPLATE]) {
-    setOption(SCRIPT_TEMPLATE, getDefaultOption(SCRIPT_TEMPLATE));
-  }
+  if (SCRIPT_TEMPLATE in changes) resetScriptTemplate(changes);
   sendMessageOrIgnore({
     cmd: 'UpdateOptions',
     data: changes,

--- a/src/background/utils/options.js
+++ b/src/background/utils/options.js
@@ -31,12 +31,18 @@ const defaults = {
   },
   scriptTemplate: `\
 // ==UserScript==
-// @name New Script
-// @namespace Violentmonkey Scripts
-// @match {{url}}
-// @grant none
+// @name        New script {{name}}
+// @namespace   Violentmonkey Scripts
+// @match       {{url}}
+// @grant       none
+// @version     1.0
+// @author      -
+// @description {{date}}
 // ==/UserScript==
 `,
+  // Enables automatic updates to the default template with new versions of VM
+  /** @type {?Boolean} this must be |null| for template-hook.js upgrade routine */
+  scriptTemplateEdited: null,
 };
 let changes = {};
 const hooks = initHooks();

--- a/src/background/utils/script.js
+++ b/src/background/utils/script.js
@@ -75,6 +75,8 @@ export function getDefaultCustom() {
 export function newScript(data) {
   const state = {
     url: '*://*/*',
+    name: '',
+    date: new Date().toLocaleString(),
     ...data,
   };
   const code = getOption('scriptTemplate')

--- a/src/background/utils/template-hook.js
+++ b/src/background/utils/template-hook.js
@@ -1,0 +1,39 @@
+import { getDefaultOption, getOption, setOption } from './options';
+
+export const SCRIPT_TEMPLATE = 'scriptTemplate';
+const SCRIPT_TEMPLATE_EDITED = `${SCRIPT_TEMPLATE}Edited`;
+const INITIAL_TEMPLATE = `\
+// ==UserScript==
+// @name New Script
+// @namespace Violentmonkey Scripts
+// @match {{url}}
+// @grant none
+// ==/UserScript==
+`;
+
+// When updating from an old version, set the edited flag retroactively
+// TODO: remove this in 2020 as the majority of users will have an updated VM
+global.addEventListener('backgroundInitialized', () => {
+  if (getOption(SCRIPT_TEMPLATE_EDITED) == null) {
+    if (getOption(SCRIPT_TEMPLATE) === INITIAL_TEMPLATE) {
+      resetScriptTemplate();
+    } else {
+      setOption(SCRIPT_TEMPLATE_EDITED, true);
+    }
+  }
+}, { once: true });
+
+export function resetScriptTemplate(changes = {}) {
+  const defaultTemplate = getDefaultOption(SCRIPT_TEMPLATE);
+  let template = changes[SCRIPT_TEMPLATE];
+  if (!template) {
+    template = defaultTemplate;
+    changes[SCRIPT_TEMPLATE] = template;
+    setOption(SCRIPT_TEMPLATE, template);
+  }
+  const edited = template !== defaultTemplate;
+  if (edited !== changes[SCRIPT_TEMPLATE_EDITED]) {
+    changes[SCRIPT_TEMPLATE_EDITED] = edited;
+    setOption(SCRIPT_TEMPLATE_EDITED, edited);
+  }
+}

--- a/src/common/ui/setting-text.vue
+++ b/src/common/ui/setting-text.vue
@@ -1,5 +1,5 @@
 <template>
-  <textarea v-model="value" @change="onChange" :disabled="disabled" />
+  <textarea class="monospace-font" v-model="value" @change="onChange" :disabled="disabled" />
 </template>
 
 <script>

--- a/src/common/ui/style/style.css
+++ b/src/common/ui/style/style.css
@@ -242,6 +242,10 @@ button,
 
 .editor-code .CodeMirror {
   height: 100%;
+}
+
+.monospace-font,
+.editor-code .CodeMirror {
   /* Use `Courier New` to ensure `&nbsp;` has the same width as an original space. */
   font-family: "Fira Code", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", Courier, monospace;
 }

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -222,6 +222,7 @@ export default {
           cmd: 'CacheNewScript',
           data: {
             url: currentTab.url.split('#')[0].split('?')[0],
+            name: `- ${domain}`,
           },
         })
       ) : Promise.resolve())


### PR DESCRIPTION
* Adds a new automatically calculated boolean flag in `options` that's truthy if the default script template was edited. When it's falsy an update of Violentmonkey can also update the default template automatically without overwriting user's customized value.
* Aligns the `@grant` values for better readability
* Adds a few common keys: `@version`, `@author`, `@description`