### PR TITLE
display errors in content script mode

### DIFF
--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -174,7 +174,6 @@ export function createGmApiProps() {
       };
       return el;
     },
-    GM_log: logging.log,
     GM_openInTab(url, options) {
       const data = options && typeof options === 'object' ? options : {
         active: !options,
@@ -207,6 +206,8 @@ export function createGmApiProps() {
       target[k] = propertyFromValue(target[k]);
     });
   });
+  // not using propertyFromValue to keep native toString on the real console.log
+  props.GM_log = { value: logging.log };
   return {
     props,
     boundProps,

--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -227,13 +227,8 @@ export function createGmApiProps() {
 }
 
 export function propertyFromValue(value) {
-  const prop = {
-    writable: false,
-    configurable: false,
-    value,
-  };
   if (typeof value === 'function') value.toString = propertyToString;
-  return prop;
+  return { value };
 }
 
 function propertyToString() {

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -20,6 +20,7 @@ export default function initialize(
 ) {
   let invokeGuest;
   bridge.props = props;
+  bridge.isFirefox = isFirefox;
   if (invokeHost) {
     bridge.mode = INJECT_CONTENT;
     bridge.post = msg => invokeHost(msg, INJECT_CONTENT);


### PR DESCRIPTION
* Fixes #692: shows uncaught errors for `@inject-into content` mode
* Restores script name in GM_log (shown as the source at the right side of devtools console) lost in 8f43c1e65a2809f6c8a5a681ed2d91eb247a12f7