### PR TITLE
GM_logging to different log-levels

### DIFF
--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -338,7 +338,15 @@ function createGmApiProps() {
       }
     },
     GM_log(...args) {
-      log('log', [this.script.meta.name || 'No name'], ...args);
+      let loglevel = 'log';
+      if (args[0] === 'error'
+        || args[0] === 'debug'
+        || args[0] === 'info'
+        || args[0] === 'log'
+        || args[0] === 'warn') {
+        loglevel = args.shift();
+      }
+      log(loglevel, [this.script.meta.name || 'No name'], ...args);
     },
     GM_registerMenuCommand(cap, func) {
       const { id } = this;


### PR DESCRIPTION
This pull will make users able to specify the log-level `GM_log` logs to. If the user specifies a specific log-level as the first parameter it'll log any further parameters to that log-level rather than `console.log` (which is still the default).

Now this *does* (slightly) break backwards compatibility with other userscript managers, and I realise people might be a bit skittish about that, but thinking about it the only use-case in which that would feasibly happen is if script calls GM_log specifically with only a log-level, say `error`, as the first parameter, in which case they probably want to log to the appropriate log-level anyway.

Alternatively, we could write specific functions `GM_debug`, `GM_error`, `GM_info`, and `GM_warn` to avoid messing with `GM_log` but in my view this would break more with other managers, as they would not support these separate calls. 

There is an argument to be made about that being additional functionality, rather than messing with backwards compatibility, and so we wouldn't have to worry about other managers, so I'm more than willing to change it to work that way instead if that is preferred. 

