### PR TITLE
fix: really hide chrome.* and browser.* from userjs in content mode

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,23 @@ module.exports = {
   rules: {
     'prefer-object-spread': 'off',
   },
-  globals: {
-    browser: true,
-  },
+  overrides: [{
+    // `browser` is a local variable since we remove the global `chrome` and `browser` in injected*
+    // to prevent exposing them to userscripts with `@inject-into content`
+    files: ['*'],
+    excludedFiles: [
+      'src/injected/**/*.js',
+      'src/injected/*.js',
+      'src/common/*.js',
+    ],
+    globals: {
+      browser: true,
+    },
+  }, {
+    // no restrictions in browser.js to check the global `browser`
+    files: ['browser.js'],
+    globals: {
+      browser: true,
+    },
+  }],
 };

--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -1,6 +1,6 @@
 import '#/common/polyfills';
 
-/* global chrome */
+const { chrome } = global;
 
 function wrapAsync(func, thisObj) {
   return (...args) => {

--- a/src/common/consts.js
+++ b/src/common/consts.js
@@ -12,3 +12,7 @@ export const CMD_SCRIPT_UPDATE = 'UpdateScript';
 export const METABLOCK_RE = /(?:^|\n)\s*\/\/\x20==UserScript==([\s\S]*?\n)\s*\/\/\x20==\/UserScript==|$/;
 
 export const INJECTABLE_TAB_URL_RE = /^(https?|file|ftps?):/;
+
+// `browser` is a local variable since we remove the global `chrome` and `browser` in injected*
+// to prevent exposing them to userscripts with `@inject-into content`
+export const { browser } = global;

--- a/src/common/handlers.js
+++ b/src/common/handlers.js
@@ -1,3 +1,4 @@
+import { browser } from '#/common/consts';
 import options from './options';
 
 const handlers = {

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -1,3 +1,4 @@
+import { browser } from '#/common/consts';
 import { noop } from './util';
 
 export * from './util';

--- a/src/injected/content/bridge.js
+++ b/src/injected/content/bridge.js
@@ -1,5 +1,5 @@
 import { sendMessage } from '#/common';
-import { INJECT_PAGE } from '#/common/consts';
+import { INJECT_PAGE, browser } from '#/common/consts';
 import { assign } from '../utils/helpers';
 
 /** @type {Object.<string, MessageFromGuestHandler>} */

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -1,6 +1,9 @@
 import { isFirefox } from '#/common/ua';
 import { getUniqId, sendCmd } from '#/common';
-import { INJECT_PAGE, INJECT_CONTENT, INJECT_AUTO } from '#/common/consts';
+import {
+  INJECT_PAGE, INJECT_CONTENT, INJECT_AUTO,
+  browser,
+} from '#/common/consts';
 import { attachFunction } from '../utils';
 import bridge from './bridge';
 import {

--- a/src/injected/web/gm-wrapper.js
+++ b/src/injected/web/gm-wrapper.js
@@ -184,8 +184,6 @@ function getWrapper() {
   // http://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects
   // http://developer.mozilla.org/docs/Web/API/Window
   const wrapper = {
-    // Block special objects
-    browser: undefined,
     // `eval` should be called directly so that it is run in current scope
     eval: wrapperInfo.eval[bridge.mode],
     ...info.methods,

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -25,6 +25,8 @@ export default function initialize(
     bridge.mode = INJECT_CONTENT;
     bridge.post = msg => invokeHost(msg, INJECT_CONTENT);
     invokeGuest = bridge.onHandle;
+    global.chrome = undefined;
+    global.browser = undefined;
   } else {
     bridge.mode = INJECT_PAGE;
     bridge.post = bindEvents(webId, contentId, bridge.onHandle);


### PR DESCRIPTION
Currently userscripts injected in content mode can freely use `unsafeWindow.browser` and `chrome` or `unsafeWindow.chrome` to abuse the internal messaging/storage of Violentmonkey. This PR makes it impossible by saving the originals into local variables and setting the originals to `undefined`.