### PR TITLE
fix: reuse isChrome

### DIFF
--- a/src/background/utils/icon.js
+++ b/src/background/utils/icon.js
@@ -1,4 +1,5 @@
 import { i18n, noop } from '#/common';
+import { isChrome } from '#/common/ua';
 import { INJECTABLE_TAB_URL_RE } from '#/common/consts';
 import { forEachTab } from './message';
 import { getOption, hookOptions } from './options';
@@ -25,7 +26,7 @@ let titleNoninjectable;
 
 // We'll cache the icon data in Chrome as it doesn't cache the data and takes up to 40ms
 // in our background page context to set the 4 icon sizes for each new tab opened
-const iconCache = (global.chrome || {}).app && {};
+const iconCache = isChrome && {};
 
 hookOptions((changes) => {
   if ('isApplied' in changes) {


### PR DESCRIPTION
Switches to using `isChrome`.

I've used `chrome.app` detection initially but `navigator.userAgent` is just as reliable inside an extension page, also `chrome.app` may go away in the future (https://crbug.com/768493).