### PR TITLE
Editor tweaks

### DIFF
--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -33,6 +33,7 @@ export default {
     lineWrapping: false,
     indentWithTabs: false,
     indentUnit: 2,
+    tabSize: 2,
     undoDepth: 200,
   },
   scriptTemplate: `\

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -342,6 +342,17 @@ export default {
         }
       }, this.cm);
     },
+    findFillQuery(force) {
+      const { state } = this.search;
+      const { cm } = this;
+      if (!state.query || force) {
+        const sel = cm.listSelections();
+        // use the currently selected text if it's within one line
+        if (sel?.length === 1 && sel[0].anchor.line === sel[0].head.line) {
+          state.query = cm.getSelection();
+        }
+      }
+    },
     doSearch(reversed) {
       const { state } = this.search;
       const { cm } = this;
@@ -354,6 +365,7 @@ export default {
       this.doSearch();
     },
     find() {
+      this.findFillQuery(true);
       this.searchInPlace();
       this.$nextTick(() => {
         const { search } = this.$refs;
@@ -362,6 +374,7 @@ export default {
       });
     },
     findNext(reversed) {
+      this.findFillQuery();
       this.doSearch(reversed);
       this.$nextTick(() => {
         this.$refs.search.focus();


### PR DESCRIPTION
* fix: reuse indent type/size for Tab key without selection in the middle of a line
* feat: autofill search query with selected text like normal editors/IDE do
  * main find key - always fills
  * next/prev key - only if query is empty