### PR TITLE
fix: GM_setClipboard in FF

### DIFF
--- a/src/injected/content/clipboard.js
+++ b/src/injected/content/clipboard.js
@@ -3,10 +3,12 @@ import { sendCmd } from '../utils';
 import { addEventListener, logging } from '../utils/helpers';
 import bridge from './bridge';
 
-const { execCommand } = Document.prototype;
+// old Firefox defines it on a different prototype so we'll just grab it from document directly
+const { execCommand } = document;
 const { setData } = DataTransfer.prototype;
 const getClipboardData = Object.getOwnPropertyDescriptor(ClipboardEvent.prototype, 'clipboardData').get;
-const { preventDefault, removeEventListener, stopImmediatePropagation } = EventTarget.prototype;
+const { preventDefault, stopImmediatePropagation } = Event.prototype;
+const { removeEventListener } = EventTarget.prototype;
 
 let clipboardData;
 
@@ -27,7 +29,7 @@ function onCopy(e) {
   e::stopImmediatePropagation();
   e::preventDefault();
   const { type, data } = clipboardData;
-  e::getClipboardData::setData(type || 'text/plain', data);
+  e::getClipboardData()::setData(type || 'text/plain', data);
 }
 
 function setClipboard({ type, data }) {


### PR DESCRIPTION
Fixes #685.

In addition to a bug in my implementation (preventDefault and stopImmediatePropagation should be picked from Event.prototype) there's apparently a bug/quirk in Firefox which prevents the entire setClipboard+onCopy hack from working when ::safe calls are used. ~I guess Firefox somehow changes the initial methods or it uses a Proxy internally on `document` specifically. It's a mystery for me because in other parts of the content script the similar safe calls work correctly with `window::addEventListener` and `document::getReadyState`.~ 

Turns out there was another bug in my code + old versions of FF define execCommand in document.__proto__ not in Document.prototype...