### PR TITLE
fix: support Chrome's Tab.pendingUrl

### DIFF
--- a/src/background/utils/icon.js
+++ b/src/background/utils/icon.js
@@ -101,7 +101,9 @@ function updateBadge(tab, data = badges[tab.id]) {
   });
 }
 
-function updateState(tab, url = tab.url) {
+// Chrome 79+ uses pendingUrl while the tab connects to the newly navigated URL
+// https://groups.google.com/a/chromium.org/forum/#!topic/chromium-extensions/5zu_PT0arls
+function updateState(tab, url = tab.pendingUrl || tab.url) {
   const tabId = tab.id;
   const injectable = INJECTABLE_TAB_URL_RE.test(url);
   const blacklisted = injectable ? testBlacklist(url) : undefined;

--- a/src/background/utils/requests.js
+++ b/src/background/utils/requests.js
@@ -304,7 +304,8 @@ browser.webRequest.onBeforeRequest.addListener((req) => {
           confirmInstall({
             code,
             url,
-            from: tab && tab.url,
+            // Chrome 79+ uses pendingUrl while the tab connects to the newly navigated URL
+            from: tab && (tab.pendingUrl || tab.url),
           });
         } else {
           if (!bypass[url]) {


### PR DESCRIPTION
`pendingUrl` was added in Chrome 79, present while the tab connects to the newly navigated URL, https://groups.google.com/a/chromium.org/forum/#!topic/chromium-extensions/5zu_PT0arls