### PR TITLE
feat: edit on right-click or Ctrl-click at script name in popup

### DIFF
--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -68,7 +68,10 @@
             @click="onToggleScript(item)">
             <img class="script-icon" :src="scriptIconUrl(item)" @error="scriptIconError">
             <icon :name="getSymbolCheck(item.data.config.enabled)"></icon>
-            <div class="flex-auto ellipsis" v-text="item.name" />
+            <div class="flex-auto ellipsis" v-text="item.name"
+                 @click.ctrl.exact.stop="onEditScript(item)"
+                 @contextmenu.exact.stop="onEditScript(item)"
+                 @mousedown.middle.exact.stop="onEditScript(item)" />
           </div>
           <div class="submenu-buttons">
             <div class="submenu-button" @click="onEditScript(item)">


### PR DESCRIPTION
Currently we have to be very accurate when clicking the edit overlay button in order not to toggle the script accidentally due to missing the target by a few pixels. This PR makes it so that a `Right-click`, `Ctrl-click`, or `Middle-click` on a script name opens it in the editor. Same as in Tampermonkey or Stylus extension.