### PR TITLE
Speed up search in the script list

### DIFF
--- a/src/common/options.js
+++ b/src/common/options.js
@@ -15,6 +15,9 @@ function getOption(key, def) {
 }
 
 function setOption(key, value) {
+  // the updated options object will be propagated from the background script after a pause
+  // so meanwhile the local code should be able to see the new value using options.get()
+  objectSet(options, normalizeKeys(key), value);
   sendMessage({
     cmd: 'SetOptions',
     data: { key, value },

--- a/src/common/ui/setting-text.vue
+++ b/src/common/ui/setting-text.vue
@@ -1,5 +1,11 @@
 <template>
-  <textarea class="monospace-font" v-model="value" @change="onChange" :disabled="disabled" />
+  <textarea
+    class="monospace-font"
+    spellcheck="false"
+    v-model="value"
+    :disabled="disabled"
+    @change="onChange"
+  />
 </template>
 
 <script>

--- a/src/options/utils/hotkeys.js
+++ b/src/options/utils/hotkeys.js
@@ -1,4 +1,8 @@
-document.addEventListener('keydown', (e) => {
+export function toggle(enable) {
+  document[`${enable ? 'add' : 'remove'}EventListener`]('keydown', onKeyDown);
+}
+
+function onKeyDown(e) {
   if (e.altKey || e.shiftKey || e.metaKey) return;
   if (e.key.length === 1 && !e.ctrlKey
   || e.code === 'KeyF' && e.ctrlKey) {
@@ -39,4 +43,4 @@ document.addEventListener('keydown', (e) => {
   }
   default:
   }
-});
+}

--- a/src/options/utils/hotkeys.js
+++ b/src/options/utils/hotkeys.js
@@ -1,0 +1,42 @@
+document.addEventListener('keydown', (e) => {
+  if (e.altKey || e.shiftKey || e.metaKey) return;
+  if (e.key.length === 1 && !e.ctrlKey
+  || e.code === 'KeyF' && e.ctrlKey) {
+    document.querySelector('.filter-search input').focus();
+    return;
+  }
+  if (e.ctrlKey) return;
+  let el = document.querySelector('.script.focused');
+  switch (e.key) {
+  case 'Enter': {
+    const activeEl = document.activeElement || document.body;
+    if (el && !activeEl.matches('select, input:not([type="search"])')) {
+      e.preventDefault();
+      el.dispatchEvent(new Event('keydownEnter'));
+    }
+    break;
+  }
+  case 'ArrowUp':
+  case 'ArrowDown': {
+    e.preventDefault();
+    const dir = e.key === 'ArrowUp' ? -1 : 1;
+    const all = document.querySelectorAll('.script:not([style*="display"])');
+    const numScripts = all.length;
+    if (!numScripts) return;
+    if (!el) {
+      all[dir > 0 ? 0 : numScripts - 1].classList.add('focused');
+      return;
+    }
+    el.classList.remove('focused');
+    el = all[([...all].indexOf(el) + dir + numScripts) % numScripts];
+    el.classList.add('focused');
+    const bounds = el.getBoundingClientRect();
+    const parentBounds = el.parentElement.getBoundingClientRect();
+    if (bounds.top > parentBounds.bottom || bounds.bottom < parentBounds.top) {
+      el.scrollIntoView({ behavior: 'smooth' });
+    }
+    break;
+  }
+  default:
+  }
+});

--- a/src/options/views/app.vue
+++ b/src/options/views/app.vue
@@ -37,6 +37,7 @@
 import { i18n } from '#/common';
 import Icon from '#/common/ui/icon';
 import { store } from '../utils';
+import * as Hotkeys from '../utils/hotkeys';
 import Installed from './tab-installed';
 import Settings from './tab-settings';
 import About from './tab-about';
@@ -77,6 +78,7 @@ export default {
       document.title = title ? `${title} - ${extName}` : extName;
     },
     'store.route.paths'() {
+      Hotkeys.toggle(store.route.paths[0] === 'scripts' && !store.route.paths[1]);
       // First time showing the aside we need to tell v-if to keep it forever
       this.canRenderAside = true;
     },

--- a/src/options/views/script-item.vue
+++ b/src/options/views/script-item.vue
@@ -3,7 +3,8 @@
     class="script"
     :class="{ disabled: !script.config.enabled, removed: script.config.removed }"
     :draggable="draggable"
-    @dragstart.prevent="onDragStart">
+    @dragstart.prevent="onDragStart"
+    @keydownEnter="onEdit">
     <img class="script-icon hidden-xs" :src="safeIcon">
     <div class="script-info flex">
       <div class="script-name ellipsis flex-auto" v-text="script.$cache.name"></div>
@@ -388,6 +389,9 @@ export default {
     .secondary {
       display: none;
     }
+  }
+  &.focused {
+    box-shadow: 1px 2px 9px gray;
   }
   &-buttons {
     line-height: 1;

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -63,7 +63,7 @@
           </div>
         </dropdown>
         <div class="filter-search hidden-sm">
-          <input type="text" :placeholder="i18n('labelSearchScript')" v-model="search">
+          <input type="search" :placeholder="i18n('labelSearchScript')" v-model="search">
           <icon name="search"></icon>
         </div>
       </header>
@@ -114,6 +114,7 @@ import { setRoute, lastRoute } from '#/common/router';
 import ScriptItem from './script-item';
 import Edit from './edit';
 import { store, showMessage } from '../utils';
+import '../utils/hotkeys';
 
 const SORT_EXEC = { value: 'exec', title: i18n('filterExecutionOrder') };
 const SORT_ALPHA = { value: 'alpha', title: i18n('filterAlphabeticalOrder') };
@@ -427,7 +428,7 @@ export default {
     width: 100%;
     padding-left: .5rem;
     padding-right: 2rem;
-    line-height: 2;
+    height: 2rem;
   }
 }
 .filter-sort {

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -114,7 +114,6 @@ import { setRoute, lastRoute } from '#/common/router';
 import ScriptItem from './script-item';
 import Edit from './edit';
 import { store, showMessage } from '../utils';
-import * as Hotkeys from '../utils/hotkeys';
 
 const SORT_EXEC = { value: 'exec', title: i18n('filterExecutionOrder') };
 const SORT_ALPHA = { value: 'alpha', title: i18n('filterAlphabeticalOrder') };
@@ -325,7 +324,6 @@ export default {
           if (id) setRoute(tab, true);
         }
       }
-      Hotkeys.toggle(!id);
     },
     toggleRecycle() {
       this.showRecycle = !this.showRecycle;

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -114,7 +114,7 @@ import { setRoute, lastRoute } from '#/common/router';
 import ScriptItem from './script-item';
 import Edit from './edit';
 import { store, showMessage } from '../utils';
-import '../utils/hotkeys';
+import * as Hotkeys from '../utils/hotkeys';
 
 const SORT_EXEC = { value: 'exec', title: i18n('filterExecutionOrder') };
 const SORT_ALPHA = { value: 'alpha', title: i18n('filterAlphabeticalOrder') };
@@ -325,6 +325,7 @@ export default {
           if (id) setRoute(tab, true);
         }
       }
+      Hotkeys.toggle(!id);
     },
     toggleRecycle() {
       this.showRecycle = !this.showRecycle;


### PR DESCRIPTION
* Huge speedup of search filtering. Currently filtering re-renders each element (especially gruesome when the search text is backspaced so the elements previously filtered out need to be shown) which takes up to 400ms on a measly list of 100 items. This PR switches the implementation to `v-show` and uses an additional property in `$cache` so the time spent in Vue is just a few milliseconds, plus the time for the browser to do layout/paint which hasn't changed.
* Reduced the time in debouncedUpdate to 100ms as it's fast now
* Fixed a dead spot after `options.set` is called until `updateOptions` receives the new options.
* Disabled spellchecker in text areas in settings to prevent freezing of UI when customCSS is more than a hundred of lines
* Added autofocus of the search input on typing a letter so now we can filter the list easily just by typing after opening the page
* Added <kbd>Up</kbd>, <kbd>Down</kbd> to navigate in the script list, <kbd>Enter</kbd> to edit the currently highlighted script. Ideally, full keyboard accessibility in all pages could be implemented.

Initially I've implemented keyboard navigation in an arguably idiomatic manner using data/props/bindings in `<template>`but it still took more than 5ms for Vue to recalculate this trivial change so I've used native DOM which is 10x faster. It's not like Vue needs to be aware of the navigation anyway.