### PR TITLE
fix: notify ValueChange listener after updating the store

### DIFF
--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -23,10 +23,11 @@ export function createGmApiProps() {
     GM_deleteValue(key) {
       const { id } = this;
       const values = loadValues(id);
-      dumpValue({
-        id, key, oldRaw: values[key],
-      });
+      const oldRaw = values[key];
       delete values[key];
+      dumpValue({
+        id, key, oldRaw,
+      });
     },
     GM_getValue(key, def) {
       const raw = loadValues(this.id)[key];
@@ -40,10 +41,11 @@ export function createGmApiProps() {
       const dumped = jsonDump(val);
       const raw = dumped ? `o${dumped}` : null;
       const values = loadValues(id);
-      dumpValue({
-        id, key, val, raw, oldRaw: values[key],
-      });
+      const oldRaw = values[key];
       values[key] = raw;
+      dumpValue({
+        id, key, val, raw, oldRaw,
+      });
     },
     /**
      * @callback GMValueChangeListener

--- a/src/injected/web/gm-values.js
+++ b/src/injected/web/gm-values.js
@@ -25,9 +25,10 @@ const dataDecoders = {
 bridge.addHandlers({
   UpdatedValues(updates) {
     objectKeys(updates)::forEach((id) => {
-      if (id in store.values) {
-        if (id in changeHooks) changedRemotely(id, updates);
+      const oldData = store.values[id];
+      if (oldData) {
         store.values[id] = updates[id];
+        if (id in changeHooks) changedRemotely(id, oldData, updates);
       }
     });
   },
@@ -74,9 +75,8 @@ function changedLocally(change) {
   }
 }
 
-function changedRemotely(id, updates) {
+function changedRemotely(id, oldData, updates) {
   const data = updates[id];
-  const oldData = loadValues(id);
   const keyHooks = changeHooks[id];
   // the remote id is a string, but all local data structures use a number
   id = +id;


### PR DESCRIPTION
Follow-up to #636: the listener should be called after the local store is updated. This is also how it works in TM.

The mistake was caused by my initial async notification implementation, which I abandoned as it didn't match TM and it was overly complex as well as unnecessary: the userscript authors can debounce and accumulate changes if they need to.