### PR TITLE
rework/simplify GMxxxValueChanged handling

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -54,7 +54,7 @@ Object.assign(commands, {
     };
     if (isApplied) {
       const scripts = await (cache.get(`preinject:${url}`) || getScriptsByURL(url));
-      addValueOpener(tabId, Object.keys(scripts.values));
+      addValueOpener(tabId, src.frameId, Object.keys(scripts.values));
       Object.assign(data, scripts);
     }
     return data;

--- a/src/background/sync/base.js
+++ b/src/background/sync/base.js
@@ -3,7 +3,7 @@ import {
 } from '#/common';
 import { TIMEOUT_HOUR } from '#/common/consts';
 import {
-  objectGet, objectSet, objectPick, objectPurify,
+  forEachEntry, objectGet, objectSet, objectPick, objectPurify,
 } from '#/common/object';
 import {
   getEventEmitter, getOption, setOption, hookOptions,
@@ -79,9 +79,8 @@ function serviceConfig(name) {
   }
   function set(key, val) {
     if (typeof key === 'object') {
-      const data = key;
-      Object.keys(data).forEach((k) => {
-        syncConfig.set(getKeys(k), data[k]);
+      key::forEachEntry(([k, v]) => {
+        syncConfig.set(getKeys(k), v);
       });
     } else {
       syncConfig.set(getKeys(key), val);
@@ -429,8 +428,7 @@ export const BaseService = serviceFactory({
           delLocal.push({ local: item });
         }
       });
-      Object.keys(remoteItemMap).forEach((uri) => {
-        const item = remoteItemMap[uri];
+      remoteItemMap::forEachEntry(([uri, item]) => {
         const info = remoteMetaData.info[uri];
         if (outdated) {
           putLocal.push({ remote: item, info });

--- a/src/background/utils/db.js
+++ b/src/background/utils/db.js
@@ -2,6 +2,7 @@ import {
   i18n, getFullUrl, isRemote, getRnd4, sendCmd,
 } from '#/common';
 import { CMD_SCRIPT_ADD, CMD_SCRIPT_UPDATE, TIMEOUT_WEEK } from '#/common/consts';
+import { forEachEntry, forEachValue } from '#/common/object';
 import storage from '#/common/storage';
 import pluginEvents from '../plugin/events';
 import {
@@ -101,7 +102,7 @@ preInitialize.push(async () => {
   };
   const idMap = {};
   const uriMap = {};
-  Object.entries(data).forEach(([key, script]) => {
+  data::forEachEntry(([key, script]) => {
     if (key.startsWith(storage.script.prefix)) {
       // {
       //   meta,
@@ -262,7 +263,7 @@ export async function getScriptsByURL(url) {
       script.meta.require.forEach((key) => {
         reqKeys[pathMap[key] || key] = 1;
       });
-      Object.values(script.meta.resources).forEach((key) => {
+      script.meta.resources::forEachValue((key) => {
         cacheKeys[pathMap[key] || key] = 1;
       });
     }
@@ -470,7 +471,7 @@ function fetchScriptResources(script, cache) {
     }
   });
   // @resource
-  Object.values(meta.resources).forEach((url) => {
+  meta.resources::forEachValue((url) => {
     const fullUrl = pathMap[url] || url;
     const cached = cache.resources?.[fullUrl];
     if (cached) {
@@ -540,7 +541,7 @@ export async function vacuum() {
     script.meta.require.forEach((url) => {
       touch(requireKeys, pathMap[url] || url);
     });
-    Object.values(script.meta.resources).forEach((url) => {
+    script.meta.resources::forEachValue((url) => {
       touch(cacheKeys, pathMap[url] || url);
     });
     const { icon } = script.meta;
@@ -550,8 +551,7 @@ export async function vacuum() {
     }
   });
   mappings.forEach(([substore, map]) => {
-    Object.keys(map).forEach((key) => {
-      const value = map[key];
+    map::forEachEntry(([key, value]) => {
       if (value < 0) {
         // redundant value
         substore.remove(key);

--- a/src/background/utils/options.js
+++ b/src/background/utils/options.js
@@ -1,7 +1,7 @@
 import {
   debounce, ensureArray, initHooks, normalizeKeys,
 } from '#/common';
-import { objectGet, objectSet, objectMap } from '#/common/object';
+import { mapEntry, objectGet, objectSet } from '#/common/object';
 import defaults from '#/common/options-defaults';
 import { preInitialize } from './init';
 import { commands } from './message';
@@ -13,7 +13,7 @@ Object.assign(commands, {
   },
   /** @return {Object} */
   GetOptions(data) {
-    return objectMap(data, key => getOption(key));
+    return data::mapEntry(key => getOption(key));
   },
   /** @return {void} */
   SetOptions(data) {

--- a/src/background/utils/requests.js
+++ b/src/background/utils/requests.js
@@ -1,7 +1,7 @@
 import {
   getUniqId, request, i18n, isEmpty, sendTabCmd,
 } from '#/common';
-import { objectPick } from '#/common/object';
+import { forEachEntry, objectPick } from '#/common/object';
 import ua from '#/common/ua';
 import cache from './cache';
 import { isUserScript, parseMeta } from './script';
@@ -127,7 +127,7 @@ const HeaderInjector = (() => {
       // need to set the entry even if it's empty [] so that 'if' check in del() runs only once
       headersToInject[reqId] = headers;
       // need the listener to get the requestId
-      Object.entries(apiEvents).forEach(([name, { listener, options }]) => {
+      apiEvents::forEachEntry(([name, { listener, options }]) => {
         browser.webRequest[name].addListener(listener, apiFilter, options);
       });
     },
@@ -135,7 +135,7 @@ const HeaderInjector = (() => {
       if (reqId in headersToInject) {
         delete headersToInject[reqId];
         if (isEmpty(headersToInject)) {
-          Object.entries(apiEvents).forEach(([name, { listener }]) => {
+          apiEvents::forEachEntry(([name, { listener }]) => {
             browser.webRequest[name].removeListener(listener);
           });
         }
@@ -220,7 +220,7 @@ async function httpRequest(details, src, cb) {
     xhr.open(method, url, true, user || '', password || '');
     xhr.setRequestHeader(VM_VERIFY, id);
     if (headers) {
-      Object.entries(headers).forEach(([name, value]) => {
+      headers::forEachEntry(([name, value]) => {
         const lowerName = name.toLowerCase();
         if (isSpecialHeader(lowerName)) {
           vmHeaders.push({ name, value });
@@ -272,8 +272,8 @@ function decodeBody(obj) {
   if (cls === 'formdata') {
     const result = new FormData();
     if (value) {
-      Object.keys(value).forEach((key) => {
-        value[key].forEach((item) => {
+      value::forEachEntry(([key, items]) => {
+        items.forEach((item) => {
           result.append(key, decodeBody(item));
         });
       });

--- a/src/background/utils/script.js
+++ b/src/background/utils/script.js
@@ -1,6 +1,6 @@
 import { getUniqId, encodeFilename } from '#/common';
 import { METABLOCK_RE } from '#/common/consts';
-import { objectMap } from '#/common/object';
+import { mapEntry } from '#/common/object';
 import { commands } from './message';
 import { getOption } from './options';
 import cache from './cache';
@@ -65,7 +65,7 @@ const metaTypes = {
 };
 export function parseMeta(code) {
   // initialize meta
-  const meta = objectMap(metaTypes, (key, value) => value.default());
+  const meta = metaTypes::mapEntry((key, value) => value.default());
   const metaBody = code.match(METABLOCK_RE)[1] || '';
   metaBody.replace(/(?:^|\n)\s*\/\/\x20(@\S+)(.*)/g, (_match, rawKey, rawValue) => {
     const [keyName, locale] = rawKey.slice(1).split(':');

--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -96,6 +96,7 @@ if (!global.browser?.runtime?.sendMessage) {
       onCreated: true,
       onUpdated: true,
       onRemoved: true,
+      onReplaced: true,
       create: wrapAsync,
       get: wrapAsync,
       query: wrapAsync,

--- a/src/common/hook-setting.js
+++ b/src/common/hook-setting.js
@@ -1,11 +1,10 @@
 import options from './options';
-import { objectGet } from './object';
+import { forEachEntry, objectGet } from './object';
 
 const hooks = {};
 
 options.hook((data) => {
-  Object.keys(hooks).forEach((key) => {
-    const list = hooks[key];
+  hooks::forEachEntry(([key, list]) => {
     if (list) {
       const value = objectGet(data, key);
       if (value !== undefined) list.forEach(update => update(value));

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -1,18 +1,13 @@
 import { browser } from '#/common/consts';
 import { noop } from './util';
 
+export { normalizeKeys } from './object';
 export * from './util';
 
 export function i18n(name, args) {
   return browser.i18n.getMessage(name, args) || name;
 }
 export const defaultImage = '/public/images/icon128.png';
-
-export function normalizeKeys(key) {
-  if (key == null) return [];
-  if (Array.isArray(key)) return key;
-  return `${key}`.split('.').filter(Boolean);
-}
 
 export function initHooks() {
   const hooks = [];

--- a/src/common/object.js
+++ b/src/common/object.js
@@ -19,16 +19,15 @@ export function objectSet(obj, rawKey, val) {
   if (!keys.length) return val;
   const root = obj || {};
   let sub = root;
-  const lastKey = keys.pop();
+  let lastKey = keys.pop();
   keys.forEach((key) => {
-    let child = sub[key];
-    if (!child) {
-      child = {};
-      sub[key] = child;
-    }
-    sub = child;
+    sub = sub[key] || (sub[key] = {});
   });
-  if (typeof val === 'undefined') {
+  if (Array.isArray(lastKey)) {
+    lastKey = lastKey[0];
+    sub = sub[lastKey] || (sub[lastKey] = []);
+    sub.push(val);
+  } else if (typeof val === 'undefined') {
     delete sub[lastKey];
   } else {
     sub[lastKey] = val;

--- a/src/common/object.js
+++ b/src/common/object.js
@@ -1,4 +1,8 @@
-import { normalizeKeys } from '.';
+export function normalizeKeys(key) {
+  if (key == null) return [];
+  if (Array.isArray(key)) return key;
+  return `${key}`.split('.').filter(Boolean);
+}
 
 export function objectGet(obj, rawKey, def) {
   const keys = normalizeKeys(rawKey);
@@ -40,10 +44,9 @@ export function objectPurify(obj) {
   if (Array.isArray(obj)) {
     obj.forEach(objectPurify);
   } else if (obj && typeof obj === 'object') {
-    Object.keys(obj).forEach((key) => {
-      const type = typeof obj[key];
-      if (type === 'undefined') delete obj[key];
-      else objectPurify(obj[key]);
+    obj::forEachEntry(([key, value]) => {
+      if (typeof value === 'undefined') delete obj[key];
+      else objectPurify(value);
     });
   }
   return obj;
@@ -57,9 +60,20 @@ export function objectPick(obj, keys) {
   }, {});
 }
 
-export function objectMap(obj, func) {
-  return Object.entries(obj).reduce((res, [key, value]) => {
+// invoked as obj::mapEntry((key, value) => transformedValue)
+export function mapEntry(func) {
+  return Object.entries(this).reduce((res, [key, value]) => {
     res[key] = func(key, value);
     return res;
   }, {});
+}
+
+// invoked as obj::forEachEntry(([key, value]) => {})
+export function forEachEntry(func) {
+  if (this) Object.entries(this).forEach(func);
+}
+
+// invoked as obj::forEachValue(value => {})
+export function forEachValue(func) {
+  if (this) Object.values(this).forEach(func);
 }

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -1,5 +1,5 @@
 import { initHooks, sendCmd, normalizeKeys } from '.';
-import { objectGet, objectSet } from './object';
+import { forEachEntry, objectGet, objectSet } from './object';
 
 let options = {};
 const hooks = initHooks();
@@ -22,8 +22,8 @@ function setOption(key, value) {
 }
 
 function updateOptions(data) {
-  Object.keys(data).forEach((key) => {
-    objectSet(options, key, data[key]);
+  data::forEachEntry(([key, value]) => {
+    objectSet(options, key, value);
   });
   hooks.fire(data);
 }

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -1,3 +1,5 @@
+import { forEachEntry } from './object';
+
 export function toString(param) {
   if (param == null) return '';
   return `${param}`;
@@ -145,8 +147,8 @@ export function request(url, options = {}) {
       headers['Content-Type'] = 'application/json';
       body = JSON.stringify(body);
     }
-    Object.keys(headers).forEach((key) => {
-      xhr.setRequestHeader(key, headers[key]);
+    headers::forEachEntry(([name, value]) => {
+      xhr.setRequestHeader(name, value);
     });
     xhr.onload = () => {
       const res = getResponse(xhr, {

--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -50,9 +50,9 @@ export function createGmApiProps() {
     /**
      * @callback GMValueChangeListener
      * @param {String} key
-     * @param {any} oldValue - undefined = value was created
-     * @param {any} newValue - undefined = value was removed
-     * @param {boolean} remote - true = value was modified in another tab
+     * @param {?} oldValue - `undefined` means value was created
+     * @param {?} newValue - `undefined` means value was removed
+     * @param {boolean} remote - `true` means value was modified in another tab
      */
     /**
      * @param {String} key - name of the value to monitor

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import {
   sendCmd, i18n, getLocaleString, cache2blobUrl,
 } from '#/common';
+import { forEachEntry, forEachValue } from '#/common/object';
 import handlers from '#/common/handlers';
 import loadZip from '#/common/zip';
 import '#/common/ui/style';
@@ -60,8 +61,7 @@ function loadData() {
       store.scripts.forEach(initScript);
     }
     if (store.cache) {
-      Object.keys(store.cache).forEach((url) => {
-        const raw = store.cache[url];
+      store.cache::forEachEntry(([url, raw]) => {
         if (oldCache[url]) {
           store.cache[url] = oldCache[url];
           delete oldCache[url];
@@ -70,9 +70,7 @@ function loadData() {
         }
       });
     }
-    Object.values(oldCache).forEach((blobUrl) => {
-      URL.revokeObjectURL(blobUrl);
-    });
+    oldCache::forEachValue(URL.revokeObjectURL);
     store.loading = false;
   });
 }

--- a/src/options/views/edit/help.vue
+++ b/src/options/views/edit/help.vue
@@ -19,6 +19,7 @@
 
 <script>
 import CodeMirror from 'codemirror';
+import { forEachEntry } from '#/common/object';
 
 export default {
   props: ['target'],
@@ -41,7 +42,7 @@ function compareString(a, b, index) {
 function expandKeyMap(res, ...maps) {
   maps.forEach((map) => {
     if (typeof map === 'string') map = CodeMirror.keyMap[map];
-    Object.entries(map).forEach(([key, value]) => {
+    map::forEachEntry(([key, value]) => {
       if (!res[key] && /^[a-z]+$/i.test(value) && CodeMirror.commands[value]) {
         res[key] = value;
       }

--- a/src/options/views/tab-settings/vm-import.vue
+++ b/src/options/views/tab-settings/vm-import.vue
@@ -19,6 +19,7 @@
 
 <script>
 import { i18n, sendCmd } from '#/common';
+import { forEachEntry } from '#/common/object';
 import options from '#/common/options';
 import SettingCheck from '#/common/ui/setting-check';
 import loadZip from '#/common/zip';
@@ -58,8 +59,8 @@ export default {
 
 function forEachItem(obj, cb) {
   if (obj) {
-    Object.keys(obj).forEach((key) => {
-      cb(obj[key], key);
+    obj::forEachEntry(([key, value]) => {
+      cb(value, key);
     });
   }
 }

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { i18n, sendCmd, getActiveTab } from '#/common';
 import { INJECTABLE_TAB_URL_RE } from '#/common/consts';
 import handlers from '#/common/handlers';
-import { objectMap } from '#/common/object';
+import { mapEntry } from '#/common/object';
 import * as tld from '#/common/tld';
 import '#/common/ui/style';
 import App from './views/app';
@@ -37,7 +37,7 @@ Object.assign(handlers, {
     allScriptIds.push(...ids);
     if (isTop) {
       mutex.resolve();
-      store.commands = objectMap(data.menus, (key, value) => Object.keys(value).sort());
+      store.commands = data.menus::mapEntry((key, value) => Object.keys(value).sort());
     }
     if (ids.length) {
       // frameScripts may be appended multiple times if iframes have unique scripts


### PR DESCRIPTION
Main change:

* `openers` now also stores frameId which is used to skip sending the updates to the initiator (the script that introduced this particular change)
* each tab's frame gets its own message with updates only for the scripts running in that frame

Collateral changes:

* `tabScripts` is removed because it's enough to enumerate the entire `openers` - there will be just a few script ids (or maybe a few dozen for super hardcore users)

* objectSet() can treat the final value as an array if the last key is also an array, for example `objectSet(obj, ['foo', ['bar']], value)` will set `obj.foo.bar = []` if needed and then do `obj.foo.bar.push(value)`.

* The second commit adds ::forEachEntry, ::forEachValue, ::mapEntry so despite it being trivial you still may find it easier to review the commits separately.