### PR TITLE
fix(objectSet): set an array by default if key is number

### DIFF
--- a/src/common/object.js
+++ b/src/common/object.js
@@ -25,7 +25,7 @@ export function objectSet(obj, rawKey, val) {
   let sub = root;
   const lastKey = keys.pop();
   keys.forEach((key) => {
-    sub = sub[key] || (sub[key] = {});
+    sub = sub[key] || (sub[key] = /^\d+$/.test(key) ? [] : {});
   });
   if (typeof val === 'undefined') {
     delete sub[lastKey];


### PR DESCRIPTION
```js
objectSet({}, ['a', 1], 'v') // -> { a: [undefined, 'v'] }
objectSet({}, ['a', '1'], 'v') // -> { a: [undefined, 'v'] }
objectSet({}, ['a', 'b'], 'v') // -> { a: { b: 'v' } }
```

With this we don't have to use the double array hack.
This is also the default behavior of `lodash.set`, which this function is trying to mimic.