### PR TITLE
fix: only skip sending the last known value

### DIFF
--- a/src/background/utils/db.js
+++ b/src/background/utils/db.js
@@ -2,7 +2,7 @@ import {
   i18n, getFullUrl, isRemote, getRnd4, sendCmd,
 } from '#/common';
 import { CMD_SCRIPT_ADD, CMD_SCRIPT_UPDATE, TIMEOUT_WEEK } from '#/common/consts';
-import { forEachEntry, forEachValue } from '#/common/object';
+import { forEachEntry, forEachKey, forEachValue } from '#/common/object';
 import storage from '#/common/storage';
 import pluginEvents from '../plugin/events';
 import {
@@ -514,7 +514,7 @@ export async function vacuum() {
     [storage.code, codeKeys],
   ];
   const data = await browser.storage.local.get();
-  Object.keys(data).forEach((key) => {
+  data::forEachKey((key) => {
     mappings.some(([substore, map]) => {
       const { prefix } = substore;
       if (key.startsWith(prefix)) {

--- a/src/background/utils/values.js
+++ b/src/background/utils/values.js
@@ -5,7 +5,7 @@ import {
 import { getValueStoresByIds, dumpValueStores, dumpValueStore } from './db';
 import { commands } from './message';
 
-const openers = {}; // { scriptId: { tabId: [frameId, ... ], ... } }
+const openers = {}; // { scriptId: { tabId: { frameId: 1, ... }, ... } }
 let cache; // { scriptId: { key: [{ value, src }, ... ], ... } }
 let updateScheduled;
 
@@ -44,7 +44,7 @@ export function resetValueOpener(tabId) {
 
 export function addValueOpener(tabId, frameId, scriptIds) {
   scriptIds.forEach((id) => {
-    objectSet(openers, [id, [tabId]], frameId);
+    objectSet(openers, [id, tabId, frameId], 1);
   });
 }
 
@@ -84,7 +84,7 @@ function broadcastUpdates(updates, oldCache = {}) {
   const toSend = {};
   updates::forEachEntry(([id, data]) => {
     openers[id]::forEachEntry(([tabId, frames]) => {
-      frames.forEach(frameId => {
+      frames::forEachKey(frameId => {
         objectSet(toSend, [tabId, frameId, id],
           avoidInitiator(data, oldCache[id], tabId, frameId));
       });

--- a/src/background/utils/values.js
+++ b/src/background/utils/values.js
@@ -1,5 +1,7 @@
 import { isEmpty, sendTabCmd } from '#/common';
-import { forEachEntry, objectPick, objectSet } from '#/common/object';
+import {
+  forEachEntry, forEachKey, objectPick, objectSet,
+} from '#/common/object';
 import { getValueStoresByIds, dumpValueStores, dumpValueStore } from './db';
 import { commands } from './message';
 
@@ -101,7 +103,7 @@ function broadcastUpdates(updates, oldCache = {}) {
 function avoidInitiator(data, history, tabId, frameId) {
   if (history) {
     let toPick;
-    Object.keys(data).forEach((key, i, allKeys) => {
+    data::forEachKey((key, i, allKeys) => {
       // Not sending `key` to this frame if its last recorded value is identical
       const frameValue = history[key]?.[tabId]?.[frameId];
       if (frameValue !== undefined && frameValue === data[key]) {

--- a/src/common/object.js
+++ b/src/common/object.js
@@ -73,6 +73,11 @@ export function forEachEntry(func) {
   if (this) Object.entries(this).forEach(func);
 }
 
+// invoked as obj::forEachKey(key => {})
+export function forEachKey(func) {
+  if (this) Object.keys(this).forEach(func);
+}
+
 // invoked as obj::forEachValue(value => {})
 export function forEachValue(func) {
   if (this) Object.values(this).forEach(func);

--- a/src/common/object.js
+++ b/src/common/object.js
@@ -23,15 +23,11 @@ export function objectSet(obj, rawKey, val) {
   if (!keys.length) return val;
   const root = obj || {};
   let sub = root;
-  let lastKey = keys.pop();
+  const lastKey = keys.pop();
   keys.forEach((key) => {
     sub = sub[key] || (sub[key] = {});
   });
-  if (Array.isArray(lastKey)) {
-    lastKey = lastKey[0];
-    sub = sub[lastKey] || (sub[lastKey] = []);
-    sub.push(val);
-  } else if (typeof val === 'undefined') {
+  if (typeof val === 'undefined') {
     delete sub[lastKey];
   } else {
     sub[lastKey] = val;

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -125,6 +125,7 @@ import SettingCheck from '#/common/ui/setting-check';
 import hookSetting from '#/common/hook-setting';
 import Icon from '#/common/ui/icon';
 import LocaleGroup from '#/common/ui/locale-group';
+import { forEachKey } from '#/common/object';
 import { setRoute, lastRoute } from '#/common/router';
 import storage from '#/common/storage';
 import ScriptItem from './script-item';
@@ -177,7 +178,7 @@ const combinedCompare = cmpFunc => (
     ? ((a, b) => b.config.enabled - a.config.enabled || cmpFunc(a, b))
     : cmpFunc
 );
-Object.keys(filters).forEach(prop => {
+filters::forEachKey(prop => {
   hookSetting(`filters.${prop}`, { target: filters, prop });
 });
 


### PR DESCRIPTION
Follow-up to #806.

It was remembering the entire change history and thus mistakenly aggressive in avoiding to send the updates, but what we really need is only to check for the last set value in each frame because this value is what's being sent to all other tabs/frames during the current broadcast call.

Added ::forEachKey() for consistency but there are only 3 calls so maybe there was no need? On the other hand, the concise form looks so good.

Reverted objectSet's support of an array because `openers` can use an object for frameId just fine.