### PR TITLE
Fix GM_(un)registerMenuCommand

### DIFF
--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -76,7 +76,7 @@ bridge.addHandlers({
       const [id, cap] = data;
       const commandMap = menus[id];
       if (commandMap) {
-        delete menus[cap];
+        delete commandMap[cap];
       }
     }
     getPopup();

--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -125,6 +125,7 @@ export function createGmApiProps() {
       const key = `${id}:${cap}`;
       store.commands[key] = func;
       bridge.post({ cmd: 'RegisterMenu', data: [id, cap] });
+      return cap;
     },
     GM_unregisterMenuCommand(cap) {
       const { id } = this;


### PR DESCRIPTION
GM_unregisterMenuCommand didn't work previously, and GM_registerMenuCommand didn't work as Scriptish and TM worked (i.e. returning the menu ID).