### PR TITLE
fix: erroneous braces in storage.cache.fetch

### DIFF
--- a/src/common/storage.js
+++ b/src/common/storage.js
@@ -68,7 +68,7 @@ export default {
     ...base,
     prefix: 'cac:',
     fetch: cacheOrFetch(async function fetch(uri, check) {
-      const { data: { buffer, xhr } } = await request(uri, { responseType: 'arraybuffer' });
+      const { data: buffer, xhr } = await request(uri, { responseType: 'arraybuffer' });
       const contentType = (xhr.getResponseHeader('content-type') || '').split(';')[0];
       const data = {
         contentType,


### PR DESCRIPTION
Broken in 893f1400, looks like I've managed to copypaste it the wrong way somehow.