### PR TITLE
chore: enable babel loose mode

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -6,6 +6,7 @@ module.exports = {
         modules: false,
       },
       useBuiltIns: false,
+      loose: true,
     }],
   ],
   plugins: [


### PR DESCRIPTION
Since we use object spread inside plain objects, its behavior is identical to Object.assign, so we can get rid of the huge polyfill added by Babel in each module where spread is used. Not chunks but modules, meaning several kB of slow and bloated and unnecessary polyfills overall.

Edit: we'll enable babel loose mode globally

the only affected transforms/plugins for our browserlist:
* object-rest-spread will use Object.assign
* nullish-coalescing-operator will use == with null