### PR TITLE
feat: add scope name|code|all to dashboard search filter

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -184,6 +184,15 @@ filterExecutionOrder:
 filterLastUpdateOrder:
   description: Label for option to sort scripts by last update time.
   message: last update time
+filterScopeAll:
+  description: Option in dashboard's search scope filter.
+  message: All
+filterScopeCode:
+  description: Option in dashboard's search scope filter.
+  message: Code
+filterScopeName:
+  description: Option in dashboard's search scope filter.
+  message: Name
 headerRecycleBin:
   description: Text shown in the header when scripts in recycle bin are listed.
   message: Recycle Bin
@@ -585,6 +594,11 @@ sideMenuSettings:
 titleScriptUpdated:
   description: Notification title for script updates.
   message: Update
+titleSearchHint:
+  description: Hover title for search icon in dashboard.
+  message: |-
+    * <Enter> key adds the text to autocomplete history
+    * RegExp syntax is supported: /re/ and /re/flags
 valueLabelKey:
   description: Label for key of a script value.
   message: Key (string)

--- a/src/common/hook-setting.js
+++ b/src/common/hook-setting.js
@@ -13,12 +13,23 @@ options.hook((data) => {
   });
 });
 
-export default function hook(key, update) {
-  let list = hooks[key];
-  if (!list) {
-    list = [];
-    hooks[key] = list;
+/**
+ * When an option is updated elsewhere (or when a yet unresolved options.ready will be fired),
+ * calls the specified `update` function or assigns the specified `prop` in `target` object.
+ * Also, when the latter mode is used, option.get() is called explicitly right away,
+ * but only if options.ready is resolved or `transform` function is specified.
+ * @param {string} key - option name
+ * @param {function(value) | { target, prop, transform }} update - either a function or the config object
+ * @return {function}
+ */
+export default function hookSetting(key, update) {
+  const { target } = update;
+  if (target) {
+    const { prop, transform } = update;
+    update = value => { target[prop] = transform ? transform(value) : value; };
+    if (transform || options.ready.indeed) update(options.get(key));
   }
+  const list = hooks[key] || (hooks[key] = []);
   list.push(update);
   return () => {
     const i = list.indexOf(update);

--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -23,6 +23,8 @@ export default {
   /** @type 'auto' | 'page' | 'content' */
   defaultInjectInto: INJECT_AUTO,
   filters: {
+    /** @type 'name' | 'code' | 'all' */
+    searchScope: 'name',
     /** @type 'exec' | 'alpha' | 'update' */
     sort: 'exec',
   },

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -1,3 +1,4 @@
+import defaults from '#/common/options-defaults';
 import { initHooks, sendCmd, normalizeKeys } from '.';
 import { objectGet, objectSet } from './object';
 
@@ -9,9 +10,9 @@ const ready = sendCmd('GetAllOptions', null, { retry: true })
   if (data) hooks.fire(data);
 });
 
-function getOption(key, def) {
+function getOption(key) {
   const keys = normalizeKeys(key);
-  return objectGet(options, keys, def);
+  return objectGet(options, keys) ?? objectGet(defaults, keys);
 }
 
 function setOption(key, value) {

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -6,6 +6,7 @@ let options = {};
 const hooks = initHooks();
 const ready = sendCmd('GetAllOptions', null, { retry: true })
 .then((data) => {
+  ready.indeed = true; // a workaround for inability to query native Promise state
   options = data;
   if (data) hooks.fire(data);
 });

--- a/src/common/ui/setting-check.vue
+++ b/src/common/ui/setting-check.vue
@@ -34,14 +34,10 @@ export default {
       this.$emit('change', value);
     },
   },
-  created() {
-    options.ready.then(() => {
-      this.value = options.get(this.name);
-      this.revoke = hookSetting(this.name, (value) => {
-        this.value = value;
-      });
-      this.$watch('value', this.onChange);
-    });
+  async created() {
+    await options.ready;
+    this.revoke = hookSetting(this.name, { target: this, prop: 'value' });
+    this.$watch('value', this.onChange);
   },
   beforeDestroy() {
     if (this.revoke) this.revoke();

--- a/src/common/ui/setting-text.vue
+++ b/src/common/ui/setting-text.vue
@@ -32,14 +32,11 @@ export default {
     };
   },
   created() {
-    const handle = this.json
+    const transform = this.json
       ? (value => JSON.stringify(value, null, '  '))
       // XXX compatible with old data format
       : (value => (Array.isArray(value) ? value.join('\n') : value || ''));
-    this.value = handle(options.get(this.name));
-    this.revoke = hookSetting(this.name, (value) => {
-      this.value = handle(value);
-    });
+    this.revoke = hookSetting(this.name, { target: this, prop: 'value', transform });
     if (this.json) this.$watch('value', this.parseJson);
   },
   beforeDestroy() {

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -152,21 +152,24 @@ const filterOptions = {
     },
   },
 };
+const filtersSort = {
+  value: null,
+  title: null,
+};
 const filters = {
   searchScope: null,
   showEnabledFirst: null,
-  sort: {
-    value: null,
-    title: null,
-    set(value) {
-      const option = filterOptions.sort[value];
-      if (option) {
-        filters.sort.value = value;
-        filters.sort.title = option.title;
-      } else {
-        filters.sort.set(Object.keys(filterOptions.sort)[0]);
-      }
-    },
+  get sort() {
+    return filtersSort;
+  },
+  set sort(value) {
+    const option = filterOptions.sort[value];
+    if (option) {
+      filtersSort.value = value;
+      filtersSort.title = option.title;
+    } else {
+      filters.sort = Object.keys(filterOptions.sort)[0];
+    }
   },
 };
 const combinedCompare = cmpFunc => (
@@ -174,19 +177,8 @@ const combinedCompare = cmpFunc => (
     ? ((a, b) => b.config.enabled - a.config.enabled || cmpFunc(a, b))
     : cmpFunc
 );
-hookSetting('filters.searchScope', (value) => {
-  filters.searchScope = value;
-});
-hookSetting('filters.showEnabledFirst', (value) => {
-  filters.showEnabledFirst = value;
-});
-hookSetting('filters.sort', (value) => {
-  filters.sort.set(value);
-});
-options.ready.then(() => {
-  filters.searchScope = options.get('filters.searchScope');
-  filters.sort.set(options.get('filters.sort'));
-  filters.showEnabledFirst = options.get('filters.showEnabledFirst');
+Object.keys(filters).forEach(prop => {
+  hookSetting(`filters.${prop}`, { target: filters, prop });
 });
 
 const MAX_BATCH_DURATION = 100;

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -168,17 +168,13 @@ export default {
       };
     },
   },
-  created() {
+  async created() {
     this.revokers = [];
-    options.ready.then(() => {
-      items.forEach((item) => {
-        const { name, normalize } = item;
-        settings[name] = normalize(options.get(name));
-        this.revokers.push(hookSetting(name, (value) => {
-          settings[name] = value;
-        }));
-        this.$watch(() => settings[name], debounce(this.getUpdater(item), 300));
-      });
+    await options.ready;
+    items.forEach((item) => {
+      const { name, normalize: transform } = item;
+      this.revokers.push(hookSetting(name, { target: settings, prop: name, transform }));
+      this.$watch(() => settings[name], debounce(this.getUpdater(item), 300));
     });
   },
   beforeDestroy() {


### PR DESCRIPTION
Default mode is `name`, which restores the old behavior (before code search was enabled by default). The reason is that searching code by default may often produce irrelevant results due to matching a common JS term or a common metablock value.

![image](https://user-images.githubusercontent.com/1310400/72587181-70e69200-3905-11ea-82b9-84eccff631cb.png)

![image](https://user-images.githubusercontent.com/1310400/72587171-61ffdf80-3905-11ea-9944-552c3b0d6601.png)

I've used a dropdown selector instead of a simple `[x] in code` because we may want to add other modes in the future like maybe `values` or individual meta keys.

Collateral:

* common/options getOption() now uses options-defaults.js to get the fallback value instead of the second parameter which wasn't used anywhere (AFAICT it was added just in case, only because options-defaults.js wasn't exposed).
* a tooltip with regexp search hint is added to the search icon
* refactor: deduplicate/simplify hookSetting() usage so it automatically calls options.get when used in the declarative invocation fashion via `{ prop: 'name' }`