### PR TITLE
feat: add GreaseMonkey4 GM.* aliases

### DIFF
--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -202,7 +202,21 @@ export function createGmApiProps() {
       target[k] = propertyFromValue(target[k]);
     });
   });
-  return { props, boundProps };
+  return {
+    props,
+    boundProps,
+    gm4: {
+      getResourceURL: { async: true },
+      getValue: { async: true },
+      deleteValue: { async: true },
+      setValue: { async: true },
+      listValues: { async: true },
+      xmlHttpRequest: { alias: 'xmlhttpRequest' },
+      notification: true,
+      openInTab: true,
+      setClipboard: true,
+    },
+  };
 }
 
 export function propertyFromValue(value) {


### PR DESCRIPTION
Fixes #283.

GM4 uses `const GM=....` so userscripts can't redefine it, but our `GM` variable can be redefined. Not sure why we should protect it. The fact that GM4 uses `const` wasn't a security measure, it's just a trivial implementation detail, moreover the **contents** of `GM` object is not protected in GM4, while it is protected in VM so `GM.info = 1` will be ignored unlike in GM4.