### PR TITLE
fix: handle gmxhr blob/arraybuffer > 64MB

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -173,13 +173,15 @@ const commands = {
   },
   GetRequestId: getRequestId,
   HttpRequest(details, src) {
-    httpRequest(details, src, (res) => {
+    httpRequest(details, src, (res) => (
       browser.tabs.sendMessage(src.tab.id, {
         cmd: 'HttpRequested',
         data: res,
+      }, {
+        frameId: src.frameId,
       })
-      .catch(noop);
-    });
+      .catch(noop)
+    ));
   },
   AbortRequest: abortRequest,
   SetBadge: setBadge,

--- a/src/injected/content/requests.js
+++ b/src/injected/content/requests.js
@@ -1,26 +1,50 @@
+import { INJECT_CONTENT } from '#/common/consts';
 import { sendCmd, sendMessage } from '../utils';
+import { includes } from '../utils/helpers';
 import bridge from './bridge';
 
 const requests = {};
 
+const { fetch } = global;
+const { blob: getBlob } = Response.prototype;
+const { createObjectURL, revokeObjectURL } = URL;
+
 bridge.addHandlers({
-  GetRequestId(_, realm) {
-    sendCmd('GetRequestId')
-    .then((id) => {
-      requests[id] = realm;
-      bridge.post({ cmd: 'GotRequestId', data: id, realm });
-    });
+  async GetRequestId(eventsToNotify, realm) {
+    const id = await sendCmd('GetRequestId', eventsToNotify);
+    requests[id] = { realm, eventsToNotify };
+    bridge.post({ cmd: 'GotRequestId', data: id, realm });
   },
   HttpRequest: sendMessage,
   AbortRequest: sendMessage,
+  RevokeObjectURL: revokeObjectURL,
 });
 
 bridge.addBackgroundHandlers({
-  HttpRequested(data) {
-    const realm = requests[data.id];
-    if (realm) {
-      if (data.type === 'loadend') delete requests[data.id];
-      bridge.post({ cmd: 'HttpRequested', data, realm });
+  async HttpRequested(msg) {
+    const req = requests[msg.id];
+    if (!req) return;
+    const isLoadEnd = msg.type === 'loadend';
+    // only CONTENT realm can read blobs from an extension:// URL
+    const url = msg.isBlob && req.realm !== INJECT_CONTENT && msg.data.response;
+    if (url) {
+      // messages will come while blob is fetched so we'll temporarily store the Promise
+      if (!req.blobUrl && req.eventsToNotify::includes(msg.type)) {
+        req.blobUrl = reexportBlob(url);
+      }
+      // ...which can be awaited in these subsequent messages
+      if (req.blobUrl?.then) {
+        req.blobUrl = await req.blobUrl;
+      }
+      // ...and make sure loadend's bridge.post() runs last
+      if (isLoadEnd) await 0;
+      msg.data.response = req.blobUrl;
     }
+    bridge.post({ cmd: 'HttpRequested', data: msg, realm: req.realm });
+    if (isLoadEnd) delete requests[msg.id];
   },
 });
+
+async function reexportBlob(url) {
+  return createObjectURL(await (await fetch(url))::getBlob());
+}

--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -1,5 +1,6 @@
 import { cache2blobUrl, getUniqId, isEmpty } from '#/common';
 import { downloadBlob } from '#/common/download';
+import { objectPick } from '#/common/object';
 import bridge from './bridge';
 import store from './store';
 import { onTabCreate } from './tabs';
@@ -10,7 +11,7 @@ import {
 } from './gm-values';
 import {
   findIndex, indexOf, slice, objectKeys, objectValues, objectEntries,
-  atob, Error, jsonDump, logging, utf8decode, Blob,
+  atob, Error, jsonDump, logging, utf8decode,
 } from '../utils/helpers';
 
 const { getElementById } = Document.prototype;
@@ -138,17 +139,17 @@ export function createGmApiProps() {
       if (!opts || !opts.url) throw new Error('GM_download: Invalid parameter!');
       return onRequestCreate({
         method: 'GET',
-        responseType: 'arraybuffer',
-        url: opts.url,
-        headers: opts.headers,
-        timeout: opts.timeout,
-        onerror: opts.onerror,
-        onprogress: opts.onprogress,
-        ontimeout: opts.ontimeout,
-        onload(res) {
-          const blob = new Blob([res.response], { type: 'application/octet-stream' });
-          downloadBlob(blob, opts.name, opts.onload);
-        },
+        responseType: 'blob',
+        overrideMimeType: 'application/octet-stream',
+        onload: res => downloadBlob(res.response, opts.name, () => opts.onload?.(res)),
+        ...objectPick(opts, [
+          'url',
+          'headers',
+          'timeout',
+          'onerror',
+          'onprogress',
+          'ontimeout',
+        ]),
       }, this.id);
     },
     GM_xmlhttpRequest(opts) {


### PR DESCRIPTION
Fixes #777.

1. extension messaging has a 128MB limit on the payload size so buffer2string is limited to 64MB as it uses just one byte out of two. **Solution:** URL.createObjectURL is used to transfer a small blob URL, then its contents is retrieved explicitly using XHR in the content script. This workaround is enabled only when `responseType` parameter is `blob` or `arraybuffer`. Ideally we could do that for all response types but I think we shouldn't do it unless someone reports at least one sensible use case.

2. extension API doesn't seem to guarantee the order of messages is preserved so now `xhrCallbackWrapper` will wait for the previous message before sending the next one.