### PR TITLE
fix: explicitly add window.wrappedJSObject to the wrapper

### DIFF
--- a/src/injected/web/gm-wrapper.js
+++ b/src/injected/web/gm-wrapper.js
@@ -50,6 +50,7 @@ export function wrapGM(script, code, cache, injectInto) {
     gm.window = unsafeWindow;
   } else {
     thisObj = getWrapper();
+    thisObj.wrappedJSObject = window.wrappedJSObject;
     gm.window = thisObj;
   }
   if (grant::includes('window.close')) {


### PR DESCRIPTION
Fixes #765.

FF doesn't expose wrappedJSObject via Object.getOwnPropertyNames so this PR explicitly adds it.