### PR TITLE
refactor: invoke mapEntry callback with map()-like args

### DIFF
--- a/src/background/utils/options.js
+++ b/src/background/utils/options.js
@@ -13,7 +13,7 @@ Object.assign(commands, {
   },
   /** @return {Object} */
   GetOptions(data) {
-    return data::mapEntry(key => getOption(key));
+    return data::mapEntry(([key]) => getOption(key));
   },
   /** @return {void} */
   SetOptions(data) {

--- a/src/background/utils/script.js
+++ b/src/background/utils/script.js
@@ -65,7 +65,7 @@ const metaTypes = {
 };
 export function parseMeta(code) {
   // initialize meta
-  const meta = metaTypes::mapEntry((key, value) => value.default());
+  const meta = metaTypes::mapEntry(([, value]) => value.default());
   const metaBody = code.match(METABLOCK_RE)[1] || '';
   metaBody.replace(/(?:^|\n)\s*\/\/\x20(@\S+)(.*)/g, (_match, rawKey, rawValue) => {
     const [keyName, locale] = rawKey.slice(1).split(':');

--- a/src/common/object.js
+++ b/src/common/object.js
@@ -56,25 +56,25 @@ export function objectPick(obj, keys) {
   }, {});
 }
 
-// invoked as obj::mapEntry((key, value) => transformedValue)
+// invoked as obj::mapEntry(([key, value], i, allEntries) => transformedValue)
 export function mapEntry(func) {
-  return Object.entries(this).reduce((res, [key, value]) => {
-    res[key] = func(key, value);
+  return Object.entries(this).reduce((res, entry, i, allEntries) => {
+    res[entry[0]] = func(entry, i, allEntries);
     return res;
   }, {});
 }
 
-// invoked as obj::forEachEntry(([key, value]) => {})
+// invoked as obj::forEachEntry(([key, value], i, allEntries) => {})
 export function forEachEntry(func) {
   if (this) Object.entries(this).forEach(func);
 }
 
-// invoked as obj::forEachKey(key => {})
+// invoked as obj::forEachKey(key => {}, i, allKeys)
 export function forEachKey(func) {
   if (this) Object.keys(this).forEach(func);
 }
 
-// invoked as obj::forEachValue(value => {})
+// invoked as obj::forEachValue(value => {}, i, allValues)
 export function forEachValue(func) {
   if (this) Object.values(this).forEach(func);
 }

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -37,7 +37,7 @@ Object.assign(handlers, {
     allScriptIds.push(...ids);
     if (isTop) {
       mutex.resolve();
-      store.commands = data.menus::mapEntry((key, value) => Object.keys(value).sort());
+      store.commands = data.menus::mapEntry(([, value]) => Object.keys(value).sort());
     }
     if (ids.length) {
       // frameScripts may be appended multiple times if iframes have unique scripts


### PR DESCRIPTION
For consistency with forEachEntry and in order not to deviate from standard Object.keys+map.