### PR TITLE
fix: don't re-request missing script icons in popup

### DIFF
--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -76,7 +76,7 @@ footer {
 }
 
 .script-icon {
-  &[src=""] {
+  &:not([src]) {
     display: none;
   }
   max-width: $scriptIconSize;

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -161,10 +161,10 @@ export default {
     },
     scriptIconUrl(item) {
       const { icon } = item.data.meta;
-      return (item.data.custom.pathMap || {})[icon] || icon || '';
+      return (item.data.custom.pathMap || {})[icon] || icon || null;
     },
     scriptIconError(event) {
-      event.target.src = '';
+      event.target.removeAttribute('src');
     },
     onToggle() {
       options.set('isApplied', !this.options.isApplied);


### PR DESCRIPTION
Fixes a bug introduced by #635: when `src` is an empty string, Chrome repeatedly requests the invalid URL, stressing the CPU.

![image](https://user-images.githubusercontent.com/1310400/66764452-7a99cd00-eeb2-11e9-9d72-25a13d424ad8.png)
