### PR TITLE
feat: expose browser/platform info in GM_info.platform

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,6 +1,6 @@
 import { noop, getUniqId, ensureArray } from '#/common';
 import { objectGet } from '#/common/object';
-import { isFirefox } from '#/common/ua';
+import ua from '#/common/ua';
 import * as sync from './sync';
 import {
   cache,
@@ -107,8 +107,9 @@ const commands = {
     if (src.frameId === 0) resetValueOpener(tabId);
     const data = {
       isApplied,
-      isFirefox,
       injectInto,
+      ua,
+      isFirefox: ua.isFirefox,
       version: VM_VER,
     };
     if (isApplied) {

--- a/src/background/utils/icon.js
+++ b/src/background/utils/icon.js
@@ -1,5 +1,5 @@
 import { i18n, noop } from '#/common';
-import { isChrome } from '#/common/ua';
+import ua from '#/common/ua';
 import { INJECTABLE_TAB_URL_RE } from '#/common/consts';
 import { forEachTab } from './message';
 import { getOption, hookOptions } from './options';
@@ -26,7 +26,7 @@ let titleNoninjectable;
 
 // We'll cache the icon data in Chrome as it doesn't cache the data and takes up to 40ms
 // in our background page context to set the 4 icon sizes for each new tab opened
-const iconCache = isChrome && {};
+const iconCache = ua.isChrome && {};
 
 hookOptions((changes) => {
   if ('isApplied' in changes) {

--- a/src/background/utils/requests.js
+++ b/src/background/utils/requests.js
@@ -1,11 +1,10 @@
 import {
   getUniqId, request, i18n, buffer2string, isEmpty,
 } from '#/common';
-import { isFirefox } from '#/common/ua';
+import ua from '#/common/ua';
 import cache from './cache';
 import { isUserScript, parseMeta } from './script';
 import { getScriptByIdSync } from './db';
-import { openerTabIdSupported } from './tabs';
 
 const VM_VERIFY = 'VM-Verify';
 const requests = {};
@@ -181,7 +180,7 @@ export async function httpRequest(details, src, cb) {
     const vmHeaders = [];
     // Firefox doesn't send cookies,
     // https://github.com/violentmonkey/violentmonkey/issues/606
-    let shouldSendCookies = isFirefox && !anonymous && (
+    let shouldSendCookies = ua.isFirefox && !anonymous && (
       withCredentials || new URL(url).origin === new URL(src.url).origin
     );
     xhr.open(method, url, true, user || '', password || '');
@@ -207,7 +206,7 @@ export async function httpRequest(details, src, cb) {
       const cookies = await browser.cookies.getAll({
         url,
         storeId: src.tab.cookieStoreId,
-        ...isFirefox >= 59 && { firstPartyDomain: null },
+        ...ua.isFirefox >= 59 && { firstPartyDomain: null },
       });
       if (cookies.length) {
         vmHeaders.push({
@@ -329,7 +328,7 @@ export async function confirmInstall(info, src = {}) {
   browser.tabs.create({
     url: `/confirm/index.html#${confirmKey}`,
     index: src.tab ? src.tab.index + 1 : undefined,
-    ...src.tab && openerTabIdSupported ? { openerTabId: src.tab.id } : {},
+    ...src.tab && ua.openerTabIdSupported ? { openerTabId: src.tab.id } : {},
   });
 }
 

--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -51,6 +51,7 @@ const meta = {
   },
   runtime: {
     getManifest: true,
+    getPlatformInfo: wrapAsync,
     getURL: true,
     openOptionsPage: wrapAsync,
     onMessage(onMessage) {

--- a/src/common/ua.js
+++ b/src/common/ua.js
@@ -1,12 +1,46 @@
-/* global browser */
+import { browser } from './consts';
 
 // UA can be overriden by about:config in FF or devtools in Chrome
 // so we'll test for window.chrome.app which is only defined in Chrome
 // and for browser.runtime.getBrowserInfo in Firefox 51+
-export const isChrome = !!window.chrome?.app;
 
-// eslint-disable-next-line import/no-mutable-exports
-export let isFirefox = !!browser.runtime.getBrowserInfo;
-browser.runtime.getBrowserInfo?.().then((info) => {
-  isFirefox = info.name === 'Firefox' && parseFloat(info.version);
+/** @typedef UA
+ * @property {Boolean} isChrome
+ * @property {Boolean | number} isFirefox - boolean initially, Firefox version number when ready
+ * @property {chrome.runtime.PlatformInfo.arch} arch
+ * @property {chrome.runtime.PlatformInfo.os} os
+ * @property {string} browserName
+ * @property {string} browserVersion
+ */
+const ua = {};
+export default ua;
+
+// using non-enumerable properties that won't be sent to content scripts via GetInjected
+Object.defineProperties(ua, {
+  isChrome: {
+    value: !!window.chrome?.app,
+  },
+  isFirefox: {
+    // will be replaced with the version number in ready()
+    value: !!browser.runtime.getBrowserInfo,
+    configurable: true,
+  },
+  ready: {
+    value: Promise.all([
+      browser.runtime.getPlatformInfo(),
+      browser.runtime.getBrowserInfo?.(),
+    ]).then(([{ os, arch }, { name, version } = {}]) => {
+      Object.assign(ua, {
+        arch,
+        os,
+        browserName: name?.toLowerCase() || 'chrome',
+        browserVersion: version || navigator.userAgent.match(/Chrom\S+?\/(\S+)|$/)[1],
+      });
+      if (ua.isFirefox) {
+        Object.defineProperty(ua, 'isFirefox', {
+          value: parseFloat(version),
+        });
+      }
+    }),
+  },
 });

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -73,6 +73,7 @@ export function injectScripts(contentId, webId, data, scriptLists) {
     webId,
     contentId,
     props,
+    data.ua,
     data.isFirefox,
   ];
   bridge.isFirefox = data.isFirefox;

--- a/src/injected/web/gm-wrapper.js
+++ b/src/injected/web/gm-wrapper.js
@@ -65,6 +65,7 @@ export function wrapGM(script, code, cache, injectInto) {
     scriptHandler: 'Violentmonkey',
     version: bridge.version,
     injectInto,
+    platform: { ...bridge.ua },
     script: {
       description: script.meta.description || '',
       excludes: [...script.meta.exclude],

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -15,11 +15,13 @@ export default function initialize(
   webId,
   contentId,
   props,
+  ua,
   isFirefox,
   invokeHost,
 ) {
   let invokeGuest;
   bridge.props = props;
+  bridge.ua = ua;
   bridge.isFirefox = isFirefox;
   if (invokeHost) {
     bridge.mode = INJECT_CONTENT;

--- a/src/options/utils/dragging.js
+++ b/src/options/utils/dragging.js
@@ -1,4 +1,4 @@
-import { isFirefox } from '#/common/ua';
+import ua from '#/common/ua';
 
 const SCROLL_GAP = 50;
 // px per one 60fps frame so the max is ~1200px per second (~one page)
@@ -66,7 +66,7 @@ function onTouchMoveDetect(e) {
   onTouchEndDetect();
   if (e === 'timer') {
     original::onDragStart(longPressEvent);
-    if (isFirefox && parentCanScroll()) {
+    if (ua.isFirefox && parentCanScroll()) {
       // FF bug workaround: prevent the script list container from scrolling on drag
       parent.scrollTop += 1;
       parent.scrollTop -= 1;

--- a/src/options/views/tab-settings/vm-export.vue
+++ b/src/options/views/tab-settings/vm-export.vue
@@ -28,7 +28,7 @@ import Modal from 'vueleton/lib/modal/bundle';
 import { sendCmd, getLocaleString } from '#/common';
 import { objectGet } from '#/common/object';
 import options from '#/common/options';
-import { isFirefox } from '#/common/ua';
+import ua from '#/common/ua';
 import SettingCheck from '#/common/ui/setting-check';
 import { downloadBlob } from '#/common/download';
 import loadZip from '#/common/zip';
@@ -38,7 +38,7 @@ import { store } from '../../utils';
  * Note:
  * - Firefox does not support multiline <select>
  */
-if (isFirefox) store.ffDownload = {};
+if (ua.isFirefox) store.ffDownload = {};
 
 export default {
   components: {
@@ -121,7 +121,7 @@ function getExportname() {
 function download(blob) {
   // Known issue: does not work on Firefox
   // https://bugzilla.mozilla.org/show_bug.cgi?id=1331176
-  if (isFirefox) {
+  if (ua.isFirefox) {
     const reader = new FileReader();
     reader.onload = () => {
       store.ffDownload = {


### PR DESCRIPTION
Implements and fixes #763.

```js
console.log(GM_info);
```

![image](https://user-images.githubusercontent.com/1310400/71188922-f50c1200-2292-11ea-8632-cee1b9d04703.png)

```js
const isChrome = GM_info.platform
   ? GM_info.platform.browserName === 'chrome'
   : /Chrome/i.test(navigator.userAgent);
```