### PR TITLE
refactor: restore simple hookSetting, prefetch options

### DIFF
--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -110,3 +110,10 @@ if (!global.browser?.runtime?.sendMessage) {
   };
   global.browser = wrapAPIs(chrome, meta);
 }
+// prefetch the options while the current extension page loads
+/* global browser */
+if (browser.tabs) {
+  global.allOptions = browser.runtime.sendMessage({ cmd: 'GetAllOptions' })
+  .then(({ data }) => data)
+  .catch(() => {});
+}

--- a/src/common/hook-setting.js
+++ b/src/common/hook-setting.js
@@ -13,21 +13,12 @@ options.hook((data) => {
 });
 
 /**
- * When an option is updated elsewhere (or when a yet unresolved options.ready will be fired),
- * calls the specified `update` function or assigns the specified `prop` in `target` object.
- * Also, when the latter mode is used, option.get() is called explicitly right away,
- * but only if options.ready is resolved or `transform` function is specified.
- * @param {string} key - option name
- * @param {function(value) | { target, prop, transform }} update - either a function or the config object
- * @return {function}
- */
+ option.get() is called even if it's not ready (a null or default value will be used),
+ which shouldn't happen usually as we retrieve the options in browser.js the first thing,
+ so either do `await options.ready` beforehand or handle the empty/default value inside update()
+*/
 export default function hookSetting(key, update) {
-  const { target } = update;
-  if (target) {
-    const { prop, transform } = update;
-    update = value => { target[prop] = transform ? transform(value) : value; };
-    if (transform || options.ready.indeed) update(options.get(key));
-  }
+  update(options.get(key));
   const list = hooks[key] || (hooks[key] = []);
   list.push(update);
   return () => {

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -4,8 +4,10 @@ import { forEachEntry, objectGet, objectSet } from './object';
 
 let options = {};
 const hooks = initHooks();
-const ready = sendCmd('GetAllOptions', null, { retry: true })
+const ready = (global.allOptions || Promise.resolve())
+.then((data) => data || sendCmd('GetAllOptions', null, { retry: true }))
 .then((data) => {
+  delete global.allOptions;
   ready.indeed = true; // a workaround for inability to query native Promise state
   options = data;
   if (data) hooks.fire(data);

--- a/src/common/ui/setting-check.vue
+++ b/src/common/ui/setting-check.vue
@@ -35,8 +35,8 @@ export default {
     },
   },
   async created() {
-    await options.ready;
-    this.revoke = hookSetting(this.name, { target: this, prop: 'value' });
+    if (!options.ready.indeed) await options.ready;
+    this.revoke = hookSetting(this.name, val => { this.value = val; });
     this.$watch('value', this.onChange);
   },
   beforeDestroy() {

--- a/src/common/ui/setting-text.vue
+++ b/src/common/ui/setting-text.vue
@@ -31,12 +31,13 @@ export default {
       error: null,
     };
   },
-  created() {
-    const transform = this.json
+  async created() {
+    if (!options.ready.indeed) await options.ready;
+    const handle = this.json
       ? (value => JSON.stringify(value, null, '  '))
       // XXX compatible with old data format
       : (value => (Array.isArray(value) ? value.join('\n') : value || ''));
-    this.revoke = hookSetting(this.name, { target: this, prop: 'value', transform });
+    this.revoke = hookSetting(this.name, val => { this.value = handle(val); });
     if (this.json) this.$watch('value', this.parseJson);
   },
   beforeDestroy() {

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -178,8 +178,10 @@ const combinedCompare = cmpFunc => (
     ? ((a, b) => b.config.enabled - a.config.enabled || cmpFunc(a, b))
     : cmpFunc
 );
-filters::forEachKey(prop => {
-  hookSetting(`filters.${prop}`, { target: filters, prop });
+filters::forEachKey(key => {
+  hookSetting(`filters.${key}`, (val) => {
+    filters[key] = val;
+  });
 });
 
 const MAX_BATCH_DURATION = 100;

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -170,10 +170,10 @@ export default {
   },
   async created() {
     this.revokers = [];
-    await options.ready;
+    if (!options.ready.indeed) await options.ready;
     items.forEach((item) => {
-      const { name, normalize: transform } = item;
-      this.revokers.push(hookSetting(name, { target: settings, prop: name, transform }));
+      const { name, normalize } = item;
+      this.revokers.push(hookSetting(name, val => { settings[name] = normalize(val); }));
       this.$watch(() => settings[name], debounce(this.getUpdater(item), 300));
     });
   },


### PR DESCRIPTION
The benefit of this approach is that it's easier to see usages of a symbol, particularly via "Find usages" command in IDE.

Added: browser.js prefetches the options while an extension page loads to drastically reduce the probability of options being not ready. It reduces the UI flicker, for example [re]loading `options/index.html#settings` now shows the real settings in the first paint of the page.