### PR TITLE
fix: remove `wrap` mode in Firefox

### DIFF
--- a/src/common/consts.js
+++ b/src/common/consts.js
@@ -4,13 +4,12 @@ export const INJECT_CONTENT = 'content';
 
 export const INJECT_INTERNAL_PAGE = 'page';
 export const INJECT_INTERNAL_CONTENT = 'content';
-export const INJECT_INTERNAL_WRAP = 'wrap';
 
 export const INJECT_MAPPING = {
   // `auto` tries to provide `window` from the real page as `unsafeWindow`
-  [INJECT_AUTO]: [INJECT_INTERNAL_PAGE, INJECT_INTERNAL_WRAP, INJECT_INTERNAL_CONTENT],
-  // inject into page context, if failed, try `wrap` mode for Firefox
-  [INJECT_PAGE]: [INJECT_INTERNAL_PAGE, INJECT_INTERNAL_WRAP],
+  [INJECT_AUTO]: [INJECT_INTERNAL_PAGE, INJECT_INTERNAL_CONTENT],
+  // inject into page context
+  [INJECT_PAGE]: [INJECT_INTERNAL_PAGE],
   // inject into content context only
   [INJECT_CONTENT]: [INJECT_INTERNAL_CONTENT],
 };

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -3,7 +3,6 @@ import {
   INJECT_CONTENT,
   INJECT_INTERNAL_CONTENT,
   INJECT_INTERNAL_PAGE,
-  INJECT_INTERNAL_WRAP,
   INJECT_MAPPING,
   INJECT_PAGE,
   browser,
@@ -36,9 +35,6 @@ export function triageScripts(data) {
     [INJECT_INTERNAL_PAGE]: [],
     [INJECT_INTERNAL_CONTENT]: [],
   };
-  // `INJECT_INTERNAL_WRAP` is a special case of `INJECT_INTERNAL_CONTENT`
-  // so we will just reuse the list to keep the execution orders
-  scriptLists[INJECT_INTERNAL_WRAP] = scriptLists[INJECT_INTERNAL_CONTENT];
   if (data.scripts) {
     data.scripts = data.scripts.filter(({ meta, props, config }) => {
       if (!meta.noframes || window.top === window) {
@@ -56,7 +52,6 @@ export function triageScripts(data) {
         if (!support) support = { injectable: checkInjectable() };
         return support.injectable;
       },
-      [INJECT_INTERNAL_WRAP]: () => isFirefox,
       [INJECT_INTERNAL_CONTENT]: () => true,
     };
     data.scripts.forEach((script) => {

--- a/src/injected/web/gm-wrapper.js
+++ b/src/injected/web/gm-wrapper.js
@@ -1,5 +1,5 @@
 import {
-  INJECT_INTERNAL_PAGE, INJECT_INTERNAL_CONTENT, INJECT_INTERNAL_WRAP, METABLOCK_RE,
+  INJECT_INTERNAL_PAGE, INJECT_INTERNAL_CONTENT, METABLOCK_RE,
 } from '#/common/consts';
 import bridge from './bridge';
 import {
@@ -25,9 +25,6 @@ let wrapperInfo = {
     // run script in content context
     // `unsafeWindow === contentGlobal, contentGlobal.window === contentWindow`
     [INJECT_INTERNAL_CONTENT]: global,
-    // run script in content context, but access pageWindow with the Firefox specific `wrappedJSObject`
-    // `unsafeWindow === wrappedJSObject === pageWindow`
-    [INJECT_INTERNAL_WRAP]: global.wrappedJSObject || global,
   },
 };
 


### PR DESCRIPTION
In `wrap` mode, `unsafeWindow` is set to `wrappedJSObject`.
Consequently, we get "Permission denied to access object" error
when trying to access objects in `wrappedJSObject` from `content` script.

This is by design in Firefox and seems unable to be fixed by us, so we
remove `wrap` mode here.

close #733