### PR TITLE
refactor: tweak browser.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,17 +15,10 @@ module.exports = {
     files: ['*'],
     excludedFiles: [
       'src/injected/**/*.js',
-      'src/injected/*.js',
       'src/common/*.js',
     ],
     globals: {
-      browser: true,
-    },
-  }, {
-    // no restrictions in browser.js to check the global `browser`
-    files: ['browser.js'],
-    globals: {
-      browser: true,
+      browser: false,
     },
   }],
 };

--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -1,139 +1,111 @@
-import '#/common/polyfills';
-
-const { chrome } = global;
-
-function wrapAsync(func, thisObj) {
-  return (...args) => {
-    const promise = new Promise((resolve, reject) => {
-      args.push((res) => {
-        const err = chrome.runtime.lastError;
-        if (err) {
-          reject(err);
-        } else {
-          resolve(res);
-        }
-      });
-      func.apply(thisObj, args);
-    });
-    promise.catch((err) => {
-      if (process.env.DEBUG) console.warn(args, err);
-    });
-    return promise;
-  };
-}
-function wrapAPIs(source, meta) {
-  const target = {};
-  Object.keys(source).forEach((key) => {
-    const metaVal = meta && meta[key];
-    if (metaVal) {
-      const value = source[key];
-      if (typeof metaVal === 'function') {
-        target[key] = metaVal(value, source);
-      } else if (typeof metaVal === 'object' && typeof value === 'object') {
-        target[key] = wrapAPIs(value, metaVal);
-      } else {
-        target[key] = value;
-      }
-    }
-  });
-  return target;
-}
-const meta = {
-  browserAction: true,
-  commands: true,
-  cookies: true,
-  extension: true,
-  i18n: true,
-  notifications: {
-    onClicked: true,
-    onClosed: true,
-    create: wrapAsync,
-  },
-  runtime: {
-    getManifest: true,
-    getPlatformInfo: wrapAsync,
-    getURL: true,
-    openOptionsPage: wrapAsync,
-    onMessage(onMessage) {
-      function wrapListener(listener) {
-        return function onChromeMessage(message, sender, sendResponse) {
-          if (process.env.DEBUG) {
-            console.info('receive', message);
-          }
-          const result = listener(message, sender);
-          if (result && typeof result.then === 'function') {
-            result.then((data) => {
-              if (process.env.DEBUG) {
-                console.info('send', data);
-              }
-              sendResponse({ data });
-            }, (error) => {
-              if (process.env.DEBUG) console.warn(error);
-              sendResponse({ error });
-            })
-            .catch(() => {
-              // Ignore sendResponse error
-            });
-            return true;
-          }
-          if (typeof result !== 'undefined') {
-            // In some browsers (e.g Chrome 56, Vivaldi), the listener in
-            // popup pages are not properly cleared after closed.
-            // They may send `undefined` before the real response is sent.
-            sendResponse({ data: result });
-          }
-        };
-      }
-      return {
-        addListener(listener) {
-          return onMessage.addListener(wrapListener(listener));
-        },
-      };
-    },
-    sendMessage(sendMessage) {
-      const promisifiedSendMessage = wrapAsync(sendMessage);
-      return (data) => {
-        const promise = promisifiedSendMessage(data)
-        .then((res) => {
-          if (res && res.error) throw res.error;
-          return res && res.data;
-        });
-        promise.catch((err) => {
-          if (process.env.DEBUG) console.warn(err);
-        });
-        return promise;
-      };
-    },
-  },
-  storage: {
-    local: {
-      get: wrapAsync,
-      set: wrapAsync,
-      remove: wrapAsync,
-    },
-  },
-  tabs: {
-    onCreated: true,
-    onUpdated: true,
-    onRemoved: true,
-    create: wrapAsync,
-    get: wrapAsync,
-    query: wrapAsync,
-    reload: wrapAsync,
-    remove: wrapAsync,
-    sendMessage: wrapAsync,
-    update: wrapAsync,
-    executeScript: wrapAsync,
-  },
-  webRequest: true,
-};
-
 // Since this also runs in a content script we'll guard against implicit global variables
 // for DOM elements with 'id' attribute which is a standard feature, more info:
 // https://github.com/mozilla/webextension-polyfill/pull/153
 // https://html.spec.whatwg.org/multipage/window-object.html#named-access-on-the-window-object
-if ((typeof browser === 'undefined' || Object.getPrototypeOf(browser) !== Object.prototype)
-    && typeof chrome !== 'undefined') {
+if (!global.browser?.runtime?.sendMessage) {
+  const { chrome, Promise } = global;
+  const wrapAPIs = (source, meta = {}) => {
+    return Object.entries(source)
+    .reduce((target, [key, value]) => {
+      const metaVal = meta[key];
+      if (metaVal) {
+        if (typeof metaVal === 'function') {
+          value = source::metaVal(value);
+        } else if (typeof metaVal === 'object' && typeof value === 'object') {
+          value = wrapAPIs(value, metaVal);
+        }
+        target[key] = value;
+      }
+      return target;
+    }, {});
+  };
+  const wrapAsync = function wrapAsync(func) {
+    return (...args) => {
+      const promise = new Promise((resolve, reject) => {
+        this::func(...args, (res) => {
+          const err = chrome.runtime.lastError;
+          if (err) reject(err);
+          else resolve(res);
+        });
+      });
+      if (process.env.DEBUG) promise.catch(err => console.warn(args, err));
+      return promise;
+    };
+  };
+  const wrapMessageListener = listener => (message, sender, sendResponse) => {
+    if (process.env.DEBUG) console.info('receive', message);
+    const result = listener(message, sender);
+    if (typeof result?.then === 'function') {
+      result.then((data) => {
+        if (process.env.DEBUG) console.info('send', data);
+        sendResponse({ data });
+      }, (error) => {
+        if (process.env.DEBUG) console.warn(error);
+        sendResponse({ error });
+      })
+      .catch(() => {}); // Ignore sendResponse error
+      return true;
+    }
+    if (typeof result !== 'undefined') {
+      // In some browsers (e.g Chrome 56, Vivaldi), the listener in
+      // popup pages are not properly cleared after closed.
+      // They may send `undefined` before the real response is sent.
+      sendResponse({ data: result });
+    }
+  };
+  const meta = {
+    browserAction: true,
+    commands: true,
+    cookies: true,
+    extension: true,
+    i18n: true,
+    notifications: {
+      onClicked: true,
+      onClosed: true,
+      create: wrapAsync,
+    },
+    runtime: {
+      getManifest: true,
+      getPlatformInfo: wrapAsync,
+      getURL: true,
+      openOptionsPage: wrapAsync,
+      onMessage: onMessage => ({
+        addListener: listener => onMessage.addListener(wrapMessageListener(listener)),
+      }),
+      sendMessage(sendMessage) {
+        const promisifiedSendMessage = wrapAsync(sendMessage);
+        const unwrapResponse = ({ data: response, error } = {}) => {
+          if (error) throw error;
+          return response;
+        };
+        return (data) => {
+          const promise = promisifiedSendMessage(data).then(unwrapResponse);
+          if (process.env.DEBUG) promise.catch(console.warn);
+          return promise;
+        };
+      },
+    },
+    storage: {
+      local: {
+        get: wrapAsync,
+        set: wrapAsync,
+        remove: wrapAsync,
+      },
+    },
+    tabs: {
+      onCreated: true,
+      onUpdated: true,
+      onRemoved: true,
+      create: wrapAsync,
+      get: wrapAsync,
+      query: wrapAsync,
+      reload: wrapAsync,
+      remove: wrapAsync,
+      sendMessage: wrapAsync,
+      update: wrapAsync,
+      executeScript: wrapAsync,
+    },
+    webRequest: true,
+  };
   global.browser = wrapAPIs(chrome, meta);
-  // global.browser.__patched = true;
 }


### PR DESCRIPTION
* don't process code needlessly in Firefox
* add a debugging .catch() only in debug builds
* use optional chaining
* use binding::call
* trivial code cosmetics like extracting wrapMessageListener to make the main API definition object smaller and more readable
* simplify eslint.rc