### PR TITLE
feat: allow responseType 'document' in GM_xmlhttpRequest

### DIFF
--- a/src/background/utils/requests.js
+++ b/src/background/utils/requests.js
@@ -105,6 +105,7 @@ function xhrCallbackWrapper(req) {
       id: req.id,
       type: evt.type,
       resType: xhr.responseType,
+      contentType: xhr.getResponseHeader('Content-Type') || 'application/octet-stream',
     };
     const data = {
       finalUrl: xhr.responseURL,
@@ -127,16 +128,9 @@ function xhrCallbackWrapper(req) {
     if (evt.type === 'loadend') clearRequest(req);
     else if (xhr.readyState >= XMLHttpRequest.LOADING) HeaderInjector.del(req.id);
     lastPromise = lastPromise.then(() => {
-      if (xhr.response && xhr.responseType === 'arraybuffer') {
-        const contentType = xhr.getResponseHeader('Content-Type') || 'application/octet-stream';
-        const binstring = buffer2string(xhr.response);
-        data.response = `data:${contentType};base64,${window.btoa(binstring)}`;
-      } else {
-        // default `null` for blob and '' for text
-        data.response = xhr.response;
-      }
-    })
-    .then(() => {
+      data.response = xhr.response && xhr.responseType === 'arraybuffer'
+        ? buffer2string(xhr.response)
+        : xhr.response;
       if (req.cb) req.cb(res);
     });
   };

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -72,11 +72,11 @@ export function getUniqId(prefix) {
 export function buffer2string(buffer) {
   const array = new window.Uint8Array(buffer);
   const sliceSize = 8192;
-  let str = '';
+  const slices = [];
   for (let i = 0; i < array.length; i += sliceSize) {
-    str += String.fromCharCode.apply(null, array.subarray(i, i + sliceSize));
+    slices.push(String.fromCharCode.apply(null, array.subarray(i, i + sliceSize)));
   }
-  return str;
+  return slices.join('');
 }
 
 export function compareVersion(ver1, ver2) {


### PR DESCRIPTION
It's convenient, the vanilla XHR has it, Tampermonkey has it, the implementation is simple.

Collateral changes:
* simplified arraybuffer/blob response handling
* no progressive string concatenation in buffer2string
* on-demand decoding of GM_xmlhttpRequest 'response'