### PR TITLE
fix: use isFirefox from extension context in injected/*

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,5 +1,6 @@
 import { noop, getUniqId, ensureArray } from '#/common';
 import { objectGet } from '#/common/object';
+import { isFirefox } from '#/common/ua';
 import * as sync from './sync';
 import {
   cache,
@@ -106,6 +107,7 @@ const commands = {
     if (src.frameId === 0) resetValueOpener(tabId);
     const data = {
       isApplied,
+      isFirefox,
       injectInto,
       version: VM_VER,
     };

--- a/src/common/ua.js
+++ b/src/common/ua.js
@@ -2,13 +2,11 @@
 
 // UA can be overriden by about:config in FF or devtools in Chrome
 // so we'll test for window.chrome.app which is only defined in Chrome
-// and for browser.runtime.BrowserInfo in Firefox 51+
+// and for browser.runtime.getBrowserInfo in Firefox 51+
 export const isChrome = !!window.chrome?.app;
 
 // eslint-disable-next-line import/no-mutable-exports
-export let isFirefox = !isChrome && 'BrowserInfo' in browser.runtime;
-// getBrowserInfo doesn't work in content scripts so if they'll ever need the exact version,
-// we'll have to pass isFirefox in GetInjected data
+export let isFirefox = !!browser.runtime.getBrowserInfo;
 browser.runtime.getBrowserInfo?.().then((info) => {
   isFirefox = info.name === 'Firefox' && parseFloat(info.version);
 });

--- a/src/injected/content/clipboard.js
+++ b/src/injected/content/clipboard.js
@@ -1,4 +1,3 @@
-import { isFirefox } from '#/common/ua';
 import { sendCmd } from '../utils';
 import { addEventListener, logging } from '../utils/helpers';
 import bridge from './bridge';
@@ -14,7 +13,7 @@ let clipboardData;
 
 bridge.addHandlers({
   SetClipboard(data) {
-    if (isFirefox) {
+    if (bridge.isFirefox) {
       // Firefox does not support copy from background page.
       // ref: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Interact_with_the_clipboard
       // The dirty way will create a <textarea> element in web page and change the selection.

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -8,7 +8,6 @@ import {
   browser,
 } from '#/common/consts';
 import { getUniqId, sendCmd } from '#/common';
-import { isFirefox } from '#/common/ua';
 
 import { attachFunction } from '../utils';
 import {
@@ -74,9 +73,10 @@ export function injectScripts(contentId, webId, data, scriptLists) {
     webId,
     contentId,
     props,
-    isFirefox,
+    data.isFirefox,
   ];
-  bridge.post.asString = isFirefox;
+  bridge.isFirefox = data.isFirefox;
+  bridge.post.asString = data.isFirefox;
 
   const injectPage = scriptLists[INJECT_PAGE];
   const injectContent = scriptLists[INJECT_CONTENT];


### PR DESCRIPTION
Makes UA detection work in FF52 which doesn't define `BrowserInfo` in the runtime object.