### PR TITLE
ui: reduce header in the editor

### DIFF
--- a/src/_locales/cs/messages.yml
+++ b/src/_locales/cs/messages.yml
@@ -574,6 +574,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: ''
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: ''

--- a/src/_locales/de/messages.yml
+++ b/src/_locales/de/messages.yml
@@ -576,6 +576,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: ''
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: ''

--- a/src/_locales/el/messages.yml
+++ b/src/_locales/el/messages.yml
@@ -582,6 +582,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: ''
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: ''

--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -126,6 +126,9 @@ descEditorOptions:
     them may not work in Violentmonkey. See <a
     href="https://codemirror.net/doc/manual.html#config" target="_blank"
     rel="noopener noreferrer">full list</a>.
+editHowToHint:
+  description: The text of the how-to link in the editor header.
+  message: Use another editor?
 editLabelMeta:
   description: Metadata section in settings tab of script editor.
   message: Custom metadata

--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -581,8 +581,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: Visit Website
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: >-
-    Some lines are too long, opening in read-only mode. Please edit with an
-    external editor.

--- a/src/_locales/es/messages.yml
+++ b/src/_locales/es/messages.yml
@@ -589,8 +589,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: Visitar sitio web
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: >-
-    Algunas líneas son demasiado largas y se abren en modo de sólo lectura. Por
-    favor, edite con un editor externo.

--- a/src/_locales/fi/messages.yml
+++ b/src/_locales/fi/messages.yml
@@ -576,8 +576,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: ''
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: >-
-    Osa riveistä on liian pitkiä, avataan vain-luku-tilassa. Ole hyvä ja muokkaa
-    ulkoisella editorilla.

--- a/src/_locales/fr/messages.yml
+++ b/src/_locales/fr/messages.yml
@@ -581,8 +581,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: ''
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: >-
-    Certaines lignes sont trop longues, ouverture en lecture seule. Veuillez
-    l’ouvrir avec un éditeur externe.

--- a/src/_locales/hr/messages.yml
+++ b/src/_locales/hr/messages.yml
@@ -574,6 +574,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: ''
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: ''

--- a/src/_locales/id/messages.yml
+++ b/src/_locales/id/messages.yml
@@ -576,6 +576,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: ''
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: ''

--- a/src/_locales/it/messages.yml
+++ b/src/_locales/it/messages.yml
@@ -576,8 +576,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: ''
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: >-
-    Alcune linee dello script sono troppo lunghe e non possono essere editate.
-    Apri lo script con un editor esterno.

--- a/src/_locales/ja/messages.yml
+++ b/src/_locales/ja/messages.yml
@@ -577,6 +577,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: ウェブサイトを開く
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: 一部の行が長すぎるため、読み取り専用モードで開きます。 外部エディタで編集してください。

--- a/src/_locales/ko/messages.yml
+++ b/src/_locales/ko/messages.yml
@@ -572,6 +572,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: ''
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: ''

--- a/src/_locales/pl/messages.yml
+++ b/src/_locales/pl/messages.yml
@@ -579,8 +579,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: Odwiedź stronę internetową rozszerzenia
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: >-
-    Niektóre linie są zbyt długie, otwieranie w trybie tylko do odczytu. Proszę
-    edytować za pomocą zewnętrznego edytora.

--- a/src/_locales/pt_BR/messages.yml
+++ b/src/_locales/pt_BR/messages.yml
@@ -578,6 +578,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: ''
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: ''

--- a/src/_locales/pt_PT/messages.yml
+++ b/src/_locales/pt_PT/messages.yml
@@ -584,8 +584,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: Visitar website
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: >-
-    Algumas linhas são demasiado compridas; a abrir em modo só de leitura. Por
-    favor, edite com um editor externo.

--- a/src/_locales/ro/messages.yml
+++ b/src/_locales/ro/messages.yml
@@ -4,7 +4,7 @@ anchorAuthor:
 anchorTranslator:
   description: Translator shown on about tab.
   message: >-
-    <a href="http://www.forumit.ro/">Nicolae Crefelean</a>, <a 
+    <a href="http://www.forumit.ro/">Nicolae Crefelean</a>, <a
     href=mailto:cristian.silaghi@mozilla.ro>Cristian Silaghi</a>
 buttonAllNone:
   description: Button to select all scripts or none.
@@ -124,9 +124,9 @@ descCustomCSS:
 descEditorOptions:
   description: Description of editor options JSON section.
   message: >-
-    Opțiuni personalizate pentru CodeMirror și suplimente în obiecte JSON 
-    {"indentUnit":2, "smartIndent":true} Cu toate acestea, reține că unele 
-    dintre ele pot să nu funcționeze în Violentmonkey. Lista completă: 
+    Opțiuni personalizate pentru CodeMirror și suplimente în obiecte JSON
+    {"indentUnit":2, "smartIndent":true} Cu toate acestea, reține că unele
+    dintre ele pot să nu funcționeze în Violentmonkey. Lista completă:
     https://codemirror.net/doc/manual.html#config
 editLabelMeta:
   description: Metadata section in settings tab of script editor.
@@ -587,8 +587,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: Vizitează site-ul web
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: >-
-    Unele rânduri sunt prea lungi, se deschide în modul numai citire. Te rugăm
-    să editezi cu un editor extern.

--- a/src/_locales/ru/messages.yml
+++ b/src/_locales/ru/messages.yml
@@ -581,8 +581,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: Посетить сайт
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: >-
-    Некоторые строки слишком длинные и открыты только для чтения. Пожалуйста
-    откройте его с помощью внешнего редактора.

--- a/src/_locales/sk/messages.yml
+++ b/src/_locales/sk/messages.yml
@@ -583,8 +583,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: Prejsť na stránku
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: >-
-    Niektoré riadky sú príliš dlhé, otváram v režime iba na čítanie. Prosím,
-    upravte s externým editorom.

--- a/src/_locales/sr/messages.yml
+++ b/src/_locales/sr/messages.yml
@@ -574,6 +574,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: ''
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: ''

--- a/src/_locales/tr/messages.yml
+++ b/src/_locales/tr/messages.yml
@@ -578,6 +578,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: ''
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: ''

--- a/src/_locales/uk/messages.yml
+++ b/src/_locales/uk/messages.yml
@@ -578,6 +578,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: ''
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: ''

--- a/src/_locales/vi/messages.yml
+++ b/src/_locales/vi/messages.yml
@@ -574,8 +574,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: Truy cập trang web
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: >-
-    Một số dòng quá dài, đang mở ở chế độ chỉ đọc. Vui lòng mở bằng trình chỉnh
-    sửa bên ngoài.

--- a/src/_locales/zh_CN/messages.yml
+++ b/src/_locales/zh_CN/messages.yml
@@ -578,6 +578,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: 访问网站
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: 某些行超长，以只读模式打开。请使用外部编辑器编辑。

--- a/src/_locales/zh_TW/messages.yml
+++ b/src/_locales/zh_TW/messages.yml
@@ -572,6 +572,3 @@ valueLabelValue:
 visitWebsite:
   description: Label for link to open Violentmonkey website.
   message: ''
-warnScriptLongLines:
-  description: Warning message shown when script has lines that are too long to be edited.
-  message: ''

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -40,18 +40,11 @@
         :class="{active: nav === 'keyboard'}"
         @click="nav = 'keyboard'"
       >?</div>
-      <div class="flex-auto pos-rel">
-        <div
-          v-if="tooLarge"
-          class="edit-warn text-red hidden-sm"
-          v-text="i18n('warnScriptLongLines')"
-        />
-      </div>
     </div>
     <div class="frame-block flex-auto pos-rel">
       <vm-code
         v-show="nav === 'code'" class="abs-full" ref="code" :editing="nav === 'code'"
-        v-model="code" :commands="commands" @warnLarge="onWarnLarge"
+        v-model="code" :commands="commands"
       />
       <vm-settings
         v-show="nav === 'settings'" class="abs-full edit-body"
@@ -100,7 +93,6 @@ export default {
       nav: 'code',
       canSave: false,
       script: null,
-      tooLarge: false,
       code: '',
       settings: {},
       commands: {
@@ -248,9 +240,6 @@ export default {
     saveClose() {
       this.save().then(this.close);
     },
-    onWarnLarge(tooLarge) {
-      this.tooLarge = tooLarge;
-    },
   },
   beforeDestroy() {
     store.title = null;
@@ -280,14 +269,6 @@ export default {
       box-shadow: 0 -1px 1px #bbb;
     }
   }
-}
-
-.edit-warn {
-  position: absolute;
-  left: 0;
-  right: .5rem;
-  bottom: .5rem;
-  text-align: right;
 }
 
 @media (max-width: 767px) {

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -1,45 +1,43 @@
 <template>
   <div class="edit frame flex flex-col fixed-full">
-    <div class="flex flex-wrap edit-header mx-1 my-1">
-      <div class="edit-info text-right ellipsis">
-        <strong v-text="i18n('labelEditing')"></strong>
-        <em v-text="scriptName"></em>
+    <div class="edit-header flex">
+      <nav>
+        <div
+          class="edit-nav-item"
+          :class="{active: nav === 'code'}"
+          v-text="i18n('editNavCode')"
+          @click="nav = 'code'"
+        />
+        <div
+          class="edit-nav-item"
+          :class="{active: nav === 'settings'}"
+          v-text="i18n('editNavSettings')"
+          @click="nav = 'settings'"
+        />
+        <div
+          class="edit-nav-item"
+          :class="{active: nav === 'values'}"
+          v-text="i18n('editNavValues')"
+          @click="nav = 'values'"
+        />
+        <div
+          class="edit-nav-item"
+          :class="{active: nav === 'keyboard'}"
+          @click="nav = 'keyboard'"
+        >?</div>
+      </nav>
+      <div class="edit-name text-center ellipsis flex-1 mr-1" v-text="scriptName"/>
+      <div class="edit-hint text-right ellipsis mr-1">
+        <a href="https://violentmonkey.github.io/2017/03/14/How-to-edit-scripts-with-your-favorite-editor/"
+           target="_blank"
+           rel="noopener noreferrer"
+           v-text="i18n('editHowToHint')"/>
       </div>
-      <div class="flex-auto flex">
-        <div class="edit-hint flex-auto text-right ellipsis mr-1">
-          <a href="https://violentmonkey.github.io/2017/03/14/How-to-edit-scripts-with-your-favorite-editor/" target="_blank" rel="noopener noreferrer">How to edit with your favorite editor?</a>
-        </div>
-        <div class="edit-buttons">
-          <button v-text="i18n('buttonSave')" @click="save" :disabled="!canSave"></button>
-          <button v-text="i18n('buttonSaveClose')" @click="saveClose" :disabled="!canSave"></button>
-          <button v-text="i18n('buttonClose')" @click="close"></button>
-        </div>
+      <div class="edit-buttons mr-1">
+        <button v-text="i18n('buttonSave')" @click="save" :disabled="!canSave"/>
+        <button v-text="i18n('buttonSaveClose')" @click="saveClose" :disabled="!canSave"/>
+        <button v-text="i18n('buttonClose')" @click="close"/>
       </div>
-    </div>
-    <div class="flex mx-1">
-      <div
-        class="edit-nav-item"
-        :class="{active: nav === 'code'}"
-        v-text="i18n('editNavCode')"
-        @click="nav = 'code'"
-      />
-      <div
-        class="edit-nav-item"
-        :class="{active: nav === 'settings'}"
-        v-text="i18n('editNavSettings')"
-        @click="nav = 'settings'"
-      />
-      <div
-        class="edit-nav-item"
-        :class="{active: nav === 'values'}"
-        v-text="i18n('editNavValues')"
-        @click="nav = 'values'"
-      />
-      <div
-        class="edit-nav-item"
-        :class="{active: nav === 'keyboard'}"
-        @click="nav = 'keyboard'"
-      >?</div>
     </div>
     <div class="frame-block flex-auto pos-rel">
       <vm-code
@@ -250,6 +248,13 @@ export default {
 <style>
 .edit {
   z-index: 2000;
+  &-header {
+    align-items: center;
+    justify-content: space-between;
+  }
+  &-name {
+    font-weight: bold;
+  }
   &-body {
     padding: .5rem 1rem;
     overflow: auto;
@@ -272,9 +277,13 @@ export default {
 }
 
 @media (max-width: 767px) {
-  .edit-header > h2,
-  .edit-hint,
-  .edit-info {
+  .edit-hint {
+    display: none;
+  }
+}
+
+@media (max-width: 500px) {
+  .edit-name {
     display: none;
   }
 }


### PR DESCRIPTION
* show controls, name, and nav in the same row
* shorten the how-to hint and make it translatable
* chore: remove the unused warnScriptLongLines/tooLarge code

Fixes #526.

Narrow width example:
![1](https://user-images.githubusercontent.com/1310400/69036590-448ec200-09f7-11ea-9776-2fb384ae396a.png)
