### PR TITLE
chore: extract big vendor chunks

### DIFF
--- a/scripts/plaid.conf.js
+++ b/scripts/plaid.conf.js
@@ -46,6 +46,15 @@ exports.pages = {
   },
 };
 
+const splitVendor = name => ({
+  [name]: {
+    test: new RegExp(`node_modules[/\\\\]${name}`),
+    name: `public/lib/${name}`,
+    chunks: 'all',
+    priority: 100,
+  },
+});
+
 exports.devServer = false;
 exports.devtool = isProd ? false : 'inline-source-map';
 exports.optimization = {
@@ -55,6 +64,7 @@ exports.optimization = {
       common: {
         name: 'common',
         minChunks: 2,
+        enforce: true,
         chunks(chunk) {
           return ![
             'browser',
@@ -62,6 +72,9 @@ exports.optimization = {
           ].includes(chunk.name);
         },
       },
+      ...splitVendor('codemirror'),
+      ...splitVendor('tldjs'),
+      ...splitVendor('vue'),
     },
   },
 };


### PR DESCRIPTION
It's been bugging me for a while that `CodeMirror`, `tldjs`, `Vue` are loaded, parsed, compiled, and... are never used in some pages. This PR extracts them into separate files. Performance-wise I see no differences, but splitting should be better for memory consumption. Also, although Chrome doesn't seem to apply its parallelized loader/compiler to extension pages now, but it may change in the future, same for Firefox.