### PR TITLE
fix: allow properties on window to be redefined

### DIFF
--- a/src/injected/web/gm-wrapper.js
+++ b/src/injected/web/gm-wrapper.js
@@ -207,6 +207,8 @@ function getWrapper() {
         modified = true;
         value = val;
       },
+      // Allow `defineProperty` and its family members
+      configurable: true,
     });
   }
 


### PR DESCRIPTION
fix #659 