### PR TITLE
.user.js install tab tweaks

### DIFF
--- a/src/background/utils/requests.js
+++ b/src/background/utils/requests.js
@@ -306,6 +306,12 @@ const blacklist = [
 const bypass = {};
 const extensionRoot = browser.runtime.getURL('/');
 
+browser.tabs.onCreated.addListener((tab) => {
+  if (/\.user\.js([?#]|$)/.test(tab.pendingUrl || tab.url)) {
+    cache.put(`autoclose:${tab.id}`, true, 1000);
+  }
+});
+
 browser.webRequest.onBeforeRequest.addListener((req) => {
   // onBeforeRequest fired for `file:`
   // - works on Chrome
@@ -334,6 +340,9 @@ browser.webRequest.onBeforeRequest.addListener((req) => {
             // Chrome 79+ uses pendingUrl while the tab connects to the newly navigated URL
             from: tab && (tab.pendingUrl || tab.url),
           });
+          if (cache.has(`autoclose:${req.tabId}`)) {
+            browser.tabs.remove(req.tabId);
+          }
         } else {
           if (!bypass[url]) {
             bypass[url] = {

--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -111,6 +111,7 @@ const meta = {
     },
   },
   tabs: {
+    onCreated: true,
     onUpdated: true,
     onRemoved: true,
     create: wrapAsync,

--- a/src/common/ua.js
+++ b/src/common/ua.js
@@ -1,5 +1,5 @@
 const { userAgent } = navigator;
 
-export const isFirefox = /firefox\//i.test(userAgent);
+export const isFirefox = +userAgent.match(/firefox\/(\d+)|$/i)[1] || false;
 export const isChrome = /chrome\//i.test(userAgent);
 export const isAndroid = /android /i.test(userAgent);


### PR DESCRIPTION
* when a valid .user.js is opened in a new tab (by drag'n'dropping or explicitly opening the URL in a new tab), it'll be autoclosed when the confirmation tab is shown.
* the confirmation tab will open next to the source tab and keep track of the opener tab id so on closing of the confirmation tab the opener tab will be focused.