### PR TITLE
refactor: separate params of bridge.post + more ES20xx

### DIFF
--- a/src/injected/content/bridge.js
+++ b/src/injected/content/bridge.js
@@ -22,13 +22,12 @@ export default {
   onHandle(req, realm) {
     const handle = handlers[req.cmd];
     if (handle === sendMessage) sendMessage(req);
-    else if (handle) handle(req.data, realm || INJECT_PAGE);
+    else handle?.(req.data, realm || INJECT_PAGE);
   },
 };
 
-browser.runtime.onMessage.addListener((req, src) => {
-  const handle = bgHandlers[req.cmd];
-  if (handle) handle(req.data, src);
+browser.runtime.onMessage.addListener(({ cmd, data }, src) => {
+  bgHandlers[cmd]?.(data, src);
 });
 
 /**

--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -1,9 +1,8 @@
-import { getUniqId, makePause } from '#/common';
+import { getUniqId, makePause, isEmpty } from '#/common';
 import { INJECT_PAGE, INJECT_CONTENT } from '#/common/consts';
 import { bindEvents, sendCmd, sendMessage } from '../utils';
 import {
-  setJsonDump, objectKeys, filter, forEach, includes, append, createElementNS, setAttribute,
-  NS_HTML,
+  setJsonDump, objectKeys, forEach, includes, append, createElementNS, setAttribute, NS_HTML,
 } from '../utils/helpers';
 import bridge from './bridge';
 import './clipboard';
@@ -41,20 +40,14 @@ bridge.addBackgroundHandlers({
   },
   GetPopup: getPopup,
   UpdatedValues(data) {
-    const realms = [
-      { data: {}, present: false },
-      { data: {}, present: false, realm: INJECT_CONTENT },
-    ];
+    const dataPage = {};
+    const dataContent = {};
+    const { invokableIds } = bridge;
     objectKeys(data)::forEach((id) => {
-      const r = realms[bridge.invokableIds::includes(id) ? 1 : 0];
-      r.data[id] = data[id];
-      r.present = true;
+      (invokableIds::includes(id) ? dataContent : dataPage)[id] = data[id];
     });
-    realms
-    ::filter(r => r.present)
-    ::forEach(({ data: d, realm }) => {
-      bridge.post('UpdatedValues', d, realm);
-    });
+    if (!isEmpty(dataPage)) bridge.post('UpdatedValues', dataPage);
+    if (!isEmpty(dataContent)) bridge.post('UpdatedValues', dataContent, INJECT_CONTENT);
   },
 });
 

--- a/src/injected/content/notifications.js
+++ b/src/injected/content/notifications.js
@@ -4,21 +4,21 @@ import bridge from './bridge';
 const notifications = {};
 
 bridge.addHandlers({
-  Notification(options, realm) {
-    sendCmd('Notification', options)
-    .then((nid) => { notifications[nid] = { id: options.id, realm }; });
+  async Notification(options, realm) {
+    const nid = await sendCmd('Notification', options);
+    notifications[nid] = { id: options.id, realm };
   },
 });
 
 bridge.addBackgroundHandlers({
   NotificationClick(nid) {
     const { id, realm } = notifications[nid] || {};
-    if (id) bridge.post({ cmd: 'NotificationClicked', data: id, realm });
+    if (id) bridge.post('NotificationClicked', id, realm);
   },
   NotificationClose(nid) {
     const { id, realm } = notifications[nid] || {};
     if (id) {
-      bridge.post({ cmd: 'NotificationClosed', data: id, realm });
+      bridge.post('NotificationClosed', id, realm);
       delete notifications[nid];
     }
   },

--- a/src/injected/content/requests.js
+++ b/src/injected/content/requests.js
@@ -12,7 +12,7 @@ bridge.addHandlers({
   async GetRequestId({ eventsToNotify, wantsBlob }, realm) {
     const id = await sendCmd('GetRequestId', eventsToNotify);
     requests[id] = { realm, eventsToNotify, wantsBlob };
-    bridge.post({ cmd: 'GotRequestId', data: id, realm });
+    bridge.post('GotRequestId', id, realm);
   },
   HttpRequest: sendMessage,
   AbortRequest: sendMessage,
@@ -40,7 +40,7 @@ bridge.addBackgroundHandlers({
       if (isLoadEnd) await 0;
       msg.data.response = req.blob;
     }
-    bridge.post({ cmd: 'HttpRequested', data: msg, realm });
+    bridge.post('HttpRequested', msg, realm);
     if (isLoadEnd) delete requests[msg.id];
   },
 });

--- a/src/injected/content/tabs.js
+++ b/src/injected/content/tabs.js
@@ -7,14 +7,12 @@ const tabKeys = {};
 const realms = {};
 
 bridge.addHandlers({
-  TabOpen({ key, data }, realm) {
+  async TabOpen({ key, data }, realm) {
     data.url = getFullUrl(data.url, window.location.href);
-    sendCmd('TabOpen', data)
-    .then(({ id }) => {
-      tabIds[key] = id;
-      tabKeys[id] = key;
-      realms[id] = realm;
-    });
+    const { id } = await sendCmd('TabOpen', data);
+    tabIds[key] = id;
+    tabKeys[id] = key;
+    realms[id] = realm;
   },
   TabClose(key) {
     const id = tabIds[key];
@@ -31,8 +29,6 @@ bridge.addBackgroundHandlers({
     delete realms[id];
     delete tabKeys[id];
     delete tabIds[key];
-    if (key) {
-      bridge.post({ cmd: 'TabClosed', data: key, realm });
-    }
+    if (key) bridge.post('TabClosed', key, realm);
   },
 });

--- a/src/injected/index.js
+++ b/src/injected/index.js
@@ -22,18 +22,16 @@ import initialize from './content';
   const { get: getReadyState } = Object.getOwnPropertyDescriptor(Document.prototype, 'readyState');
   // For installation
   // Firefox does not support `onBeforeRequest` for `file:`
-  function checkJS() {
+  async function checkJS() {
     if (!document::querySelector('title')) {
       // plain text
-      sendCmd('ConfirmInstall', {
+      await sendCmd('ConfirmInstall', {
         code: document.body.textContent,
         url: window.location.href,
         from: document.referrer,
-      })
-      .then(() => {
-        if (window.history.length > 1) window.history::go(-1);
-        else sendCmd('TabClose');
       });
+      if (window.history.length > 1) window.history::go(-1);
+      else sendCmd('TabClose');
     }
   }
   if (window.location.pathname::match(/\.user\.js$/)) {

--- a/src/injected/utils/index.js
+++ b/src/injected/utils/index.js
@@ -9,7 +9,8 @@ const { dispatchEvent } = EventTarget.prototype;
 export function bindEvents(srcId, destId, handle, cloneInto) {
   document::addEventListener(srcId, e => handle(e.detail));
   const pageContext = cloneInto && document.defaultView;
-  return data => {
+  return (cmd, params) => {
+    const data = { cmd, data: params };
     const detail = cloneInto ? cloneInto(data, pageContext) : data;
     const e = new CustomEvent(destId, { detail });
     document::dispatchEvent(e);

--- a/src/injected/web/bridge.js
+++ b/src/injected/web/bridge.js
@@ -7,8 +7,7 @@ export default {
   addHandlers(obj) {
     assign(handlers, obj);
   },
-  onHandle(obj) {
-    const handle = handlers[obj.cmd];
-    if (handle) handle(obj.data);
+  onHandle({ cmd, data }) {
+    handlers[cmd]?.(data);
   },
 };

--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -62,16 +62,8 @@ export function createGmApiProps() {
     GM_addValueChangeListener(key, fn) {
       if (typeof key !== 'string') key = `${key}`;
       if (typeof fn !== 'function') return;
-      let keyHooks = changeHooks[this.id];
-      if (!keyHooks) {
-        keyHooks = {};
-        changeHooks[this.id] = keyHooks;
-      }
-      let hooks = keyHooks[key];
-      if (!hooks) {
-        hooks = {};
-        keyHooks[key] = hooks;
-      }
+      const keyHooks = changeHooks[this.id] || (changeHooks[this.id] = {});
+      const hooks = keyHooks[key] || (keyHooks[key] = {});
       const i = objectValues(hooks)::indexOf(fn);
       let listenerId = i >= 0 && objectKeys(hooks)[i];
       if (!listenerId) {
@@ -125,14 +117,14 @@ export function createGmApiProps() {
       const { id } = this;
       const key = `${id}:${cap}`;
       store.commands[key] = func;
-      bridge.post({ cmd: 'RegisterMenu', data: [id, cap] });
+      bridge.post('RegisterMenu', [id, cap]);
       return cap;
     },
     GM_unregisterMenuCommand(cap) {
       const { id } = this;
       const key = `${id}:${cap}`;
       delete store.commands[key];
-      bridge.post({ cmd: 'UnregisterMenu', data: [id, cap] });
+      bridge.post('UnregisterMenu', [id, cap]);
     },
     GM_download(arg1, name) {
       const opts = typeof arg1 === 'string' ? { url: arg1, name } : arg1;
@@ -164,7 +156,7 @@ export function createGmApiProps() {
       const callbackId = registerCallback((styleId) => {
         el = document::getElementById(styleId);
       });
-      bridge.post({ cmd: 'AddStyle', data: { css, callbackId } });
+      bridge.post('AddStyle', { css, callbackId });
       // Mock a Promise without the need for polyfill
       // It's not actually necessary because DOM messaging is synchronous
       // but we keep it for compatibility with VM's 2017-2019 behavior
@@ -196,10 +188,7 @@ export function createGmApiProps() {
       onNotificationCreate(options);
     },
     GM_setClipboard(data, type) {
-      bridge.post({
-        cmd: 'SetClipboard',
-        data: { type, data },
-      });
+      bridge.post('SetClipboard', { data, type });
     },
   };
   // convert to object property descriptors

--- a/src/injected/web/gm-values.js
+++ b/src/injected/web/gm-values.js
@@ -16,9 +16,9 @@ let cleanupTimer;
 const CLEANUP_TIMEOUT = 10e3;
 
 const dataDecoders = {
-  o: val => jsonLoad(val),
+  o: jsonLoad,
   // deprecated
-  n: val => Number(val),
+  n: Number,
   b: val => val === 'true',
 };
 
@@ -43,12 +43,9 @@ export function dumpValue(change = {}) {
   const {
     id, key, raw, oldRaw,
   } = change;
-  bridge.post({
-    cmd: 'UpdateValue',
-    data: {
-      id,
-      update: { key, value: raw },
-    },
+  bridge.post('UpdateValue', {
+    id,
+    update: { key, value: raw },
   });
   if (raw !== oldRaw) changedLocally(change);
 }
@@ -67,8 +64,7 @@ export function decodeValue(raw) {
 
 // { id, key, val, raw, oldRaw }
 function changedLocally(change) {
-  const keyHooks = changeHooks[change.id];
-  const hooks = keyHooks && keyHooks[change.key];
+  const hooks = changeHooks[change.id]?.[change.key];
   if (hooks) {
     change.hooks = hooks;
     notifyChange(change);

--- a/src/injected/web/gm-wrapper.js
+++ b/src/injected/web/gm-wrapper.js
@@ -54,9 +54,7 @@ export function wrapGM(script, code, cache, injectInto) {
     gm.window = thisObj;
   }
   if (grant::includes('window.close')) {
-    gm.window.close = () => {
-      bridge.post({ cmd: 'TabClose' });
-    };
+    gm.window.close = () => bridge.post('TabClose');
   }
   const resources = script.meta.resources || {};
   const gmInfo = propertyFromValue({

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -25,7 +25,7 @@ export default function initialize(
   bridge.isFirefox = isFirefox;
   if (invokeHost) {
     bridge.mode = INJECT_CONTENT;
-    bridge.post = msg => invokeHost(msg, INJECT_CONTENT);
+    bridge.post = (cmd, data) => invokeHost({ cmd, data }, INJECT_CONTENT);
     invokeGuest = bridge.onHandle;
     global.chrome = undefined;
     global.browser = undefined;
@@ -44,11 +44,9 @@ export default function initialize(
 
 bridge.addHandlers({
   Command(data) {
-    const func = store.commands[data];
-    if (func) func();
+    store.commands[data]?.();
   },
   Callback({ callbackId, payload }) {
-    const func = store.callbacks[callbackId];
-    if (func) func(payload);
+    store.callbacks[callbackId]?.(payload);
   },
 });

--- a/src/injected/web/load-scripts.js
+++ b/src/injected/web/load-scripts.js
@@ -94,13 +94,13 @@ bridge.addHandlers({
     }
 
     function run(list) {
-      bridge.post({ cmd: 'InjectMulti', data: list::map(buildCode) });
+      bridge.post('InjectMulti', list::map(buildCode));
       list.length = 0;
     }
 
     async function runIdle() {
       for (const script of idle) {
-        bridge.post({ cmd: 'Inject', data: buildCode(script) });
+        bridge.post('Inject', buildCode(script));
         await new Promise(setTimeout);
       }
       deletePropsCache();
@@ -163,14 +163,7 @@ function exposeVM() {
       key += 1;
       const callback = key;
       checking[callback] = resolve;
-      bridge.post({
-        cmd: 'CheckScript',
-        data: {
-          name,
-          namespace,
-          callback,
-        },
-      });
+      bridge.post('CheckScript', { name, namespace, callback });
     }),
   });
   defineProperty(window.external, 'Violentmonkey', {

--- a/src/injected/web/notifications.js
+++ b/src/injected/web/notifications.js
@@ -5,18 +5,13 @@ const notifications = {};
 
 bridge.addHandlers({
   NotificationClicked(id) {
-    const options = notifications[id];
-    if (options) {
-      const { onclick } = options;
-      if (onclick) onclick();
-    }
+    notifications[id]?.onclick?.();
   },
   NotificationClosed(id) {
     const options = notifications[id];
     if (options) {
       delete notifications[id];
-      const { ondone } = options;
-      if (ondone) ondone();
+      options.ondone?.();
     }
   },
 });
@@ -24,13 +19,10 @@ bridge.addHandlers({
 export function onNotificationCreate(options) {
   lastId += 1;
   notifications[lastId] = options;
-  bridge.post({
-    cmd: 'Notification',
-    data: {
-      id: lastId,
-      text: options.text,
-      title: options.title,
-      image: options.image,
-    },
+  bridge.post('Notification', {
+    id: lastId,
+    text: options.text,
+    title: options.title,
+    image: options.image,
   });
 }

--- a/src/injected/web/requests.js
+++ b/src/injected/web/requests.js
@@ -37,26 +37,23 @@ export function onRequestCreate(details, scriptId) {
   };
   details.url = getFullUrl(details.url);
   queue::push(req);
-  bridge.post({
-    cmd: 'GetRequestId',
-    data: {
-      eventsToNotify: [
-        'abort',
-        'error',
-        'load',
-        // 'loadend' will always be sent for internal cleanup
-        'progress',
-        'readystatechange',
-        'timeout',
-      ]::filter(e => typeof details[`on${e}`] === 'function'),
-      wantsBlob: details.responseType === 'blob',
-    },
+  bridge.post('GetRequestId', {
+    eventsToNotify: [
+      'abort',
+      'error',
+      'load',
+      // 'loadend' will always be sent for internal cleanup
+      'progress',
+      'readystatechange',
+      'timeout',
+    ]::filter(e => typeof details[`on${e}`] === 'function'),
+    wantsBlob: details.responseType === 'blob',
   });
   return req.req;
 }
 
 function reqAbort(id) {
-  bridge.post({ cmd: 'AbortRequest', data: id });
+  bridge.post('AbortRequest', id);
 }
 
 function parseData(response, req, details) {
@@ -140,7 +137,7 @@ async function start(req, id) {
   payload.data = details.binary
     ? { value: `${details.data}`, cls: 'blob' }
     : await encodeBody(details.data);
-  bridge.post({ cmd: 'HttpRequest', data: payload });
+  bridge.post('HttpRequest', payload);
 }
 
 function getFullUrl(url) {

--- a/src/injected/web/tabs.js
+++ b/src/injected/web/tabs.js
@@ -8,8 +8,7 @@ bridge.addHandlers({
     const item = tabs[key];
     if (item) {
       item.closed = true;
-      const { onclose } = item;
-      if (onclose) onclose();
+      item.onclose?.();
       delete tabs[key];
     }
   },
@@ -22,10 +21,10 @@ export function onTabCreate(data) {
     onclose: null,
     closed: false,
     close() {
-      bridge.post({ cmd: 'TabClose', data: key });
+      bridge.post('TabClose', key);
     },
   };
   tabs[key] = item;
-  bridge.post({ cmd: 'TabOpen', data: { key, data } });
+  bridge.post('TabOpen', { key, data });
   return item;
 }


### PR DESCRIPTION
Trivial refactor of injected/*
* separate params of bridge.post for consistency with `sendCmd`
* optional chaining
* async/await
* simplified UpdatedValues a bit