### PR TITLE
fix: use sendTabCmd to suppress the error

### DIFF
--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -1,5 +1,7 @@
 import Vue from 'vue';
-import { i18n, sendCmd, getActiveTab } from '#/common';
+import {
+  getActiveTab, i18n, sendCmd, sendTabCmd,
+} from '#/common';
 import { INJECTABLE_TAB_URL_RE } from '#/common/consts';
 import handlers from '#/common/handlers';
 import { mapEntry } from '#/common/object';
@@ -49,7 +51,7 @@ Object.assign(handlers, {
 getActiveTab()
 .then(async ({ id, url }) => {
   store.currentTab = { id, url };
-  browser.tabs.sendMessage(id, { cmd: 'GetPopup' });
+  sendTabCmd(id, 'GetPopup');
   if (/^https?:\/\//i.test(url)) {
     const matches = url.match(/:\/\/([^/]*)/);
     const domain = matches[1];


### PR DESCRIPTION
There's an error displayed in the popup (at least in Chrome) because browser.tabs.sendMessage adds a callback to the underlying API function but our content script doesn't respond to GetPopup command so the API complains that the "port was closed". It was working before 15f33f99 fixed wrapAsync() to preserve Promise rejections whereas previously they were silently suppressed in production mode. By "suppressed" I mean they weren't printed in console so there was no way to guess that something is wrong other than manually adding a catch handler.