### PR TITLE
fix: avoid layout shift when logo loads

### DIFF
--- a/src/options/style.css
+++ b/src/options/style.css
@@ -15,6 +15,7 @@ aside {
   background: #fafafa;
   img {
     width: 5rem;
+    height: 5rem;
   }
 }
 .aside-menu {


### PR DESCRIPTION
Fixes this UI glitch:

1. open options.html not in the editor mode

Expected: the left panel doesn't shift when the logo image loads
Observed: sometimes (randomly) it shifts

This is totally unpredictable and rare but when it happens it's really noticeable.
To force the glitch you can simply reload the page repeatedly.