### PR TITLE
Show unique iframe scripts in popup

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -431,6 +431,9 @@ menuFindScripts:
 menuMatchedScripts:
   description: Label for menu listing matched scripts.
   message: Matched scripts
+menuMatchedFrameScripts:
+  description: Label for menu listing matching scripts in sub-frames.
+  message: Sub-frames only scripts
 menuNewScript:
   description: Menu item to create a new script.
   message: Create a new script

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -99,9 +99,9 @@ const commands = {
       return data;
     });
   },
-  async GetInjected({ url, reset }, src) {
+  async GetInjected(url, src) {
     const { id: tabId } = src.tab || {};
-    if (reset && tabId >= 0) resetValueOpener(tabId);
+    if (src.frameId === 0) resetValueOpener(tabId);
     const data = {
       isApplied,
       injectInto,

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -33,6 +33,10 @@ export function initHooks() {
   return { hook, fire };
 }
 
+export function sendCmd(cmd, data, options) {
+  return sendMessage({ cmd, data }, options);
+}
+
 export function sendMessage(payload, { retry } = {}) {
   if (retry) return sendMessageRetry(payload);
   const promise = browser.runtime.sendMessage(payload)

--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -4,7 +4,8 @@ export default {
   // ignoreGrant: false,
   lastUpdate: 0,
   lastModified: 0,
-  showBadge: 'unique', // '' | 'unique' | 'total'
+  /** @type 'unique' | 'total' | '' */
+  showBadge: 'unique',
   exportValues: true,
   closeAfterInstall: false,
   trackLocalFile: false,

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -1,9 +1,9 @@
-import { initHooks, sendMessage, normalizeKeys } from '.';
+import { initHooks, sendCmd, normalizeKeys } from '.';
 import { objectGet, objectSet } from './object';
 
 let options = {};
 const hooks = initHooks();
-const ready = sendMessage({ cmd: 'GetAllOptions' }, { retry: true })
+const ready = sendCmd('GetAllOptions', null, { retry: true })
 .then((data) => {
   options = data;
   if (data) hooks.fire(data);
@@ -18,10 +18,7 @@ function setOption(key, value) {
   // the updated options object will be propagated from the background script after a pause
   // so meanwhile the local code should be able to see the new value using options.get()
   objectSet(options, normalizeKeys(key), value);
-  sendMessage({
-    cmd: 'SetOptions',
-    data: { key, value },
-  });
+  sendCmd('SetOptions', { key, value });
 }
 
 function updateOptions(data) {

--- a/src/confirm/views/app.vue
+++ b/src/confirm/views/app.vue
@@ -37,7 +37,7 @@
 <script>
 import Dropdown from 'vueleton/lib/dropdown/bundle';
 import {
-  sendMessage, leftpad, request, buffer2string, isRemote, getFullUrl,
+  sendCmd, leftpad, request, buffer2string, isRemote, getFullUrl,
 } from '#/common';
 import options from '#/common/options';
 import initCache from '#/common/cache';
@@ -77,12 +77,7 @@ export default {
     .then(() => {
       const id = route.paths[0];
       this.guard = setInterval(() => {
-        sendMessage({
-          cmd: 'CacheHit',
-          data: {
-            key: `confirm-${id}`,
-          },
-        });
+        sendCmd('CacheHit', { key: `confirm-${id}` });
       }, 5000);
     }, () => {
       this.close();
@@ -100,10 +95,7 @@ export default {
   methods: {
     loadInfo() {
       const id = route.paths[0];
-      return sendMessage({
-        cmd: 'CacheLoad',
-        data: `confirm-${id}`,
-      })
+      return sendCmd('CacheLoad', `confirm-${id}`)
       .then((info) => {
         if (!info) return Promise.reject();
         this.info = info;
@@ -119,10 +111,7 @@ export default {
       });
     },
     parseMeta() {
-      return sendMessage({
-        cmd: 'ParseMeta',
-        data: this.code,
-      })
+      return sendCmd('ParseMeta', this.code)
       .then((script) => {
         const urls = Object.keys(script.resources)
         .map(key => script.resources[key]);
@@ -169,7 +158,7 @@ export default {
       });
     },
     close() {
-      sendMessage({ cmd: 'TabClose' });
+      sendCmd('TabClose');
     },
     getFile(url, { isBlob, useCache } = {}) {
       const cacheKey = isBlob ? `blob+${url}` : `text+${url}`;
@@ -186,10 +175,7 @@ export default {
       });
     },
     getScript(url) {
-      return sendMessage({
-        cmd: 'CacheLoad',
-        data: url,
-      })
+      return sendCmd('CacheLoad', url)
       .then(text => text || Promise.reject())
       .catch(() => this.getFile(url))
       .catch(() => {
@@ -203,15 +189,12 @@ export default {
     },
     installScript() {
       this.installable = false;
-      sendMessage({
-        cmd: 'ParseScript',
-        data: {
-          code: this.code,
-          url: this.info.url,
-          from: this.info.from,
-          require: this.require,
-          resources: this.resources,
-        },
+      sendCmd('ParseScript', {
+        code: this.code,
+        url: this.info.url,
+        from: this.info.from,
+        require: this.require,
+        resources: this.resources,
       })
       .then((result) => {
         this.message = `${result.update.message}[${this.getTimeString()}]`;

--- a/src/injected/content/clipboard.js
+++ b/src/injected/content/clipboard.js
@@ -1,5 +1,5 @@
 import { isFirefox } from '#/common/ua';
-import { sendMessage } from '../utils';
+import { sendCmd } from '../utils';
 import { addEventListener, logging } from '../utils/helpers';
 import bridge from './bridge';
 
@@ -18,7 +18,7 @@ bridge.addHandlers({
       // The dirty way will create a <textarea> element in web page and change the selection.
       setClipboard(data);
     } else {
-      sendMessage({ cmd: 'SetClipboard', data });
+      sendCmd('SetClipboard', data);
     }
   },
 });

--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -22,10 +22,7 @@ export default async function initialize(contentId, webId) {
   bridge.post = bindEvents(contentId, webId, bridge.onHandle);
   bridge.destId = webId;
   setJsonDump({ native: true });
-  const data = await sendCmd('GetInjected', {
-    url: window.location.href,
-    reset: IS_TOP,
-  }, null, { retry: true });
+  const data = await sendCmd('GetInjected', window.location.href, { retry: true });
   const scriptLists = triageScripts(data);
   getPopup();
   setBadge();
@@ -102,17 +99,11 @@ bridge.addHandlers({
 });
 
 function getPopup() {
-  // XXX: only scripts run in top level window are counted
-  if (IS_TOP) {
-    sendCmd('SetPopup', { ids: bridge.ids, menus });
-  }
+  sendCmd('SetPopup', { ids: bridge.ids, menus });
 }
 
-function setBadge() {
+async function setBadge() {
   // delay setBadge in frames so that they can be added to the initial count
-  new Promise(resolve => setTimeout(resolve, IS_TOP ? 0 : 300))
-  .then(() => sendCmd('SetBadge', {
-    ids: bridge.enabledIds,
-    reset: IS_TOP,
-  }));
+  if (!IS_TOP) await new Promise(resolve => setTimeout(resolve, 300));
+  sendCmd('SetBadge', bridge.enabledIds);
 }

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -1,5 +1,5 @@
 import { isFirefox } from '#/common/ua';
-import { getUniqId, sendMessage } from '#/common';
+import { getUniqId, sendCmd } from '#/common';
 import { INJECT_PAGE, INJECT_CONTENT, INJECT_AUTO } from '#/common/consts';
 import { attachFunction } from '../utils';
 import bridge from './bridge';
@@ -137,10 +137,7 @@ function injectScript(data) {
     `,"${vCallbackId}");`,
   ];
   if (mode === INJECT_CONTENT) {
-    sendMessage({
-      cmd: 'InjectScript',
-      data: injectedCode::join(''),
-    });
+    sendCmd('InjectScript', injectedCode::join(''));
   } else {
     const name = encodeURIComponent(scriptName::replace(/[#/]/g, ''));
     inject(injectedCode, browser.extension.getURL(`${name}.user.js#${scriptId}`));

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -26,11 +26,13 @@ export function triageScripts(data) {
     [INJECT_CONTENT]: [],
   };
   if (data.scripts) {
-    data.scripts = data.scripts.filter((script) => {
-      bridge.ids.push(script.props.id);
-      if ((window.top === window || !script.meta.noframes) && script.config.enabled) {
-        bridge.enabledIds.push(script.props.id);
-        return true;
+    data.scripts = data.scripts.filter(({ meta, props, config }) => {
+      if (!meta.noframes || window.top === window) {
+        bridge.ids.push(props.id);
+        if (config.enabled) {
+          bridge.enabledIds.push(props.id);
+          return true;
+        }
       }
       return false;
     });

--- a/src/injected/content/notifications.js
+++ b/src/injected/content/notifications.js
@@ -1,11 +1,11 @@
-import { sendMessage } from '../utils';
+import { sendCmd } from '../utils';
 import bridge from './bridge';
 
 const notifications = {};
 
 bridge.addHandlers({
   Notification(options, realm) {
-    sendMessage({ cmd: 'Notification', data: options })
+    sendCmd('Notification', options)
     .then((nid) => { notifications[nid] = { id: options.id, realm }; });
   },
 });

--- a/src/injected/content/requests.js
+++ b/src/injected/content/requests.js
@@ -1,11 +1,11 @@
-import { sendMessage } from '../utils';
+import { sendCmd, sendMessage } from '../utils';
 import bridge from './bridge';
 
 const requests = {};
 
 bridge.addHandlers({
   GetRequestId(_, realm) {
-    sendMessage({ cmd: 'GetRequestId' })
+    sendCmd('GetRequestId')
     .then((id) => {
       requests[id] = realm;
       bridge.post({ cmd: 'GotRequestId', data: id, realm });

--- a/src/injected/content/tabs.js
+++ b/src/injected/content/tabs.js
@@ -1,5 +1,5 @@
 import { getFullUrl } from '#/common';
-import { sendMessage } from '../utils';
+import { sendCmd } from '../utils';
 import bridge from './bridge';
 
 const tabIds = {};
@@ -9,7 +9,7 @@ const realms = {};
 bridge.addHandlers({
   TabOpen({ key, data }, realm) {
     data.url = getFullUrl(data.url, window.location.href);
-    sendMessage({ cmd: 'TabOpen', data })
+    sendCmd('TabOpen', data)
     .then(({ id }) => {
       tabIds[key] = id;
       tabKeys[id] = key;
@@ -20,7 +20,7 @@ bridge.addHandlers({
     const id = tabIds[key];
     // !key => close current tab
     // id => close tab by id
-    if (!key || id) sendMessage({ cmd: 'TabClose', data: { id } });
+    if (!key || id) sendCmd('TabClose', { id });
   },
 });
 

--- a/src/injected/index.js
+++ b/src/injected/index.js
@@ -1,4 +1,4 @@
-import { getUniqId, sendMessage } from './utils';
+import { getUniqId, sendCmd } from './utils';
 import { addEventListener, match } from './utils/helpers';
 import initialize from './content';
 
@@ -25,17 +25,14 @@ import initialize from './content';
   function checkJS() {
     if (!document::querySelector('title')) {
       // plain text
-      sendMessage({
-        cmd: 'ConfirmInstall',
-        data: {
-          code: document.body.textContent,
-          url: window.location.href,
-          from: document.referrer,
-        },
+      sendCmd('ConfirmInstall', {
+        code: document.body.textContent,
+        url: window.location.href,
+        from: document.referrer,
       })
       .then(() => {
         if (window.history.length > 1) window.history::go(-1);
-        else sendMessage({ cmd: 'TabClose' });
+        else sendCmd('TabClose');
       });
     }
   }

--- a/src/injected/utils/index.js
+++ b/src/injected/utils/index.js
@@ -3,7 +3,7 @@ import { jsonDump, jsonLoad, addEventListener } from './helpers';
 
 export { getUniqId, jsonDump };
 export {
-  sendMessage, request, throttle, cache2blobUrl,
+  sendCmd, sendMessage, request, throttle, cache2blobUrl,
 } from '#/common';
 
 const { CustomEvent } = global;

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import {
-  sendMessage, i18n, getLocaleString, cache2blobUrl,
+  sendCmd, i18n, getLocaleString, cache2blobUrl,
 } from '#/common';
 import handlers from '#/common/handlers';
 import loadZip from '#/common/zip';
@@ -50,7 +50,7 @@ function initScript(script) {
 }
 
 function loadData() {
-  sendMessage({ cmd: 'GetData' }, { retry: true })
+  sendCmd('GetData', null, { retry: true })
   .then((data) => {
     const oldCache = store.cache || {};
     store.cache = data.cache;

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -69,7 +69,7 @@
 </template>
 
 <script>
-import { i18n, sendMessage, noop } from '#/common';
+import { i18n, sendCmd, noop } from '#/common';
 import { objectGet } from '#/common/object';
 import VmCode from '#/common/ui/code';
 import { route } from '#/common/router';
@@ -140,14 +140,8 @@ export default {
   mounted() {
     const id = objectGet(this.script, 'props.id');
     (id
-      ? sendMessage({
-        cmd: 'GetScriptCode',
-        data: id,
-      })
-      : sendMessage({
-        cmd: 'NewScript',
-        data: route.paths[2],
-      })
+      ? sendCmd('GetScriptCode', id)
+      : sendCmd('NewScript', route.paths[2])
       .then(({ script, code }) => {
         this.script = script;
         return code;
@@ -208,19 +202,16 @@ export default {
         excludeMatch: toList(rawCustom.excludeMatch),
       });
       const id = objectGet(this.script, 'props.id');
-      return sendMessage({
-        cmd: 'ParseScript',
-        data: {
-          id,
-          custom,
-          config,
-          code: this.code,
-          // User created scripts MUST be marked `isNew` so that
-          // the backend is able to check namespace conflicts,
-          // otherwise the script with same namespace will be overridden
-          isNew: !id,
-          message: '',
-        },
+      return sendCmd('ParseScript', {
+        id,
+        custom,
+        config,
+        code: this.code,
+        // User created scripts MUST be marked `isNew` so that
+        // the backend is able to check namespace conflicts,
+        // otherwise the script with same namespace will be overridden
+        isNew: !id,
+        message: '',
       })
       .then((res) => {
         this.canSave = false;

--- a/src/options/views/edit/values.vue
+++ b/src/options/views/edit/values.vue
@@ -45,7 +45,7 @@
 </template>
 
 <script>
-import { sendMessage } from '#/common';
+import { sendCmd } from '#/common';
 import Icon from '#/common/ui/icon';
 
 const PAGE_SIZE = 25;
@@ -100,7 +100,7 @@ export default {
       return value;
     },
     refresh() {
-      sendMessage({ cmd: 'GetValueStore', data: this.script.props.id })
+      sendCmd('GetValueStore', this.script.props.id)
       .then((values) => {
         this.values = values;
         this.keys = Object.keys(values).sort();
@@ -109,14 +109,11 @@ export default {
     },
     updateValue({ key, value, isNew }) {
       const rawValue = value ? `o${value}` : '';
-      return sendMessage({
-        cmd: 'UpdateValue',
-        data: {
-          id: this.script.props.id,
-          update: {
-            key,
-            value: rawValue,
-          },
+      return sendCmd('UpdateValue', {
+        id: this.script.props.id,
+        update: {
+          key,
+          value: rawValue,
         },
       })
       .then(() => {

--- a/src/options/views/script-item.vue
+++ b/src/options/views/script-item.vue
@@ -94,7 +94,7 @@
 
 <script>
 import Tooltip from 'vueleton/lib/tooltip/bundle';
-import { sendMessage, getLocaleString, formatTime } from '#/common';
+import { sendCmd, getLocaleString, formatTime } from '#/common';
 import { objectGet } from '#/common/object';
 import Icon from '#/common/ui/icon';
 import { store, throttledRender } from '../utils';
@@ -211,12 +211,9 @@ export default {
       this.$emit('edit', this.script.props.id);
     },
     markRemoved(removed) {
-      sendMessage({
-        cmd: 'MarkRemoved',
-        data: {
-          id: this.script.props.id,
-          removed,
-        },
+      sendCmd('MarkRemoved', {
+        id: this.script.props.id,
+        removed,
       });
     },
     onRemove() {
@@ -228,21 +225,15 @@ export default {
       this.markRemoved(0);
     },
     onEnable() {
-      sendMessage({
-        cmd: 'UpdateScriptInfo',
-        data: {
-          id: this.script.props.id,
-          config: {
-            enabled: this.script.config.enabled ? 0 : 1,
-          },
+      sendCmd('UpdateScriptInfo', {
+        id: this.script.props.id,
+        config: {
+          enabled: this.script.config.enabled ? 0 : 1,
         },
       });
     },
     onUpdate() {
-      sendMessage({
-        cmd: 'CheckUpdate',
-        data: this.script.props.id,
-      });
+      sendCmd('CheckUpdate', this.script.props.id);
     },
     onDragStart(e) {
       const el = e.currentTarget;

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -103,7 +103,7 @@
 import Dropdown from 'vueleton/lib/dropdown/bundle';
 import Tooltip from 'vueleton/lib/tooltip/bundle';
 import {
-  i18n, sendMessage, debounce,
+  i18n, sendCmd, debounce,
 } from '#/common';
 import options from '#/common/options';
 import SettingCheck from '#/common/ui/setting-check';
@@ -242,7 +242,7 @@ export default {
       this.debouncedUpdate();
     },
     updateAll() {
-      sendMessage({ cmd: 'CheckUpdateAll' });
+      sendCmd('CheckUpdateAll');
     },
     installFromURL() {
       new Promise((resolve, reject) => {
@@ -263,7 +263,7 @@ export default {
         });
       })
       .then((url) => {
-        if (url && url.includes('://')) return sendMessage({ cmd: 'ConfirmInstall', data: { url } });
+        if (url && url.includes('://')) return sendCmd('ConfirmInstall', { url });
       })
       .catch((err) => {
         if (err) showMessage({ text: err });
@@ -271,12 +271,9 @@ export default {
     },
     moveScript(data) {
       if (data.from === data.to) return;
-      sendMessage({
-        cmd: 'Move',
-        data: {
-          id: this.scripts[data.from].props.id,
-          offset: data.to - data.from,
-        },
+      sendCmd('Move', {
+        id: this.scripts[data.from].props.id,
+        offset: data.to - data.from,
       })
       .then(() => {
         const { scripts } = this;

--- a/src/options/views/tab-settings/vm-blacklist.vue
+++ b/src/options/views/tab-settings/vm-blacklist.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script>
-import { i18n, sendMessage } from '#/common';
+import { i18n, sendCmd } from '#/common';
 import options from '#/common/options';
 import { showMessage } from '#/options/utils';
 import SettingText from '#/common/ui/setting-text';
@@ -24,7 +24,7 @@ export default {
     onSave() {
       options.set('blacklist', this.$refs.blacklist.value);
       showMessage({ text: i18n('msgSavedBlacklist') });
-      sendMessage({ cmd: 'BlacklistReset' });
+      sendCmd('BlacklistReset');
     },
   },
 };

--- a/src/options/views/tab-settings/vm-export.vue
+++ b/src/options/views/tab-settings/vm-export.vue
@@ -25,7 +25,7 @@
 
 <script>
 import Modal from 'vueleton/lib/modal/bundle';
-import { sendMessage, getLocaleString } from '#/common';
+import { sendCmd, getLocaleString } from '#/common';
 import { objectGet } from '#/common/object';
 import options from '#/common/options';
 import { isFirefox } from '#/common/ua';
@@ -141,11 +141,8 @@ function normalizeFilename(name) {
 
 function exportData() {
   const withValues = options.get('exportValues');
-  return sendMessage({
-    cmd: 'ExportZip',
-    data: {
-      values: withValues,
-    },
+  return sendCmd('ExportZip', {
+    values: withValues,
   })
   .then((data) => {
     const names = {};

--- a/src/options/views/tab-settings/vm-import.vue
+++ b/src/options/views/tab-settings/vm-import.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script>
-import { i18n, sendMessage } from '#/common';
+import { i18n, sendCmd } from '#/common';
 import options from '#/common/options';
 import SettingCheck from '#/common/ui/setting-check';
 import loadZip from '#/common/zip';
@@ -47,7 +47,7 @@ export default {
     vacuum() {
       this.vacuuming = true;
       this.labelVacuum = this.i18n('buttonVacuuming');
-      sendMessage({ cmd: 'Vacuum' })
+      sendCmd('Vacuum')
       .then(() => {
         this.vacuuming = false;
         this.labelVacuum = this.i18n('buttonVacuumed');
@@ -97,10 +97,7 @@ function getVMFile(entry, vmFile) {
           if ('update' in more) data.config.shouldUpdate = more.update;
         }
       }
-      sendMessage({
-        cmd: 'ParseScript',
-        data,
-      })
+      sendCmd('ParseScript', data)
       .then(() => resolve(true), () => resolve());
     });
   }));
@@ -152,17 +149,14 @@ function importData(file) {
     .then((count) => {
       forEachItem(vm.values, (valueStore, key) => {
         if (valueStore) {
-          sendMessage({
-            cmd: 'SetValueStore',
-            data: {
-              where: { uri: key },
-              valueStore,
-            },
+          sendCmd('SetValueStore', {
+            where: { uri: key },
+            valueStore,
           });
         }
       });
       showMessage({ text: i18n('msgImported', [count]) });
-      sendMessage({ cmd: 'CheckPosition' });
+      sendCmd('CheckPosition');
     });
   });
 }

--- a/src/options/views/tab-settings/vm-sync.vue
+++ b/src/options/views/tab-settings/vm-sync.vue
@@ -71,7 +71,7 @@
 </template>
 
 <script>
-import { sendMessage } from '#/common';
+import { sendCmd } from '#/common';
 import options from '#/common/options';
 import SettingCheck from '#/common/ui/setting-check';
 import hookSetting from '#/common/hook-setting';
@@ -144,10 +144,7 @@ export default {
   },
   methods: {
     onSaveUserConfig() {
-      sendMessage({
-        cmd: 'SyncSetConfig',
-        data: this.state.userConfig,
-      });
+      sendCmd('SyncSetConfig', this.state.userConfig);
     },
     onSyncChange(e) {
       const { value } = e.target;
@@ -157,14 +154,14 @@ export default {
       const { service } = this;
       if (['authorized'].includes(service.authState)) {
         // revoke
-        sendMessage({ cmd: 'SyncRevoke' });
+        sendCmd('SyncRevoke');
       } else if (['unauthorized', 'error'].includes(service.authState)) {
         // authorize
-        sendMessage({ cmd: 'SyncAuthorize' });
+        sendCmd('SyncAuthorize');
       }
     },
     onSync() {
-      sendMessage({ cmd: 'SyncStart' });
+      sendCmd('SyncStart');
     },
     getMessage() {
       const { service } = this;

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -31,9 +31,8 @@ Object.assign(handlers, {
   async SetPopup(data, src) {
     if (store.currentTab.id !== src.tab.id) return;
     const isTop = src.frameId === 0;
-    const ids = isTop
-      ? data.ids
-      : (await mutex.ready, data.ids.filter(id => !allScriptIds.includes(id)));
+    if (!isTop) await mutex.ready;
+    const ids = data.ids.filter(id => !allScriptIds.includes(id));
     allScriptIds.push(...ids);
     if (isTop) {
       mutex.resolve();

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { i18n, sendMessage } from '#/common';
+import { i18n, sendCmd } from '#/common';
 import { INJECTABLE_TAB_URL_RE } from '#/common/consts';
 import handlers from '#/common/handlers';
 import * as tld from '#/common/tld';
@@ -25,10 +25,7 @@ Object.assign(handlers, {
       map[id] = Object.keys(values).sort();
       return map;
     }, {});
-    sendMessage({
-      cmd: 'GetMetas',
-      data: data.ids,
-    })
+    sendCmd('GetMetas', data.ids)
     .then((scripts) => {
       store.scripts = scripts;
     });
@@ -36,7 +33,7 @@ Object.assign(handlers, {
 });
 
 browser.tabs.query({ currentWindow: true, active: true })
-.then((tabs) => {
+.then(async (tabs) => {
   const currentTab = {
     id: tabs[0].id,
     url: tabs[0].url,
@@ -51,9 +48,6 @@ browser.tabs.query({ currentWindow: true, active: true })
   if (!INJECTABLE_TAB_URL_RE.test(currentTab.url)) {
     store.injectable = false;
   } else {
-    sendMessage({ cmd: 'TestBlacklist', data: currentTab.url })
-    .then((blocked) => {
-      if (blocked) store.blacklisted = true;
-    });
+    store.blacklisted = await sendCmd('TestBlacklist', currentTab.url);
   }
 });

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -30,6 +30,12 @@ body {
   }
 }
 
+.page-popup {
+  /* hardcoded popup height in Chrome */
+  max-height: 600px;
+  overflow: hidden;
+}
+
 footer {
   height: 40px;
   line-height: 40px;
@@ -145,6 +151,9 @@ footer {
   }
   &-group {
     padding-left: $leftPaneWidth;
+    & [data-totals]::after {
+      content: ": " attr(data-totals);
+    }
   }
   &.expand {
     background: #fbfbfb;
@@ -221,5 +230,5 @@ footer {
 }
 
 .failure-reason {
-  padding: .75rem $itemPaddingX 0 $leftPaneWidth;
+  padding: .75rem $itemPaddingX .75rem $leftPaneWidth;
 }

--- a/src/popup/utils/index.js
+++ b/src/popup/utils/index.js
@@ -1,5 +1,6 @@
 export const store = {
   scripts: [],
+  frameScripts: [],
   commands: [],
   domain: '',
   injectable: true,

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -105,7 +105,7 @@
 <script>
 import Tooltip from 'vueleton/lib/tooltip/bundle';
 import options from '#/common/options';
-import { getLocaleString, i18n, sendMessage } from '#/common';
+import { getLocaleString, i18n, sendCmd } from '#/common';
 import Icon from '#/common/ui/icon';
 import { store } from '../utils';
 
@@ -203,12 +203,9 @@ export default {
     onToggleScript(item) {
       const { data } = item;
       const enabled = !data.config.enabled;
-      sendMessage({
-        cmd: 'UpdateScriptInfo',
-        data: {
-          id: data.props.id,
-          config: { enabled },
-        },
+      sendCmd('UpdateScriptInfo', {
+        id: data.props.id,
+        config: { enabled },
       })
       .then(() => {
         data.config.enabled = enabled;
@@ -221,12 +218,9 @@ export default {
     onCreateScript() {
       const { currentTab, domain } = this.store;
       (domain ? (
-        sendMessage({
-          cmd: 'CacheNewScript',
-          data: {
-            url: currentTab.url.split('#')[0].split('?')[0],
-            name: `- ${domain}`,
-          },
+        sendCmd('CacheNewScript', {
+          url: currentTab.url.split('#')[0].split('?')[0],
+          name: `- ${domain}`,
         })
       ) : Promise.resolve())
       .then((id) => {


### PR DESCRIPTION
Fixes #664.

Adds `sendCmd(cmd, data)` method, which I can split off into a separate PR (and also convert to async/await) if you wish. 

Test links (also try blacklisting the main page URL):
* https://jsfiddle.net/chrisvfritz/50wL7mdz/
* https://chrome.google.com/webstore/detail/ocfjjjjhkpapocigimmppepjgfdecjkb

BTW what do you think about enabling Stage-3 [nullish-coalescing-operator](https://babeljs.io/docs/en/babel-plugin-proposal-nullish-coalescing-operator) and then replacing most of `objectGet(obj, 'foo.bar', def)` with `obj.foo?.bar ?? def` ? The only caveat I see is that technically it's not the same behavior as objectGet, which checks `key in res`, so if VM stores `null` or `undefined` somewhere in its data objects, we'd better not use `??` at all in order to avoid possible confusion.