### PR TITLE
Sort & filtering in popup

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -331,6 +331,9 @@ labelNoSearchScripts:
 labelNotifyUpdates:
   description: Option to show notification when script is updated.
   message: Notify script updates
+labelPopupSort:
+  description: Label in the VM settings tab for script list sort order in popup
+  message: Sort scripts in popup by
 labelRelated:
   description: Label of related links.
   message: 'Related links: '
@@ -542,6 +545,12 @@ msgUpdating:
 noValues:
   description: Label shown when there is no value for current script.
   message: No value is stored
+optionPopupEnabledFirst:
+  description: Option to show enabled scripts first in popup.
+  message: Enabled first
+optionPopupHideDisabled:
+  description: Option to hide disabled scripts in popup.
+  message: Hide disabled
 optionShowEnabledFirst:
   description: Option to show enabled scripts first in alphabetical order.
   message: Show enabled scripts first

--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -20,7 +20,14 @@ export default {
   version: null,
   defaultInjectInto: 'page', // 'page' | 'auto',
   filters: {
+    /** @type 'exec' | 'alpha' | 'update' */
     sort: 'exec',
+  },
+  filtersPopup: {
+    /** @type 'exec' | 'alpha' */
+    sort: 'exec',
+    enabledFirst: false,
+    hideDisabled: false,
   },
   editor: {
     lineWrapping: false,

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -41,6 +41,21 @@
         </label>
         <a class="ml-1" href="https://violentmonkey.github.io/2018/11/23/inject-into-context/" target="_blank" rel="noopener noreferrer" v-text="i18n('learnInjectionMode')"></a>
       </div>
+      <div class="mb-1 multi-opt-row">
+        <label>
+          <span v-text="i18n('labelPopupSort')"></span>
+          <select v-model="popupSort">
+            <option value="exec" v-text="i18n('filterExecutionOrder')" />
+            <option value="alpha" v-text="i18n('filterAlphabeticalOrder')" />
+          </select>
+        </label>
+        <label>
+          <setting-check name="filtersPopup.enabledFirst" />{{i18n('optionPopupEnabledFirst')}}
+        </label>
+        <label>
+          <setting-check name="filtersPopup.hideDisabled" />{{i18n('optionPopupHideDisabled')}}
+        </label>
+      </div>
     </section>
     <vm-import></vm-import>
     <vm-export></vm-export>
@@ -87,6 +102,11 @@ const items = [
     normalize(value) {
       return value === 'auto' ? 'auto' : 'page';
     },
+  },
+  {
+    key: 'filtersPopup.sort',
+    name: 'popupSort',
+    normalize: value => value === 'exec' && value || 'alpha',
   },
 ];
 const settings = {
@@ -140,6 +160,13 @@ export default {
 <style>
 .tab-settings {
   overflow-y: auto;
+  .multi-opt-row {
+    display: flex;
+    align-items: center;
+    label {
+      margin-right: 1em;
+    }
+  }
   textarea {
     height: 10em;
   }

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -160,9 +160,19 @@ export default {
 <style>
 .tab-settings {
   overflow-y: auto;
+  label {
+    display: inline-flex;
+    @media (min-width: 600px) {
+      align-items: center;
+    }
+    select {
+      margin-left: .5em;
+    }
+  }
   .multi-opt-row {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     label {
       margin-right: 1em;
     }


### PR DESCRIPTION
Since I've never needed to care about the execution order in all the years I've been using userscripts I have a reason to believe the same applies to most users, at least to a lot of them, so this PR adds several options to display the scripts in the popup in a more human-friendly way, mostly useful when there are many scripts installed.

* alphabetical order (default: execution)
* enabled scripts first (default: false)
* disabled scripts hidden (default: false)

The default state preserves the historical behavior.

![image](https://user-images.githubusercontent.com/1310400/68074823-eb951c00-fdb0-11e9-90f5-686bb0c7f1e2.png)

**Collateral change:**

* Removed the implicit space between the checkbox and its text in settings + aligned them vertically against each other.