### PR TITLE
fix: also throttle script list rendering on first nav

### DIFF
--- a/src/options/utils/throttled-render.js
+++ b/src/options/utils/throttled-render.js
@@ -5,7 +5,7 @@ const MAX_BATCH_DURATION = 150;
 const queue = [];
 // When script list is the initial navigation of this tab, startTime should start now
 // so that the first batch is rendered earlier to compensate for main app init
-let startTime = route.pathname === 'scripts' ? performance.now() : 0;
+let startTime = !route.pathname || route.pathname === 'scripts' ? performance.now() : 0;
 let batchSize = 0;
 let maxBatchSize = 0;
 let timer = 0;


### PR DESCRIPTION
This is the same missed case like #654. Makes the first opening of the script list seem faster. In numbers it's ~300ms now vs ~400ms before.