### PR TITLE
fix: wait for active getScriptsByURL and use its result

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -108,7 +108,7 @@ const commands = {
       version: VM_VER,
     };
     if (isApplied) {
-      const scripts = cache.get(`preinject:${url}`) || await getScriptsByURL(url);
+      const scripts = await (cache.get(`preinject:${url}`) || getScriptsByURL(url));
       addValueOpener(tabId, Object.keys(scripts.values));
       Object.assign(data, scripts);
     }
@@ -231,10 +231,13 @@ function togglePreinject(enable) {
   }
 }
 
-async function preinject({ url }) {
+function preinject({ url }) {
   const key = `preinject:${url}`;
   if (!cache.has(key)) {
-    cache.put(key, await getScriptsByURL(url), 250);
+    // GetInjected message will be sent soon by the content script
+    // and it may easily happen while getScriptsByURL is still waiting for browser.storage
+    // so we'll let GetInjected await this pending data by storing Promise in the cache
+    cache.put(key, getScriptsByURL(url), 250);
   }
 }
 


### PR DESCRIPTION
**TL;DR:**

Fixes the not-so-rare case when `GetInjected` message arrives while `getScriptsByURL` is still waiting for browser.storage. 

**More info:**

It usually happens when navigating a URL for which there is no data cached by `testScript` recently. With my 100 scripts (half enabled) it takes 40ms for getScriptsByURL to match all scripts. During this time `GetInjected` arrives and sees nothing in the preinject cache so it runs a second `getScriptsByURL`, which is faster of course since all the matching cache was primed by the first run, but still it's 5-10ms (plus another 5-10ms waiting for browser.storage), which is a non-negligible time span as we're trying to deliver the scripts to the web page tab ASAP.