### PR TITLE
feat: per-script update notification option

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -353,6 +353,9 @@ labelNoSearchScripts:
 labelNotifyUpdates:
   description: Option to show notification when script is updated.
   message: Notify script updates
+labelNotifyUpdatesGlobal:
+  description: Option to prioritize global notification option over script's setting.
+  message: ignore per-script notification ("settings" tab in editor)
 labelPopupSort:
   description: Label in the VM settings tab for script list sort order in popup
   message: Sort scripts in popup by $1

--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -602,6 +602,9 @@ titleSearchHint:
   message: |-
     * <Enter> key adds the text to autocomplete history
     * RegExp syntax is supported: /re/ and /re/flags
+useGlobalSetting:
+  description: Option to use the global setting for something that's customizable per-script.
+  message: Use global setting
 valueLabelKey:
   description: Label for key of a script value.
   message: Key (string)

--- a/src/background/utils/db.js
+++ b/src/background/utils/db.js
@@ -573,7 +573,7 @@ export async function vacuum() {
  * @property {Boolean} enabled - stored as 0 or 1
  * @property {Boolean} removed - stored as 0 or 1
  * @property {Boolean} shouldUpdate - stored as 0 or 1
- * @property {Boolean | null} notifyUpdates - `null` (default) means "use global setting"
+ * @property {Boolean | null} notifyUpdates - stored as 0 or 1 or null (default) which means "use global setting"
  */
 /** @typedef VMScriptCustom *
  * @property {string[]} exclude

--- a/src/background/utils/db.js
+++ b/src/background/utils/db.js
@@ -573,6 +573,7 @@ export async function vacuum() {
  * @property {Boolean} enabled - stored as 0 or 1
  * @property {Boolean} removed - stored as 0 or 1
  * @property {Boolean} shouldUpdate - stored as 0 or 1
+ * @property {Boolean | null} notifyUpdates - `null` (default) means "use global setting"
  */
 /** @typedef VMScriptCustom *
  * @property {string[]} exclude

--- a/src/background/utils/update.js
+++ b/src/background/utils/update.js
@@ -49,7 +49,7 @@ async function doCheckUpdate(script) {
       code: await downloadUpdate(script),
       update: { checking: false },
     });
-    if (getOption('notifyUpdates')) {
+    if (canNotify(script)) {
       notify({
         title: i18n('titleScriptUpdated'),
         body: i18n('msgScriptUpdated', [update.meta.name || i18n('labelNoName')]),
@@ -107,4 +107,11 @@ async function downloadUpdate(script) {
     });
     sendCmd(CMD_SCRIPT_UPDATE, result);
   }
+}
+
+function canNotify(script) {
+  const allowed = getOption('notifyUpdates');
+  return getOption('notifyUpdatesGlobal')
+    ? allowed
+    : script.config.notifyUpdates ?? allowed;
 }

--- a/src/common/object.js
+++ b/src/common/object.js
@@ -48,9 +48,10 @@ export function objectPurify(obj) {
   return obj;
 }
 
-export function objectPick(obj, keys) {
+export function objectPick(obj, keys, transform) {
   return keys.reduce((res, key) => {
-    const value = obj ? obj[key] : null;
+    let value = obj?.[key];
+    if (transform) value = transform(value);
     if (value != null) res[key] = value;
     return res;
   }, {});

--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -19,6 +19,7 @@ export default {
   customCSS: null,
   importSettings: true,
   notifyUpdates: false,
+  notifyUpdatesGlobal: false, // `true` ignores script.config.notifyUpdates
   version: null,
   /** @type 'auto' | 'page' | 'content' */
   defaultInjectInto: INJECT_AUTO,

--- a/src/common/ui/style/style.css
+++ b/src/common/ui/style/style.css
@@ -114,20 +114,6 @@ textarea {
     }
   }
 }
-input[type=checkbox]:indeterminate::after {
-  content: "?";
-  font-weight: bold;
-  font-size: 11px;
-  line-height: 1;
-  color: var(--fg);
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  margin: auto;
-  position: absolute;
-  text-align: center;
-}
 code {
   padding: 0 .2em;
   background: hsla(50, 100%, 50%, .35);

--- a/src/common/ui/style/style.css
+++ b/src/common/ui/style/style.css
@@ -114,6 +114,20 @@ textarea {
     }
   }
 }
+input[type=checkbox]:indeterminate::after {
+  content: "?";
+  font-weight: bold;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--fg);
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: auto;
+  position: absolute;
+  text-align: center;
+}
 code {
   padding: 0 .2em;
   background: hsla(50, 100%, 50%, .35);

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -157,10 +157,10 @@ export default {
     }
     const { custom, config } = this.script;
     this.settings = {
-      config: objectPick(config, [
-        'notifyUpdates',
-        'shouldUpdate',
-      ]),
+      config: {
+        notifyUpdates: `${config.notifyUpdates ?? ''}`,
+        shouldUpdate: config.shouldUpdate,
+      },
       custom: {
         ...objectPick(custom, CUSTOM_PROPS),
         ...objectPick(custom, CUSTOM_LISTS, fromList),
@@ -174,11 +174,15 @@ export default {
   methods: {
     async save() {
       const { config, custom } = this.settings;
+      const { notifyUpdates } = config;
       try {
         const id = this.script?.props?.id;
         const res = await sendCmd('ParseScript', {
           id,
-          config,
+          config: {
+            ...config,
+            notifyUpdates: notifyUpdates ? +notifyUpdates : null,
+          },
           code: this.code,
           custom: {
             ...objectPick(custom, CUSTOM_PROPS),

--- a/src/options/views/edit/settings.vue
+++ b/src/options/views/edit/settings.vue
@@ -6,10 +6,10 @@
         <input type="checkbox" v-model="config.shouldUpdate">
         <span v-text="i18n('labelAllowUpdate')"></span>
       </label>
-      <label class="ml-2">
-        <span v-text="i18n('labelNotifyUpdates')"/>
+      <label class="flex">
+        <span v-text="i18n('labelNotifyUpdates')" class="mr-1"/>
         <select v-model="config.notifyUpdates">
-          <option value="" v-text="i18n('useGlobalSetting')"></option>
+          <option value="" v-text="i18n('useGlobalSetting')"/>
           <option value="1" v-text="i18n('buttonEnable')"/>
           <option value="0" v-text="i18n('buttonDisable')"/>
         </select>

--- a/src/options/views/edit/settings.vue
+++ b/src/options/views/edit/settings.vue
@@ -6,6 +6,11 @@
         <input type="checkbox" v-model="config.shouldUpdate">
         <span v-text="i18n('labelAllowUpdate')"></span>
       </label>
+      <label class="ml-2">
+        <input type="checkbox" v-model="config.notifyUpdates"
+               :indeterminate.prop="config.notifyUpdates == null">
+        <span v-text="i18n('labelNotifyUpdates')"/>
+      </label>
     </div>
     <h4 v-text="i18n('editLabelMeta')"></h4>
     <div class="form-group flex">
@@ -113,6 +118,11 @@ export default {
       };
     },
   },
+  watch: {
+    'config.notifyUpdates'(val, oldVal) {
+      if (val && oldVal === false) this.config.notifyUpdates = null;
+    },
+  },
 };
 </script>
 
@@ -128,6 +138,9 @@ export default {
     margin-bottom: .5em;
     &.vl-tooltip {
       display: block;
+    }
+    input[type=checkbox] + span {
+      user-select: none;
     }
     input[type=text] {
       display: block;

--- a/src/options/views/edit/settings.vue
+++ b/src/options/views/edit/settings.vue
@@ -7,9 +7,12 @@
         <span v-text="i18n('labelAllowUpdate')"></span>
       </label>
       <label class="ml-2">
-        <input type="checkbox" v-model="config.notifyUpdates"
-               :indeterminate.prop="config.notifyUpdates == null">
         <span v-text="i18n('labelNotifyUpdates')"/>
+        <select v-model="config.notifyUpdates">
+          <option value="" v-text="i18n('useGlobalSetting')"></option>
+          <option value="1" v-text="i18n('buttonEnable')"/>
+          <option value="0" v-text="i18n('buttonDisable')"/>
+        </select>
       </label>
     </div>
     <h4 v-text="i18n('editLabelMeta')"></h4>
@@ -116,11 +119,6 @@ export default {
         updateURL: objectGet(value, 'meta.updateURL') || i18n('hintUseDownloadURL'),
         downloadURL: objectGet(value, 'meta.downloadURL') || objectGet(value, 'custom.lastInstallURL'),
       };
-    },
-  },
-  watch: {
-    'config.notifyUpdates'(val, oldVal) {
-      if (val && oldVal === false) this.config.notifyUpdates = null;
     },
   },
 };

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -14,6 +14,10 @@
           <setting-check name="notifyUpdates" />
           <span v-text="i18n('labelNotifyUpdates')"></span>
         </label>
+        <label class="ml-2">
+          <setting-check name="notifyUpdatesGlobal" />
+          <span v-text="i18n('labelNotifyUpdatesGlobal')"></span>
+        </label>
       </div>
       <div class="mb-1">
         <label>


### PR DESCRIPTION
Fixes #333.

* A tri-state option to customize update notifications per script. The indeterminate state `?` means "not configured" so the current global value in Violentmonkey's settings will be used.

  ![image](https://user-images.githubusercontent.com/1310400/72669800-2ec56980-3a47-11ea-884d-b666da0ee1a6.png)

* A global option to ignore the per-script option. Isn't really useful normally, I'd say it's an emergency kill-switch to disable the notifications globally and ignore the per-script option.

  ![image](https://user-images.githubusercontent.com/1310400/72669795-1ead8a00-3a47-11ea-9a3c-38cdbccbd270.png)

Collateral:

* converted two related methods to async
* added value transformation function as a third parameter in `objectPick`

Didn't test it extensively yet.