### PR TITLE
feature: show icons in the popup

### DIFF
--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -55,6 +55,20 @@ footer {
   }
 }
 
+.script-icon {
+  &[src=""] {
+    display: none;
+  }
+  max-width: 1.25rem;
+  max-height: 1.25rem;
+  margin-left: .125rem;
+  position: absolute;
+  & + .icon {
+    margin-right: .75rem;
+    margin-left: 1.5rem;
+  }
+}
+
 .menu-buttons {
   align-items: center;
   padding: 8px;
@@ -99,6 +113,12 @@ footer {
       padding-right: 2rem;
     }
   }
+  &-find {
+    padding-left: 1.25rem;
+  }
+  &-group {
+    padding-left: 3.25rem;
+  }
   &.expand {
     background: #fbfbfb;
     > .submenu {
@@ -114,7 +134,6 @@ footer {
   display: none;
   min-height: 4rem;
   max-height: 30rem;
-  margin-left: 1rem;
   overflow-y: auto;
   background: white;
   border-top: 1px dashed #ddd;
@@ -149,7 +168,7 @@ footer {
     font-size: .8rem;
     color: #333;
     > .menu-item {
-      padding-left: 2rem;
+      padding-left: 3.25rem;
       > .icon {
         margin-right: .5rem;
       }

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -38,7 +38,7 @@
       </tooltip>
     </div>
     <div class="menu" v-if="store.injectable" v-show="store.domain">
-      <div class="menu-item menu-area" @click="onFindSameDomainScripts">
+      <div class="menu-item menu-area menu-find" @click="onFindSameDomainScripts">
         <icon name="search"></icon>
         <div class="flex-1" v-text="i18n('menuFindScripts')"></div>
       </div>
@@ -52,7 +52,7 @@
       v-show="scripts.length"
       class="menu menu-scripts"
       :class="{expand: activeMenu === 'scripts'}">
-      <div class="menu-item menu-area" @click="toggleMenu('scripts')">
+      <div class="menu-item menu-area menu-group" @click="toggleMenu('scripts')">
         <div class="flex-auto" v-text="i18n('menuMatchedScripts')"></div>
         <icon name="arrow" class="icon-collapse"></icon>
       </div>
@@ -66,6 +66,7 @@
           <div
             class="menu-item menu-area"
             @click="onToggleScript(item)">
+            <img class="script-icon" :src="scriptIconUrl(item)" @error="scriptIconError">
             <icon :name="getSymbolCheck(item.data.config.enabled)"></icon>
             <div class="flex-auto ellipsis" v-text="item.name" />
           </div>
@@ -157,6 +158,13 @@ export default {
     },
     getSymbolCheck(bool) {
       return `toggle-${bool ? 'on' : 'off'}`;
+    },
+    scriptIconUrl(item) {
+      const { icon } = item.data.meta;
+      return (item.data.custom.pathMap || {})[icon] || icon || '';
+    },
+    scriptIconError(event) {
+      event.target.src = '';
     },
     onToggle() {
       options.set('isApplied', !this.options.isApplied);


### PR DESCRIPTION
Fixes #591.

![1-fs8](https://user-images.githubusercontent.com/1310400/66343027-6c4c2e00-e953-11e9-805f-9ab04f5b62ec.png)

Implementation notes:
* since only a small amount of scripts is shown I didn't use a cache for the icons
* all text was aligned to match "Violentmonkey" so the added padding on the left doesn't look weird
* `menu-group` and `menu-find` classes were added to target these non-uniform unique entries, which will be also helpful for customCSS (for example I've used a different color and font style).