### PR TITLE
feat: send gmxhr cookies explicitly (needed in FF)

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -170,7 +170,7 @@ const commands = {
   },
   GetRequestId: getRequestId,
   HttpRequest(details, src) {
-    httpRequest(details, (res) => {
+    httpRequest(details, src, (res) => {
       browser.tabs.sendMessage(src.tab.id, {
         cmd: 'HttpRequested',
         data: res,

--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -41,6 +41,7 @@ function wrapAPIs(source, meta) {
 const meta = {
   browserAction: true,
   commands: true,
+  cookies: true,
   extension: true,
   i18n: true,
   notifications: {

--- a/src/injected/web/requests.js
+++ b/src/injected/web/requests.js
@@ -1,3 +1,4 @@
+import { objectPick } from '#/common/object';
 import {
   includes, join, map, push, jsonDump, jsonLoad, objectToString, Promise, Blob, Uint8Array,
   setAttribute, log, charCodeAt, fromCharCode, shift, slice, defineProperty,
@@ -92,14 +93,17 @@ async function start(req, id) {
   const payload = {
     id,
     scriptId,
-    anonymous: details.anonymous,
-    method: details.method,
-    url: details.url,
-    user: details.user,
-    password: details.password,
-    headers: details.headers,
-    timeout: details.timeout,
-    overrideMimeType: details.overrideMimeType,
+    ...objectPick(details, [
+      'anonymous',
+      'headers',
+      'method',
+      'overrideMimeType',
+      'password',
+      'timeout',
+      'url',
+      'user',
+      'withCredentials',
+    ]),
   };
   req.id = id;
   idMap[id] = req;

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -42,6 +42,7 @@ permissions:
   - storage
   - unlimitedStorage
   - clipboardWrite
+  - cookies
 commands:
   _execute_browser_action: {}
   dashboard:


### PR DESCRIPTION
Fixes #606.

Per [GM4 behavior](https://github.com/greasemonkey/greasemonkey/blob/80b179bc5ecb9af12c771c998aed4e81b9ca0d74/src/bg/on-user-script-xhr.js#L125-L149) cookies will be sent in these cases:

* when `withCredentials: true`
* when gmxhr URL origin === tab URL origin