### PR TITLE
fix: ensure openerTabId is used only when supported

### DIFF
--- a/src/background/utils/requests.js
+++ b/src/background/utils/requests.js
@@ -1,10 +1,10 @@
 import {
   getUniqId, request, i18n, buffer2string,
 } from '#/common';
-import { isFirefox } from '#/common/ua';
 import cache from './cache';
 import { isUserScript, parseMeta } from './script';
 import { getScriptByIdSync } from './db';
+import { openerTabIdSupported } from './tabs';
 
 const requests = {};
 const verify = {};
@@ -286,7 +286,7 @@ export async function confirmInstall(info, src = {}) {
   browser.tabs.create({
     url: `/confirm/index.html#${confirmKey}`,
     index: src.tab ? src.tab.index + 1 : undefined,
-    ...src.tab && (!isFirefox || isFirefox >= 57) ? { openerTabId: src.tab.id } : {},
+    ...src.tab && openerTabIdSupported ? { openerTabId: src.tab.id } : {},
   });
 }
 

--- a/src/background/utils/tabs.js
+++ b/src/background/utils/tabs.js
@@ -1,6 +1,9 @@
 import { noop } from '#/common';
 import { isFirefox, isAndroid } from '#/common/ua';
 
+// Firefox Android does not support `openerTabId` field, it fails if this field is passed
+export const openerTabIdSupported = !isFirefox || isFirefox >= 57 && !isAndroid;
+
 const openers = {};
 
 browser.tabs.onRemoved.addListener((id) => {
@@ -30,8 +33,7 @@ export function tabOpen(data, src) {
   if (insert) {
     options.index = srcTab.index + 1;
   }
-  // Firefox Android does not support `openerTabId` field, it fails if this field is passed
-  if (!isFirefox || !isAndroid) {
+  if (openerTabIdSupported) {
     // XXX openerTabId seems buggy on Chrome
     // It seems to do nothing even set successfully with `browser.tabs.update`.
     // Reference: http://crbug.com/967150


### PR DESCRIPTION
* Adds a missing check for isAndroid in the new code for confirmInstall
* Adds a missing check for FF version >= 57 in the old code for tabOpen