### PR TITLE
Fixups

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -34,12 +34,14 @@ hookOptions((changes) => {
 });
 
 Object.assign(commands, {
+  /** @return {Promise<Object>} */
   async GetData() {
     const data = await getData();
     data.sync = sync.getStates();
     data.version = VM_VER;
     return data;
   },
+  /** @return {Promise<Object>} */
   async GetInjected(url, src) {
     const { id: tabId } = src.tab || {};
     if (src.frameId === 0) resetValueOpener(tabId);

--- a/src/background/utils/notifications.js
+++ b/src/background/utils/notifications.js
@@ -4,6 +4,7 @@ import { commands } from './message';
 const openers = {};
 
 Object.assign(commands, {
+  /** @return {Promise<string>} */
   async Notification(data, src) {
     const srcTab = src.tab || {};
     const notificationId = await browser.notifications.create({

--- a/src/background/utils/options.js
+++ b/src/background/utils/options.js
@@ -7,12 +7,15 @@ import { preInitialize } from './init';
 import { commands } from './message';
 
 Object.assign(commands, {
+  /** @return {Object} */
   GetAllOptions() {
     return commands.GetOptions(defaults);
   },
+  /** @return {Object} */
   GetOptions(data) {
     return objectMap(data, key => getOption(key));
   },
+  /** @return {void} */
   SetOptions(data) {
     ensureArray(data).forEach(item => setOption(item.key, item.value));
   },

--- a/src/background/utils/requests.js
+++ b/src/background/utils/requests.js
@@ -14,6 +14,7 @@ const verify = {};
 
 Object.assign(commands, {
   ConfirmInstall: confirmInstall,
+  /** @return {string} */
   GetRequestId(eventsToNotify = []) {
     eventsToNotify.push('loadend');
     const id = getUniqId();
@@ -24,12 +25,14 @@ Object.assign(commands, {
     };
     return id;
   },
+  /** @return {void} */
   HttpRequest(details, src) {
     const { tab, frameId } = src;
     httpRequest(details, src, res => (
       sendTabCmd(tab.id, 'HttpRequested', res, { frameId })
     ));
   },
+  /** @return {void} */
   AbortRequest(id) {
     const req = requests[id];
     if (req) {

--- a/src/background/utils/script.js
+++ b/src/background/utils/script.js
@@ -6,17 +6,20 @@ import { getOption } from './options';
 import cache from './cache';
 
 Object.assign(commands, {
+  /** @return {string} */
   CacheNewScript(data) {
     const id = getUniqId();
     cache.put(`new-${id}`, newScript(data));
     return id;
   },
+  /** @return {Promise<Array>} */
   InjectScript(code, src) {
     return browser.tabs.executeScript(src.tab.id, {
       code,
       runAt: 'document_start',
     });
   },
+  /** @return {VMScript} */
   NewScript(id) {
     return id && cache.get(`new-${id}`) || newScript();
   },

--- a/src/background/utils/tabs.js
+++ b/src/background/utils/tabs.js
@@ -5,6 +5,7 @@ import { commands } from './message';
 const openers = {};
 
 Object.assign(commands, {
+  /** @return {Promise<{ id: number }>} */
   async TabOpen({ url, active, insert = true }, src) {
     // src.tab may be absent when invoked from popup (e.g. edit/create buttons)
     const { id: openerTabId, index, windowId } = src?.tab || await getActiveTab() || {};
@@ -21,6 +22,7 @@ Object.assign(commands, {
     openers[id] = openerTabId;
     return { id };
   },
+  /** @return {void} */
   TabClose({ id } = {}, src) {
     const tabId = id || src?.tab?.id;
     if (tabId >= 0) browser.tabs.remove(tabId);

--- a/src/background/utils/update.js
+++ b/src/background/utils/update.js
@@ -8,10 +8,12 @@ import { getOption, setOption } from './options';
 import { commands, notify } from './message';
 
 Object.assign(commands, {
+  /** @return {Promise<true?>} */
   CheckUpdate(id) {
     return checkUpdate(getScriptById(id));
   },
-  CheckUpdateAll() {
+  /** @return {Promise<boolean>} */
+  async CheckUpdateAll() {
     setOption('lastUpdate', Date.now());
     const toUpdate = getScripts().filter(item => item.config.shouldUpdate);
     const results = await Promise.all(toUpdate.map(checkUpdate));

--- a/src/background/utils/update.js
+++ b/src/background/utils/update.js
@@ -14,7 +14,8 @@ Object.assign(commands, {
   CheckUpdateAll() {
     setOption('lastUpdate', Date.now());
     const toUpdate = getScripts().filter(item => item.config.shouldUpdate);
-    return Promise.all(toUpdate.map(checkUpdate));
+    const results = await Promise.all(toUpdate.map(checkUpdate));
+    return results.includes(true);
   },
 });
 

--- a/src/background/utils/values.js
+++ b/src/background/utils/values.js
@@ -8,15 +8,18 @@ let cache;
 let timer;
 
 Object.assign(commands, {
+  /** @return {Promise<Object>} */
   async GetValueStore(id) {
     const stores = await getValueStoresByIds([id]);
     return stores[id] || {};
   },
+  /** @return {Promise<void>} */
   async SetValueStore({ where, valueStore }) {
     // Value store will be replaced soon.
     const store = await dumpValueStore(where, valueStore);
-    return broadcastUpdates(store);
+    broadcastUpdates(store);
   },
+  /** @return {Promise<void>} */
   UpdateValue({ id, update }) {
     // Value will be updated to store later.
     updateLater();


### PR DESCRIPTION
* Restores the check of results that I somehow lost in `CheckUpdateAll`
* Adds JSDoc comments for commands
* Fixes JSDoc property names in VMScript meta
* Uses `storage.script.prefix` instead of `scr:` literal and a magic constant `4`