### PR TITLE
feat: open tabs from popup using tabOpen()

### DIFF
--- a/src/background/sync/base.js
+++ b/src/background/sync/base.js
@@ -1,5 +1,5 @@
 import {
-  debounce, normalizeKeys, request, noop,
+  debounce, normalizeKeys, request, noop, makePause,
 } from '#/common';
 import {
   objectGet, objectSet, objectPick, objectPurify,
@@ -322,14 +322,7 @@ export const BaseService = serviceFactory({
     let lastFetch = Promise.resolve();
     if (delay) {
       lastFetch = this.lastFetch
-      .then(ts => new Promise((resolve) => {
-        const delta = delay - (Date.now() - ts);
-        if (delta > 0) {
-          setTimeout(resolve, delta);
-        } else {
-          resolve();
-        }
-      }))
+      .then(ts => makePause(delay - (Date.now() - ts)))
       .then(() => Date.now());
       this.lastFetch = lastFetch;
     }

--- a/src/background/utils/commands.js
+++ b/src/background/utils/commands.js
@@ -1,3 +1,4 @@
+import { getActiveTab } from '#/common';
 import { tabOpen } from './tabs';
 
 const ROUTES = {
@@ -7,7 +8,7 @@ const ROUTES = {
 
 global.addEventListener('backgroundInitialized', () => {
   browser.commands.onCommand.addListener(async (cmd) => {
-    const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+    const tab = await getActiveTab();
     const optionsUrl = browser.runtime.getURL(browser.runtime.getManifest().options_ui.page);
     const url = `${optionsUrl}${ROUTES[cmd] || ''}`;
     tabOpen({ url, insert: true }, { tab });

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -58,7 +58,6 @@ export function sendMessage(payload, { retry } = {}) {
  * or when configured to restore the session, https://crbug.com/314686
  */
 export async function sendMessageRetry(payload, retries = 10) {
-  const makePause = ms => new Promise(resolve => setTimeout(resolve, ms));
   let pauseDuration = 10;
   for (; retries > 0; retries -= 1) {
     const data = await sendMessage(payload).catch(noop);
@@ -194,4 +193,18 @@ export function encodeFilename(name) {
 
 export function decodeFilename(filename) {
   return filename.replace(/-([0-9a-f]{2})/g, (_m, g) => String.fromCharCode(parseInt(g, 16)));
+}
+
+export async function getActiveTab() {
+  const [tab] = await browser.tabs.query({
+    active: true,
+    currentWindow: true,
+  });
+  return tab;
+}
+
+export function makePause(ms) {
+  return ms < 0
+    ? Promise.resolve()
+    : new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/src/confirm/views/app.vue
+++ b/src/confirm/views/app.vue
@@ -37,7 +37,7 @@
 <script>
 import Dropdown from 'vueleton/lib/dropdown/bundle';
 import {
-  sendCmd, leftpad, request, buffer2string, isRemote, getFullUrl,
+  sendCmd, leftpad, request, buffer2string, isRemote, getFullUrl, makePause,
 } from '#/common';
 import options from '#/common/options';
 import initCache from '#/common/cache';
@@ -206,9 +206,7 @@ export default {
       });
     },
     trackLocalFile() {
-      new Promise((resolve) => {
-        setTimeout(resolve, 2000);
-      })
+      makePause(2000)
       .then(() => this.loadData(true))
       .then(this.parseMeta)
       .then(() => {

--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -1,4 +1,4 @@
-import { getUniqId } from '#/common';
+import { getUniqId, makePause } from '#/common';
 import { INJECT_PAGE, INJECT_CONTENT } from '#/common/consts';
 import { bindEvents, sendCmd, sendMessage } from '../utils';
 import {
@@ -104,6 +104,6 @@ function getPopup() {
 
 async function setBadge() {
   // delay setBadge in frames so that they can be added to the initial count
-  if (!IS_TOP) await new Promise(resolve => setTimeout(resolve, 300));
+  if (!IS_TOP) await makePause(300);
   sendCmd('SetBadge', bridge.enabledIds);
 }

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -104,7 +104,7 @@
 import Dropdown from 'vueleton/lib/dropdown/bundle';
 import Tooltip from 'vueleton/lib/tooltip/bundle';
 import {
-  i18n, sendCmd, debounce,
+  i18n, sendCmd, debounce, makePause,
 } from '#/common';
 import options from '#/common/options';
 import SettingCheck from '#/common/ui/setting-check';
@@ -375,7 +375,7 @@ export default {
         if (!step && performance.now() - startTime >= MAX_BATCH_DURATION) {
           step = limit;
         }
-        if (step) await new Promise(resolve => setTimeout(resolve));
+        if (step) await makePause();
       }
     },
   },

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -216,21 +216,22 @@ export default {
       window.close();
     },
     onVisitWebsite() {
-      browser.tabs.create({
+      sendCmd('TabOpen', {
         url: 'https://violentmonkey.github.io/',
       });
       window.close();
     },
     onEditScript(item) {
-      browser.tabs.create({
-        url: browser.runtime.getURL(`/options/index.html#scripts/${item.data.props.id}`),
+      sendCmd('TabOpen', {
+        url: `/options/index.html#scripts/${item.data.props.id}`,
       });
       window.close();
     },
     onFindSameDomainScripts() {
-      browser.tabs.create({
+      sendCmd('TabOpen', {
         url: `https://greasyfork.org/scripts/by-site/${encodeURIComponent(this.store.domain)}`,
       });
+      window.close();
     },
     onCommand(id, cap) {
       browser.tabs.sendMessage(this.store.currentTab.id, {
@@ -253,21 +254,16 @@ export default {
     checkReload() {
       if (options.get('autoReload')) browser.tabs.reload(this.store.currentTab.id);
     },
-    onCreateScript() {
+    async onCreateScript() {
       const { currentTab, domain } = this.store;
-      (domain ? (
-        sendCmd('CacheNewScript', {
-          url: currentTab.url.split('#')[0].split('?')[0],
-          name: `- ${domain}`,
-        })
-      ) : Promise.resolve())
-      .then((id) => {
-        const path = ['scripts', '_new', id].filter(Boolean).join('/');
-        browser.tabs.create({
-          url: browser.runtime.getURL(`/options/index.html#${path}`),
-        });
-        window.close();
+      const id = domain && await sendCmd('CacheNewScript', {
+        url: currentTab.url.split(/[#?]/)[0],
+        name: `- ${domain}`,
       });
+      sendCmd('TabOpen', {
+        url: `/options/index.html#scripts/_new${id ? `/${id}` : ''}`,
+      });
+      window.close();
     },
   },
 };


### PR DESCRIPTION
Tabs opened from popup will use `tabOpen()` so they are opened next to the source and have openerTabId (on closing of such a tab the source tab will be focused).

Collateral refactor: deduplicate getActiveTab() and makePause()