### PR TITLE
Trivial editor improvements

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -115,6 +115,12 @@ descCustomCSS:
   message: >-
     Custom CSS for options page and script installation page. If you are not
     sure what this is for, please do not edit it.
+descEditorOptions:
+  description: Description of editor options JSON section.
+  message: >-
+    Custom CodeMirror options in JSON object like {"indentUnit":2, "smartIndent":true}
+    however note that Violentmonkey doesn't support all of them.
+    Full list: https://codemirror.net/doc/manual.html#config
 editLabelMeta:
   description: Metadata section in settings tab of script editor.
   message: Custom metadata
@@ -492,6 +498,9 @@ msgSavedBlacklist:
 msgSavedCustomCSS:
   description: Message shown when custom CSS is saved.
   message: Custom style is updated.
+msgSavedEditorOptions:
+  description: Message shown when editor options are saved.
+  message: Editor options are updated.
 msgSavedScriptTemplate:
   description: Message shown when custom script template is saved.
   message: Custom script template is updated.

--- a/src/background/utils/options.js
+++ b/src/background/utils/options.js
@@ -1,49 +1,8 @@
 import { initHooks, debounce, normalizeKeys } from '#/common';
 import { objectGet, objectSet } from '#/common/object';
+import defaults from '#/common/options-defaults';
 import { register } from './init';
 
-const defaults = {
-  isApplied: true,
-  autoUpdate: true,
-  // ignoreGrant: false,
-  lastUpdate: 0,
-  lastModified: 0,
-  showBadge: 'unique', // '' | 'unique' | 'total'
-  exportValues: true,
-  closeAfterInstall: false,
-  trackLocalFile: false,
-  autoReload: false,
-  features: null,
-  blacklist: null,
-  syncScriptStatus: true,
-  sync: null,
-  customCSS: null,
-  importSettings: true,
-  notifyUpdates: false,
-  version: null,
-  defaultInjectInto: 'page', // 'page' | 'auto',
-  filters: {
-    sort: 'exec',
-  },
-  editor: {
-    lineWrapping: false,
-    indentUnit: 2,
-  },
-  scriptTemplate: `\
-// ==UserScript==
-// @name        New script {{name}}
-// @namespace   Violentmonkey Scripts
-// @match       {{url}}
-// @grant       none
-// @version     1.0
-// @author      -
-// @description {{date}}
-// ==/UserScript==
-`,
-  // Enables automatic updates to the default template with new versions of VM
-  /** @type {?Boolean} this must be |null| for template-hook.js upgrade routine */
-  scriptTemplateEdited: null,
-};
 let changes = {};
 const hooks = initHooks();
 const callHooksLater = debounce(callHooks, 100);

--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -1,0 +1,44 @@
+export default {
+  isApplied: true,
+  autoUpdate: true,
+  // ignoreGrant: false,
+  lastUpdate: 0,
+  lastModified: 0,
+  showBadge: 'unique', // '' | 'unique' | 'total'
+  exportValues: true,
+  closeAfterInstall: false,
+  trackLocalFile: false,
+  autoReload: false,
+  features: null,
+  blacklist: null,
+  syncScriptStatus: true,
+  sync: null,
+  customCSS: null,
+  importSettings: true,
+  notifyUpdates: false,
+  version: null,
+  defaultInjectInto: 'page', // 'page' | 'auto',
+  filters: {
+    sort: 'exec',
+  },
+  editor: {
+    lineWrapping: false,
+    indentWithTabs: false,
+    indentUnit: 2,
+    undoDepth: 200,
+  },
+  scriptTemplate: `\
+// ==UserScript==
+// @name        New script {{name}}
+// @namespace   Violentmonkey Scripts
+// @match       {{url}}
+// @grant       none
+// @version     1.0
+// @author      -
+// @description {{date}}
+// ==/UserScript==
+`,
+  // Enables automatic updates to the default template with new versions of VM
+  /** @type {?Boolean} this must be |null| for template-hook.js upgrade routine */
+  scriptTemplateEdited: null,
+};

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -238,7 +238,7 @@ export default {
       this.placeholders = placeholders;
       const { cm } = this;
       if (!cm) return;
-      cm.off('change', this.onChange);
+      cm.off('changes', this.onChange);
       cm.setValue(this.content || '');
       placeholders.forEach(({
         line, start, body, length,
@@ -258,7 +258,7 @@ export default {
       });
       cm.getDoc().clearHistory();
       cm.focus();
-      cm.on('change', this.onChange);
+      cm.on('changes', this.onChange);
     },
     'search.state.query'() {
       this.debouncedFind();

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -61,6 +61,7 @@ import 'codemirror/addon/fold/comment-fold';
 import 'codemirror/addon/search/match-highlighter';
 import 'codemirror/addon/search/searchcursor';
 import 'codemirror/addon/selection/active-line';
+import 'codemirror/keymap/sublime';
 import CodeMirror from 'codemirror';
 import Tooltip from 'vueleton/lib/tooltip/bundle';
 import { debounce } from '#/common';
@@ -87,10 +88,6 @@ function getHandler(key) {
 ].forEach((key) => {
   CodeMirror.commands[key] = getHandler(key);
 });
-Object.assign(CodeMirror.keyMap.default, {
-  Tab: 'indentMore',
-  'Shift-Tab': 'indentLess',
-});
 
 const cmOptions = {
   continueComments: true,
@@ -103,6 +100,7 @@ const cmOptions = {
   matchBrackets: true,
   autoCloseBrackets: true,
   highlightSelectionMatches: true,
+  keyMap: 'sublime',
 };
 const searchOptions = {
   useRegex: false,

--- a/src/common/ui/setting-text.vue
+++ b/src/common/ui/setting-text.vue
@@ -4,6 +4,7 @@
     spellcheck="false"
     v-model="value"
     :disabled="disabled"
+    :title="error"
     @change="onChange"
   />
 </template>
@@ -15,6 +16,7 @@ import hookSetting from '../hook-setting';
 export default {
   props: {
     name: String,
+    json: Boolean,
     disabled: Boolean,
     sync: {
       type: Boolean,
@@ -24,26 +26,51 @@ export default {
   data() {
     return {
       value: null,
+      jsonValue: null,
+      error: null,
     };
   },
   created() {
-    // XXX compatible with old data format
-    const handle = value => (Array.isArray(value) ? value.join('\n') : (value || ''));
+    const handle = this.json
+      ? (value => JSON.stringify(value, null, '  '))
+      // XXX compatible with old data format
+      : (value => (Array.isArray(value) ? value.join('\n') : value || ''));
     this.value = handle(options.get(this.name));
     this.revoke = hookSetting(this.name, (value) => {
       this.value = handle(value);
     });
+    if (this.json) this.$watch('value', this.parseJson);
   },
   beforeDestroy() {
     this.revoke();
   },
   methods: {
-    onChange() {
-      if (this.sync) {
-        options.set(this.name, this.value);
+    parseJson() {
+      try {
+        this.jsonValue = JSON.parse(this.value);
+        this.error = null;
+      } catch (e) {
+        this.error = e.message || e;
       }
-      this.$emit('change', this.value);
+    },
+    onChange() {
+      if (this.error) return;
+      const value = this.json ? this.jsonValue : this.value;
+      if (this.sync) options.set(this.name, value);
+      this.$emit('change', value);
     },
   },
 };
 </script>
+
+<style>
+  textarea {
+    &[title] {
+      border-color: #4004;
+      background: #f001;
+      &:focus {
+        border-color: #400c;
+      }
+    }
+  }
+</style>

--- a/src/common/ui/style/style.css
+++ b/src/common/ui/style/style.css
@@ -96,6 +96,9 @@ button {
   &:active {
     background: #bfbfbf;
   }
+  &:focus {
+    border-color: #000;
+  }
   &[disabled] {
     color: #d0d0d0;
     border-color: #d0d0d0;

--- a/src/options/utils/index.js
+++ b/src/options/utils/index.js
@@ -17,7 +17,10 @@ export function showMessage(message) {
   }), {
     transition: 'in-out',
   });
-  if (!message.buttons) {
+  if (message.buttons) {
+    // TODO: implement proper keyboard navigation, autofocus, and Enter/Esc in Modal module
+    document.querySelector('.vl-modal button').focus();
+  } else {
     setTimeout(() => {
       modal.close();
     }, 2000);

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -105,7 +105,7 @@ export default {
       settings: {},
       commands: {
         save: this.save,
-        close: this.close,
+        close: () => this.close({ fromCM: true }),
         showHelp: () => {
           this.nav = 'keyboard';
         },
@@ -229,8 +229,8 @@ export default {
         showMessage({ text: err });
       });
     },
-    close() {
-      if (this.nav !== 'code') {
+    close({ fromCM } = {}) {
+      if (fromCM && this.nav !== 'code') {
         this.nav = 'code';
         return;
       }

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -35,6 +35,11 @@
         v-text="i18n('editNavValues')"
         @click="nav = 'values'"
       />
+      <div
+        class="edit-nav-item"
+        :class="{active: nav === 'keyboard'}"
+        @click="nav = 'keyboard'"
+      >?</div>
       <div class="flex-auto pos-rel">
         <div
           v-if="tooLarge"
@@ -45,7 +50,7 @@
     </div>
     <div class="frame-block flex-auto pos-rel">
       <vm-code
-        v-show="nav === 'code'" class="abs-full"
+        v-show="nav === 'code'" class="abs-full" ref="code" :editing="nav === 'code'"
         v-model="code" :commands="commands" @warnLarge="onWarnLarge"
       />
       <vm-settings
@@ -54,6 +59,10 @@
       />
       <vm-values
         :show="nav === 'values'" class="abs-full edit-body" :script="script"
+      />
+      <vm-keyboard
+        v-if="nav === 'keyboard'" class="abs-full edit-body"
+        :target="this.$refs.code"
       />
     </div>
   </div>
@@ -67,6 +76,7 @@ import { route } from '#/common/router';
 import { store, showMessage } from '../../utils';
 import VmSettings from './settings';
 import VmValues from './values';
+import VmKeyboard from './keyboard';
 
 function fromList(list) {
   return (list || []).join('\n');
@@ -83,6 +93,7 @@ export default {
     VmCode,
     VmSettings,
     VmValues,
+    VmKeyboard,
   },
   data() {
     return {
@@ -95,6 +106,9 @@ export default {
       commands: {
         save: this.save,
         close: this.close,
+        showHelp: () => {
+          this.nav = 'keyboard';
+        },
       },
     };
   },
@@ -115,6 +129,9 @@ export default {
       handler() {
         this.canSave = true;
       },
+    },
+    nav() {
+      setTimeout(() => this.nav === 'code' && this.$refs.code.cm.focus());
     },
   },
   created() {
@@ -213,6 +230,10 @@ export default {
       });
     },
     close() {
+      if (this.nav !== 'code') {
+        this.nav = 'code';
+        return;
+      }
       (this.canSave ? Promise.reject() : Promise.resolve())
       .catch(() => new Promise((resolve, reject) => {
         showMessage({

--- a/src/options/views/edit/keyboard.vue
+++ b/src/options/views/edit/keyboard.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="edit-keyboard">
+    <table>
+      <tr v-for="([key, cmd]) of hotkeys" :key="key">
+        <th class="monospace-font">{{key}}</th>
+        <td>{{cmd}}</td>
+      </tr>
+    </table>
+  </div>
+</template>
+
+<script>
+import CodeMirror from 'codemirror';
+
+export default {
+  props: ['target'],
+  data() {
+    return {
+      hotkeys: null,
+    };
+  },
+  mounted() {
+    const cmOpts = this.target.cm.options;
+    this.hotkeys = Object.entries(expandKeyMap({}, cmOpts.extraKeys, cmOpts.keyMap))
+    .sort((a, b) => compareString(a, b, 1) || compareString(a, b, 0));
+  },
+};
+
+function compareString(a, b, index) {
+  return a[index] < b[index] ? -1 : a[index] > b[index];
+}
+
+function expandKeyMap(res, ...maps) {
+  maps.forEach((map) => {
+    if (typeof map === 'string') map = CodeMirror.keyMap[map];
+    Object.entries(map).forEach(([key, value]) => {
+      if (!res[key] && /^[a-z]+$/i.test(value)) {
+        res[key] = value;
+      }
+    });
+    if (map.fallthrough) expandKeyMap(res, map.fallthrough);
+  });
+  delete res.fallthrough;
+  return res;
+}
+</script>
+
+<style>
+.edit-keyboard {
+  column-width: 20em;
+  & th {
+    text-align: right;
+    padding-right: .5em;
+  }
+}
+</style>

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -52,21 +52,7 @@
       </button>
     </div>
     <div v-show="showAdvanced">
-      <section>
-        <h3 v-text="i18n('labelEditor')"></h3>
-        <div class="mb-1">
-          <label>
-            <setting-check name="editor.lineWrapping" />
-            <span v-text="i18n('labelLineWrapping')"></span>
-          </label>
-        </div>
-        <div class="mb-1">
-          <label>
-            <span class="mr-1" v-text="i18n('labelIndentUnit')"></span>
-            <input type="number" min="1" class="w-1" v-model="indentUnit" />
-          </label>
-        </div>
-      </section>
+      <vm-editor />
       <vm-template />
       <vm-blacklist />
       <vm-css />
@@ -83,6 +69,7 @@ import Icon from '#/common/ui/icon';
 import VmImport from './vm-import';
 import VmExport from './vm-export';
 import VmSync from './vm-sync';
+import VmEditor from './vm-editor';
 import VmTemplate from './vm-template';
 import VmBlacklist from './vm-blacklist';
 import VmCss from './vm-css';
@@ -101,13 +88,6 @@ const items = [
       return value === 'auto' ? 'auto' : 'page';
     },
   },
-  {
-    name: 'indentUnit',
-    key: 'editor.indentUnit',
-    normalize(value) {
-      return +value || 2;
-    },
-  },
 ];
 const settings = {
   showAdvanced: false,
@@ -122,6 +102,7 @@ export default {
     VmImport,
     VmExport,
     VmSync,
+    VmEditor,
     VmTemplate,
     VmBlacklist,
     VmCss,

--- a/src/options/views/tab-settings/vm-editor.vue
+++ b/src/options/views/tab-settings/vm-editor.vue
@@ -1,0 +1,42 @@
+<template>
+  <section>
+    <h3 v-text="i18n('labelEditor')"></h3>
+    <p v-html="i18n('descEditorOptions')" />
+    <setting-text name="editor" ref="editor" :json="true" />
+    <button v-text="i18n('buttonSave')" @click="onSave"></button>
+    <button v-text="i18n('buttonReset')" @click="onReset"></button>
+  </section>
+</template>
+
+<script>
+import { i18n } from '#/common';
+import options from '#/common/options';
+import { showMessage } from '#/options/utils';
+import SettingText from '#/common/ui/setting-text';
+import defaults from '#/common/options-defaults';
+
+export default {
+  components: {
+    SettingText,
+  },
+  mounted() {
+    this.$refs.editor.$el.addEventListener('dblclick', this.toggleBoolean);
+  },
+  methods: {
+    onSave() {
+      const { jsonValue, error } = this.$refs.editor;
+      if (!error) options.set('editor', jsonValue);
+      showMessage({ text: error || i18n('msgSavedEditorOptions') });
+    },
+    onReset() {
+      options.set('editor', defaults.editor);
+    },
+    toggleBoolean(event) {
+      const el = event.target;
+      const selection = el.value.slice(el.selectionStart, el.selectionEnd);
+      const toggled = selection === 'false' && 'true' || selection === 'true' && 'false';
+      if (toggled) document.execCommand('insertText', false, toggled);
+    },
+  },
+};
+</script>


### PR DESCRIPTION
The built-in editor can be much more convenient for quick edits if we enable a few trivial options in CodeMirror.

Fixes #242.
Fixes #596.

* the CodeMirror's `sublime` key map is a very small addon that makes the editor not a total PITA to use.
* user-customizable editor options JSON to accommodate for some weird setups like indentWithTabs etc.
* `?` sub-tab with the active key map cheat sheet:
  ![2019-10-12 21-30-11](https://user-images.githubusercontent.com/1310400/66706148-0c30ff80-ed38-11e9-83dd-0dc94c9fabbf.png)

Trivial UX changes:
* <kbd>Esc</kbd> closes the sub-tab first (Settings, Values, ?)
* <kbd>F1</kbd> shows the hotkeys tab
* CodeMirror is focused when switching back from other tabs so it's possible to press F1 (view the hotkeys), then Esc, then just keep editing without using the mouse.