### PR TITLE
UI tweaks

### DIFF
--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -9,9 +9,11 @@
       <form class="inline-block mr-1" @submit.prevent="findNext()">
         <span v-text="i18n('labelSearch')"></span>
         <tooltip content="Ctrl-F">
+          <!-- id is required for the built-in autocomplete using entered values -->
           <input
             :class="{ 'is-error': !search.state.hasResult }"
-            type="text"
+            type="search"
+            id="editor-search"
             ref="search"
             v-model="search.state.query"
           />
@@ -25,7 +27,8 @@
       </form>
       <form class="inline-block mr-1" @submit.prevent="replace()" v-if="!readonly">
         <span v-text="i18n('labelReplace')"></span>
-        <input type="text" v-model="search.state.replace">
+        <!-- id is required for the built-in autocomplete using entered values -->
+        <input type="search" id="editor-replace" v-model="search.state.replace">
         <tooltip content="Shift-Ctrl-F">
           <button type="submit" v-text="i18n('buttonReplace')"></button>
         </tooltip>

--- a/src/common/ui/style/style.css
+++ b/src/common/ui/style/style.css
@@ -391,6 +391,10 @@ button,
       }
     }
   }
+  :-webkit-autofill {
+    box-shadow: 0 0 0 1000px #111 inset;
+    -webkit-text-fill-color: #fff;
+  }
 }
 
 @media (min-width: 768px) {

--- a/src/options/views/edit/values.vue
+++ b/src/options/views/edit/values.vue
@@ -37,9 +37,15 @@
         </div>
       </div>
       <label class="mb-1" v-text="i18n('valueLabelKey')"></label>
-      <input type="text" v-model="current.key" :readOnly="!current.isNew">
+      <input type="text" v-model="current.key" :readOnly="!current.isNew"
+             ref="key"
+             spellcheck="false"
+             @keydown.esc.exact.stop="onCancel">
       <label class="mt-1 mb-1" v-text="i18n('valueLabelValue')"></label>
-      <textarea class="flex-auto" v-model="current.value"></textarea>
+      <textarea class="flex-auto" v-model="current.value"
+                ref="value"
+                spellcheck="false"
+                @keydown.esc.exact.stop="onCancel"/>
     </div>
   </div>
 </template>
@@ -86,6 +92,15 @@ export default {
   watch: {
     show(show) {
       if (show && !this.keys) this.refresh();
+    },
+    current(val) {
+      if (val) {
+        this.$nextTick(() => {
+          const el = this.$refs[val.isNew ? 'key' : 'value'];
+          el.setSelectionRange(0, 0);
+          el.focus();
+        });
+      }
     },
   },
   methods: {

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -62,11 +62,12 @@
             </label>
           </div>
         </dropdown>
-        <div class="filter-search hidden-sm">
+        <!-- form and id are required for the built-in autocomplete using entered values -->
+        <form class="filter-search hidden-sm" @submit.prevent>
           <input type="search" :placeholder="i18n('labelSearchScript')" :title="searchError"
-                 v-model="search">
+                 v-model="search" id="installed-search">
           <icon name="search"></icon>
-        </div>
+        </form>
       </header>
       <div
         v-if="showRecycle"


### PR DESCRIPTION
* autocomplete using entered values in filter/search/replace inputs, the entered value is remembered when <kbd>Enter</kbd> is pressed in a focused input element
  ![image](https://user-images.githubusercontent.com/1310400/70128399-cd5f5c00-168d-11ea-8d53-6b80f1018647.png)
* autofocus values editor input element (`key` for a new value or `value`)
* close value editor on Esc when pressed inside the input/textarea element
* disable spellcheck in the key/value input elements