### PR TITLE
fix: enable hotkeys listener on page load

### DIFF
--- a/src/options/utils/hotkeys.js
+++ b/src/options/utils/hotkeys.js
@@ -1,4 +1,9 @@
-export function toggle(enable) {
+import { route } from '#/common/router';
+
+routeChanged();
+
+export function routeChanged() {
+  const enable = !route.pathname || route.pathname === 'scripts';
   document[`${enable ? 'add' : 'remove'}EventListener`]('keydown', onKeyDown);
 }
 

--- a/src/options/views/app.vue
+++ b/src/options/views/app.vue
@@ -78,7 +78,7 @@ export default {
       document.title = title ? `${title} - ${extName}` : extName;
     },
     'store.route.paths'() {
-      Hotkeys.toggle(store.route.paths[0] === 'scripts' && !store.route.paths[1]);
+      Hotkeys.routeChanged();
       // First time showing the aside we need to tell v-if to keep it forever
       this.canRenderAside = true;
     },


### PR DESCRIPTION
Follow-up to #640.
Fixes the missed case of clean `options.html` URL with no routes.