### PR TITLE
fix: retry bg connection on startup in options.html

### DIFF
--- a/src/common/options.js
+++ b/src/common/options.js
@@ -3,7 +3,7 @@ import { objectGet, objectSet } from './object';
 
 let options = {};
 const hooks = initHooks();
-const ready = sendMessage({ cmd: 'GetAllOptions' })
+const ready = sendMessage({ cmd: 'GetAllOptions' }, { retry: true })
 .then((data) => {
   options = data;
   if (data) hooks.fire(data);

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -50,7 +50,7 @@ function initScript(script) {
 }
 
 function loadData() {
-  sendMessage({ cmd: 'GetData' })
+  sendMessage({ cmd: 'GetData' }, { retry: true })
   .then((data) => {
     const oldCache = store.cache || {};
     store.cache = data.cache;


### PR DESCRIPTION
The active page and its [content] scripts load before the extension's persistent background script when Chrome starts with a URL via command line or when configured to restore the session, https://crbug.com/314686