### PR TITLE
feat: save&read script update/mod datetime in backup zip

### DIFF
--- a/src/options/views/tab-settings/vm-export.vue
+++ b/src/options/views/tab-settings/vm-export.vue
@@ -81,9 +81,13 @@ function getWriter() {
 function addFile(writer, file) {
   return loadZip()
   .then(zip => new Promise((resolve) => {
-    writer.add(file.name, new zip.TextReader(file.content), () => {
-      resolve(writer);
-    });
+    writer.add(
+      file.name,
+      new zip.TextReader(file.content),
+      () => resolve(writer),
+      null,
+      { lastModDate: file.lastModDate },
+    );
   }));
 }
 
@@ -157,10 +161,13 @@ function exportData() {
         names[name] += 1;
         name = `${name}_${names[name]}`;
       } else names[name] = 1;
+      const { lastModified, lastUpdated } = script.props;
       const info = {
         custom: script.custom,
         config: script.config,
         position: script.props.position,
+        lastModified,
+        lastUpdated,
       };
       if (withValues) {
         // `values` are related to scripts by `props.id` in Violentmonkey,
@@ -172,6 +179,7 @@ function exportData() {
       return {
         name: `${name}.user.js`,
         content: code,
+        lastModDate: new Date(lastUpdated || lastModified),
       };
     });
     files.push({

--- a/src/options/views/tab-settings/vm-import.vue
+++ b/src/options/views/tab-settings/vm-import.vue
@@ -88,6 +88,10 @@ function getVMFile(entry, vmFile) {
           data.custom = more.custom;
           data.config = more.config || {};
           data.position = more.position;
+          data.props = {
+            lastModified: more.lastModified || +entry.lastModDate,
+            lastUpdated: more.lastUpdated || +entry.lastModDate,
+          };
           // Import data from older version
           if ('enabled' in more) data.config.enabled = more.enabled;
           if ('update' in more) data.config.shouldUpdate = more.update;


### PR DESCRIPTION
* Saves script's lastModified and lastUpdated on export and restores them on import
* Sets file date inside zip accordingly

This implements the missing aspect of a conventional backup behavior - seamless/nondestructive operation. Now we can export/import any time without losing the ability to see real last modification/update timestamps and use them to sort the list.