### PR TITLE
use Proxy for sandboxing

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -42,9 +42,8 @@ Object.assign(commands, {
     return data;
   },
   /** @return {Promise<Object>} */
-  async GetInjected(url, src) {
-    const { id: tabId } = src.tab || {};
-    if (src.frameId === 0) resetValueOpener(tabId);
+  async GetInjected(_, { url, tab, frameId }) {
+    if (frameId === 0) resetValueOpener(tab.id);
     const data = {
       isApplied,
       injectInto,
@@ -54,7 +53,7 @@ Object.assign(commands, {
     };
     if (isApplied) {
       const scripts = await (cache.get(`preinject:${url}`) || getScriptsByURL(url));
-      addValueOpener(tabId, src.frameId, Object.keys(scripts.values));
+      addValueOpener(tab.id, frameId, Object.keys(scripts.values));
       Object.assign(data, scripts);
     }
     return data;

--- a/src/common/consts.js
+++ b/src/common/consts.js
@@ -2,16 +2,13 @@ export const INJECT_AUTO = 'auto';
 export const INJECT_PAGE = 'page';
 export const INJECT_CONTENT = 'content';
 
-export const INJECT_INTERNAL_PAGE = 'page';
-export const INJECT_INTERNAL_CONTENT = 'content';
-
 export const INJECT_MAPPING = {
   // `auto` tries to provide `window` from the real page as `unsafeWindow`
-  [INJECT_AUTO]: [INJECT_INTERNAL_PAGE, INJECT_INTERNAL_CONTENT],
+  [INJECT_AUTO]: [INJECT_PAGE, INJECT_CONTENT],
   // inject into page context
-  [INJECT_PAGE]: [INJECT_INTERNAL_PAGE],
+  [INJECT_PAGE]: [INJECT_PAGE],
   // inject into content context only
-  [INJECT_CONTENT]: [INJECT_INTERNAL_CONTENT],
+  [INJECT_CONTENT]: [INJECT_CONTENT],
 };
 
 export const CMD_SCRIPT_ADD = 'AddScript';

--- a/src/injected/content/clipboard.js
+++ b/src/injected/content/clipboard.js
@@ -1,11 +1,11 @@
 import { sendCmd } from '../utils';
-import { addEventListener, logging } from '../utils/helpers';
+import { addEventListener, describeProperty, logging } from '../utils/helpers';
 import bridge from './bridge';
 
 // old Firefox defines it on a different prototype so we'll just grab it from document directly
 const { execCommand } = document;
 const { setData } = DataTransfer.prototype;
-const getClipboardData = Object.getOwnPropertyDescriptor(ClipboardEvent.prototype, 'clipboardData').get;
+const { get: getClipboardData } = describeProperty(ClipboardEvent.prototype, 'clipboardData');
 const { preventDefault, stopImmediatePropagation } = Event.prototype;
 const { removeEventListener } = EventTarget.prototype;
 

--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -2,7 +2,7 @@ import { getUniqId, makePause, isEmpty } from '#/common';
 import { INJECT_PAGE, INJECT_CONTENT } from '#/common/consts';
 import { bindEvents, sendCmd, sendMessage } from '../utils';
 import {
-  setJsonDump, objectKeys, forEach, includes, append, createElementNS, setAttribute, NS_HTML,
+  objectKeys, forEach, includes, append, createElementNS, setAttribute, NS_HTML,
 } from '../utils/helpers';
 import bridge from './bridge';
 import './clipboard';
@@ -22,7 +22,6 @@ export default async function initialize(contentId, webId) {
   // 2) cloneInto is provided by Firefox in content scripts to expose data to the page
   bridge.post = bindEvents(contentId, webId, bridge.onHandle, global.cloneInto);
   bridge.destId = webId;
-  setJsonDump({ native: true });
   const data = await sendCmd('GetInjected', window.location.href, { retry: true });
   const scriptLists = triageScripts(data);
   getPopup();

--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -1,12 +1,12 @@
 import { getUniqId, makePause, isEmpty } from '#/common';
-import { INJECT_PAGE, INJECT_CONTENT } from '#/common/consts';
+import { INJECT_CONTENT } from '#/common/consts';
 import { bindEvents, sendCmd, sendMessage } from '../utils';
 import {
   objectKeys, forEach, includes, append, createElementNS, setAttribute, NS_HTML,
 } from '../utils/helpers';
 import bridge from './bridge';
 import './clipboard';
-import { injectScripts, triageScripts } from './inject';
+import injectScripts from './inject';
 import './notifications';
 import './requests';
 import './tabs';
@@ -18,17 +18,15 @@ const menus = {};
 const { split } = String.prototype;
 
 export default async function initialize(contentId, webId) {
-  // 1) bridge.post may be overriden in injectScripts
+  const data = await sendCmd('GetInjected', null, { retry: true });
+  // 1) bridge.post may be overridden in injectScripts
   // 2) cloneInto is provided by Firefox in content scripts to expose data to the page
   bridge.post = bindEvents(contentId, webId, bridge.onHandle, global.cloneInto);
   bridge.destId = webId;
-  const data = await sendCmd('GetInjected', window.location.href, { retry: true });
-  const scriptLists = triageScripts(data);
+  bridge.isFirefox = data.isFirefox;
+  if (data.scripts) injectScripts(contentId, webId, data);
   getPopup();
   setBadge();
-  if (scriptLists[INJECT_PAGE].length || scriptLists[INJECT_CONTENT].length) {
-    injectScripts(contentId, webId, data, scriptLists);
-  }
 }
 
 bridge.addBackgroundHandlers({

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -11,7 +11,7 @@ import { getUniqId, sendCmd } from '#/common';
 
 import { attachFunction } from '../utils';
 import {
-  forEach, join, jsonDump, setJsonDump, append, createElementNS, NS_HTML,
+  forEach, join, append, createElementNS, NS_HTML,
   charCodeAt, fromCharCode,
 } from '../utils/helpers';
 import bridge from './bridge';
@@ -95,18 +95,12 @@ export function injectScripts(contentId, webId, data, scriptLists) {
   }
   if (injectPage.length) {
     // Avoid using Function::apply in case it is shimmed
-    inject(`(${VMInitInjection}())(${jsonDump(args).slice(1, -1)})`);
+    inject(`(${VMInitInjection}())(${JSON.stringify(args).slice(1, -1)})`);
     bridge.post('LoadScripts', {
       ...data,
       mode: INJECT_PAGE,
       items: injectPage,
     });
-  }
-  if (injectContent.length) {
-    // content script userscripts will run in one of the next event loop cycles
-    // (we use browser.tabs.executeScript) so we need to switch to jsonDumpSafe because
-    // after this point we can't rely on JSON.stringify anymore, see the notes for setJsonDump
-    setJsonDump({ native: false });
   }
 }
 
@@ -119,7 +113,7 @@ function checkInjectable() {
     a.id = domId;
     document.documentElement.appendChild(a);
   };
-  inject(`(${detect})(${jsonDump(id)})`);
+  inject(`(${detect})(${JSON.stringify(id)})`);
   const a = document.querySelector(`#${id}`);
   const injectable = !!a;
   if (a) a.remove();

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -77,8 +77,8 @@ export default function injectScripts(contentId, webId, data) {
     }, INJECT_CONTENT);
   }
   if (injectPage.length) {
-    // Avoid using Function::apply in case it is shimmed
-    inject(`(${VMInitInjection}())(${JSON.stringify(args).slice(1, -1)})`);
+    inject(`(${VMInitInjection}())(${JSON.stringify(args).slice(1, -1)})`,
+      `${window.location.origin}/Violentmonkey.sandbox.js`);
     bridge.post('LoadScripts', {
       ...data,
       mode: INJECT_PAGE,

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -1,8 +1,6 @@
 import {
   INJECT_AUTO,
   INJECT_CONTENT,
-  INJECT_INTERNAL_CONTENT,
-  INJECT_INTERNAL_PAGE,
   INJECT_MAPPING,
   INJECT_PAGE,
   browser,
@@ -29,57 +27,42 @@ bridge.addHandlers({
   InjectMulti: data => data::forEach(injectScript),
 });
 
-export function triageScripts(data) {
+export default function injectScripts(contentId, webId, data) {
+  const injectPage = [];
+  const injectContent = [];
   const scriptLists = {
-    [INJECT_INTERNAL_PAGE]: [],
-    [INJECT_INTERNAL_CONTENT]: [],
+    [INJECT_PAGE]: injectPage,
+    [INJECT_CONTENT]: injectContent,
   };
-  if (data.scripts) {
-    data.scripts = data.scripts.filter(({ meta, props, config }) => {
-      if (!meta.noframes || window.top === window) {
-        bridge.ids.push(props.id);
-        if (config.enabled) {
-          bridge.enabledIds.push(props.id);
-          return true;
-        }
+  let { scripts } = data;
+  scripts = scripts.filter(({ meta, props, config }) => {
+    if (!meta.noframes || window.top === window) {
+      bridge.ids.push(props.id);
+      if (config.enabled) {
+        bridge.enabledIds.push(props.id);
+        return true;
       }
-      return false;
-    });
-    let support;
-    const injectChecking = {
-      [INJECT_INTERNAL_PAGE]: () => {
-        if (!support) support = { injectable: checkInjectable() };
-        return support.injectable;
-      },
-      [INJECT_INTERNAL_CONTENT]: () => true,
-    };
-    data.scripts.forEach((script) => {
-      const injectInto = script.custom.injectInto || script.meta.injectInto || data.injectInto;
-      const internalInjectInto = INJECT_MAPPING[injectInto] || INJECT_MAPPING[INJECT_AUTO];
-      const availableInjectInto = internalInjectInto.find(key => injectChecking[key]?.());
-      scriptLists[availableInjectInto]?.push({ script, injectInto: availableInjectInto });
-    });
-  }
-  return scriptLists;
-}
-
-export function injectScripts(contentId, webId, data, scriptLists) {
-  const props = [];
-  // combining directly to avoid GC due to a big intermediate object
-  const addUniqProp = key => !props.includes(key) && props.push(key);
-  // some browsers may list duplicate props within one window object!
-  [window, global].forEach(wnd => Object.getOwnPropertyNames(wnd).forEach(addUniqProp));
+    }
+    return false;
+  });
+  let injectable;
+  const injectChecking = {
+    // eslint-disable-next-line no-return-assign
+    [INJECT_PAGE]: () => injectable ?? (injectable = checkInjectable()),
+    [INJECT_CONTENT]: () => true,
+  };
+  scripts.forEach((script) => {
+    const injectInto = script.custom.injectInto || script.meta.injectInto || data.injectInto;
+    const internalInjectInto = INJECT_MAPPING[injectInto] || INJECT_MAPPING[INJECT_AUTO];
+    const availableInjectInto = internalInjectInto.find(key => injectChecking[key]?.());
+    scriptLists[availableInjectInto]?.push({ script, injectInto: availableInjectInto });
+  });
   const args = [
     webId,
     contentId,
-    props,
     data.ua,
     data.isFirefox,
   ];
-  bridge.isFirefox = data.isFirefox;
-
-  const injectPage = scriptLists[INJECT_PAGE];
-  const injectContent = scriptLists[INJECT_CONTENT];
   if (injectContent.length) {
     const invokeGuest = VMInitInjection()(...args, bridge.onHandle);
     const postViaBridge = bridge.post;

--- a/src/injected/index.js
+++ b/src/injected/index.js
@@ -1,5 +1,5 @@
 import { getUniqId, sendCmd } from './utils';
-import { addEventListener, match } from './utils/helpers';
+import { addEventListener, describeProperty, match } from './utils/helpers';
 import initialize from './content';
 
 (function main() {
@@ -19,7 +19,7 @@ import initialize from './content';
 
   const { go } = History.prototype;
   const { querySelector } = Document.prototype;
-  const { get: getReadyState } = Object.getOwnPropertyDescriptor(Document.prototype, 'readyState');
+  const { get: getReadyState } = describeProperty(Document.prototype, 'readyState');
   // For installation
   // Firefox does not support `onBeforeRequest` for `file:`
   async function checkJS() {

--- a/src/injected/utils/helpers.js
+++ b/src/injected/utils/helpers.js
@@ -9,20 +9,20 @@ export const {
 } = global;
 
 export const {
-  filter, findIndex, forEach, includes, indexOf, join, map, push, shift,
+  concat, filter, findIndex, forEach, includes, indexOf, join, map, push, shift,
   // arraySlice, // to differentiate from String::slice which we use much more often
 } = Array.prototype;
 
 export const {
   keys: objectKeys, values: objectValues, entries: objectEntries,
-  assign, defineProperty, defineProperties,
+  assign, defineProperty, defineProperties, getOwnPropertyDescriptor: describeProperty,
 } = Object;
 export const { charCodeAt, match, slice } = String.prototype;
 export const { toString: objectToString } = Object.prototype;
 const { toString: numberToString } = Number.prototype;
 const { replace } = String.prototype;
 export const { fromCharCode } = String;
-export const { addEventListener } = EventTarget.prototype;
+export const { addEventListener, removeEventListener } = EventTarget.prototype;
 export const { append, setAttribute } = Element.prototype;
 export const { createElementNS } = Document.prototype;
 export const logging = assign({}, console);

--- a/src/injected/web/gm-wrapper.js
+++ b/src/injected/web/gm-wrapper.js
@@ -1,44 +1,30 @@
-import {
-  INJECT_INTERNAL_PAGE, INJECT_INTERNAL_CONTENT, METABLOCK_RE,
-} from '#/common/consts';
+import { INJECT_CONTENT, METABLOCK_RE } from '#/common/consts';
 import bridge from './bridge';
 import {
-  forEach, includes, match, objectKeys, map, defineProperties, filter, defineProperty, slice,
+  filter, forEach, includes, map, match, slice, assign, defineProperty, defineProperties,
+  describeProperty, objectKeys, addEventListener, removeEventListener,
 } from '../utils/helpers';
-import { createGmApiProps, propertyFromValue } from './gm-api';
+import { makeGmApi } from './gm-api';
 
+const { Proxy } = global;
+const { hasOwnProperty: has } = Object.prototype;
 const { startsWith } = String.prototype;
 
-// - Chrome, `global === window`
-// - Firefox, `global` is a sandbox, `global.window === window`:
-//   - some properties (like `isFinite`) are defined in `global` but not `window`
-//   - all `window` properties can be accessed from `global`
-
-// store the initial eval now (before the page scripts run) just in case
-let wrapperInfo = {
-  global,
-  eval: global.eval, // eslint-disable-line no-eval
-  unsafeWindow: {
-    // run script in page context
-    // `unsafeWindow === pageWindow === pageGlobal`
-    [INJECT_INTERNAL_PAGE]: global,
-    // run script in content context
-    // `unsafeWindow === contentGlobal, contentGlobal.window === contentWindow`
-    [INJECT_INTERNAL_CONTENT]: global,
-  },
-};
-
 let gmApi;
+let gm4Api;
+let componentUtils;
+const propertyToString = {
+  toString: () => '[Violentmonkey property]',
+};
 
 export function deletePropsCache() {
   // let GC sweep the no longer necessary stuff
   gmApi = null;
-  wrapperInfo = null;
-  bridge.props = null;
+  gm4Api = null;
+  componentUtils = null;
 }
 
 export function wrapGM(script, code, cache, injectInto) {
-  const unsafeWindow = wrapperInfo.unsafeWindow[injectInto];
   // Add GM functions
   // Reference: http://wiki.greasespot.net/Greasemonkey_Manual:API
   const gm = {};
@@ -47,206 +33,272 @@ export function wrapGM(script, code, cache, injectInto) {
   if (!grant.length || (grant.length === 1 && grant[0] === 'none')) {
     // @grant none
     grant.length = 0;
-    gm.window = unsafeWindow;
+    gm.window = global;
   } else {
-    thisObj = getWrapper();
-    thisObj.wrappedJSObject = window.wrappedJSObject;
+    thisObj = makeGlobalWrapper();
     gm.window = thisObj;
   }
   if (grant::includes('window.close')) {
     gm.window.close = () => bridge.post('TabClose');
   }
   const resources = script.meta.resources || {};
-  const gmInfo = propertyFromValue({
-    uuid: script.props.uuid,
+  const gmInfo = makeGmInfo(script, code, resources, injectInto);
+  const gm4Props = { info: { value: gmInfo } };
+  const gm4Object = {};
+  const grantedProps = {
+    ...componentUtils || (componentUtils = makeComponentUtils()),
+    unsafeWindow: { value: global },
+    GM_info: { value: gmInfo },
+    GM: { value: gm4Object },
+  };
+  const context = {
+    cache,
+    script,
+    resources,
+    id: script.props.id,
+    pathMap: script.custom.pathMap || {},
+    urls: {},
+  };
+  if (!gmApi) [gmApi, gm4Api] = makeGmApi();
+  grant::forEach((name) => {
+    const gm4name = name::startsWith('GM.') && name::slice(3);
+    const gm4 = gm4Api[gm4name];
+    const method = gmApi[gm4 ? `GM_${gm4.alias || gm4name}` : name];
+    if (method) {
+      const prop = makeGmMethodProp(method, context, gm4?.async);
+      if (gm4) gm4Props[gm4name] = prop;
+      else grantedProps[name] = prop;
+    }
+  });
+  defineProperties(gm4Object, gm4Props);
+  defineProperties(gm, grantedProps);
+  return { gm, thisObj, keys: objectKeys(grantedProps) };
+}
+
+function makeGmInfo({ config, meta, props }, code, resources, injectInto) {
+  return {
+    uuid: props.uuid,
     scriptMetaStr: code::match(METABLOCK_RE)[1] || '',
-    scriptWillUpdate: !!script.config.shouldUpdate,
+    scriptWillUpdate: !!config.shouldUpdate,
     scriptHandler: 'Violentmonkey',
     version: bridge.version,
     injectInto,
     platform: { ...bridge.ua },
     script: {
-      description: script.meta.description || '',
-      excludes: [...script.meta.exclude],
-      includes: [...script.meta.include],
-      matches: [...script.meta.match],
-      name: script.meta.name || '',
-      namespace: script.meta.namespace || '',
+      description: meta.description || '',
+      excludes: [...meta.exclude],
+      includes: [...meta.include],
+      matches: [...meta.match],
+      name: meta.name || '',
+      namespace: meta.namespace || '',
       resources: objectKeys(resources)::map(name => ({
         name,
         url: resources[name],
       })),
-      runAt: script.meta.runAt || '',
+      runAt: meta.runAt || '',
       unwrap: false, // deprecated, always `false`
-      version: script.meta.version || '',
+      version: meta.version || '',
     },
-  });
-  const gm4props = { info: gmInfo };
-  const grantedProps = {
-    unsafeWindow: propertyFromValue(unsafeWindow),
-    GM_info: gmInfo,
-    GM: propertyFromValue({}),
   };
-  let selfData;
-  if (!gmApi) gmApi = createGmApiProps();
-  grant::forEach((name) => {
-    const gm4name = name::startsWith('GM.') && name::slice(3);
-    const gm4 = gmApi.gm4[gm4name];
-    if (gm4) name = `GM_${gm4.alias || gm4name}`;
-    let prop = gmApi.boundProps[name];
-    if (prop) {
-      const gmFunction = prop.value;
-      prop = { ...prop };
-      prop.value = gm4 && gm4.async
-        ? (async (...args) => gmFunction.apply(selfData, args))
-        : ((...args) => gmFunction.apply(selfData, args));
-      selfData = true;
-    } else {
-      prop = gmApi.props[name];
-    }
-    if (!prop) return;
-    if (gm4) gm4props[gm4name] = prop;
-    else grantedProps[name] = prop;
-  });
-  if (selfData) {
-    selfData = {
-      cache,
-      script,
-      resources,
-      id: script.props.id,
-      pathMap: script.custom.pathMap || {},
-      urls: {},
-    };
-  }
-  defineProperties(grantedProps.GM.value, gm4props);
+}
+
+function makeGmMethodProp(gmMethod, context, isAsync) {
   return {
-    thisObj,
-    wrapper: defineProperties(gm, grantedProps),
-    keys: objectKeys(grantedProps),
+    // keeping the native console.log intact
+    value: gmMethod === gmApi.GM_log ? gmMethod : assign(
+      isAsync
+        ? (async (...args) => context::gmMethod(...args))
+        : ((...args) => context::gmMethod(...args)),
+      propertyToString,
+    ),
   };
 }
 
-function createWrapperMethods(info) {
-  const { global } = info;
-  const methods = {};
-  [
-    // 'uneval',
-    'isFinite',
-    'isNaN',
-    'parseFloat',
-    'parseInt',
-    'decodeURI',
-    'decodeURIComponent',
-    'encodeURI',
-    'encodeURIComponent',
-
-    'addEventListener',
-    'alert',
-    'atob',
-    'blur',
-    'btoa',
-    'clearInterval',
-    'clearTimeout',
-    'close',
-    'confirm',
-    'dispatchEvent',
-    'fetch',
-    'find',
-    'focus',
-    'getComputedStyle',
-    'getDefaultComputedStyle', // Non-standard, Firefox only, used by jQuery
-    'getSelection',
-    'matchMedia',
-    'moveBy',
-    'moveTo',
-    'open',
-    'openDialog',
-    'postMessage',
-    'print',
-    'prompt',
-    'removeEventListener',
-    'requestAnimationFrame',
-    'resizeBy',
-    'resizeTo',
-    'scroll',
-    'scrollBy',
-    'scrollByLines',
-    'scrollByPages',
-    'scrollTo',
-    'setInterval',
-    'setTimeout',
-    'stop',
-  ]::forEach((name) => {
-    const method = global[name];
-    if (method) {
-      methods[name] = (...args) => method.apply(global, args);
-    }
-  });
-  info.methods = methods;
-}
-
+// https://html.spec.whatwg.org/multipage/window-object.html#the-window-object
+// https://w3c.github.io/webappsec-secure-contexts/#monkey-patching-global-object
+// https://compat.spec.whatwg.org/#windoworientation-interface
+const readonlyGlobals = [
+  'applicationCache',
+  'closed',
+  'customElements',
+  'frameElement',
+  'history',
+  'isSecureContext',
+  'navigator',
+  'orientation',
+  'styleMedia',
+];
+// https://html.spec.whatwg.org/multipage/window-object.html
+// https://w3c.github.io/webappsec-trusted-types/dist/spec/#extensions-to-the-window-interface
+const unforgeableGlobals = [
+  'document',
+  'location',
+  'top',
+  'trustedTypes',
+  'window',
+];
+// the index strings that look exactly like integers can't be forged
+// but for example '011' doesn't look like 11 so it's allowed
+const isUnforgeableFrameIndex = name => typeof name !== 'symbol' && /^(0|[1-9]\d+)$/.test(name);
+// These can't run with an arbitrary object in `this` such as our wrapper
+// https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects
+// https://developer.mozilla.org/docs/Web/API/Window
+const boundGlobals = [
+  'addEventListener',
+  'alert',
+  'atob',
+  'blur',
+  'btoa',
+  'clearInterval',
+  'clearTimeout',
+  'close',
+  'confirm',
+  'dispatchEvent',
+  'fetch',
+  'find',
+  'focus',
+  'getComputedStyle',
+  'getDefaultComputedStyle', // Non-standard, Firefox only, used by jQuery
+  'getSelection',
+  'matchMedia',
+  'moveBy',
+  'moveTo',
+  'open',
+  'openDialog',
+  'postMessage',
+  'print',
+  'prompt',
+  'removeEventListener',
+  'requestAnimationFrame',
+  'resizeBy',
+  'resizeTo',
+  'scroll',
+  'scrollBy',
+  'scrollByLines',
+  'scrollByPages',
+  'scrollTo',
+  'setInterval',
+  'setTimeout',
+  'stop',
+];
+const boundGlobalsRunner = {
+  apply: (fn, thisArg, args) => fn.apply(global, args),
+};
 /**
  * @desc Wrap helpers to prevent unexpected modifications.
  */
-function getWrapper() {
-  const { global } = wrapperInfo;
-  if (!wrapperInfo.methods) createWrapperMethods(wrapperInfo);
-  // http://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects
-  // http://developer.mozilla.org/docs/Web/API/Window
-  const wrapper = {
-    // `eval` should be called directly so that it is run in current scope
-    eval: wrapperInfo.eval,
-    ...wrapperInfo.methods,
-  };
-  if (!wrapperInfo.propsToWrap) {
-    wrapperInfo.propsToWrap = bridge.props::filter(p => !(p in wrapper));
-    bridge.props = null;
-  }
-
-  function wrapWindowValue(value) {
-    // Return the window wrapper if the original value is the real `window`
-    // so that libraries depending on `window` will work as expected.
-    return value === window ? wrapper : value;
-  }
-
-  function defineProtectedProperty(name) {
-    let modified = false;
-    let value;
-    defineProperty(wrapper, name, {
-      get() {
-        if (!modified) value = wrapWindowValue(global[name]);
-        return value;
-      },
-      set(val) {
-        modified = true;
-        value = val;
-      },
-      // Allow `defineProperty` and its family members
-      configurable: true,
-    });
-  }
-
-  function defineReactedProperty(name) {
-    defineProperty(wrapper, name, {
-      get() {
-        return wrapWindowValue(global[name]);
-      },
-      set(val) {
-        global[name] = val;
-      },
-    });
-  }
-
-  // Wrap properties
-  // A major GC may hit here no matter how we define props
-  // all at once, in batches of 10, 100, 500, or one by one.
-  // TODO: try Proxy API if userscripts wouldn't notice the difference
-  wrapperInfo.propsToWrap::forEach((name) => {
-    if (name::startsWith('on')) {
-      defineReactedProperty(name);
-    } else {
-      defineProtectedProperty(name);
-    }
+function makeGlobalWrapper() {
+  const props = {};
+  const events = {};
+  const deleted = {};
+  // - Chrome, `global === window`
+  // - Firefox, `global` is a sandbox, `global.window === window`:
+  //   - some properties (like `isFinite`) are defined in `global` but not `window`
+  //   - all `window` properties can be accessed from `global`
+  const wrapper = new Proxy(props, {
+    defineProperty(_, name, info) {
+      if (unforgeableGlobals::includes(name) || isUnforgeableFrameIndex(name)) return false;
+      defineProperty(props, name, info);
+      if (name::startsWith('on')) {
+        setEventHandler(name::slice(2));
+      }
+      delete deleted[name];
+      return true;
+    },
+    deleteProperty(_, name) {
+      if (unforgeableGlobals::includes(name) || deleted::has(name)) return false;
+      if (isUnforgeableFrameIndex(name)) return true;
+      if (global::has(name)) deleted[name] = 1;
+      return delete props[name];
+    },
+    get(_, name) {
+      if (!deleted::has(name)) {
+        const value = props[name];
+        return value !== undefined || props::has(name) ? value : resolveProp(name);
+      }
+    },
+    getOwnPropertyDescriptor(_, name) {
+      const desc = describeProperty(props, name) ?? describeProperty(wrapper[name]);
+      if (desc?.value === window) desc.value = wrapper;
+      return desc;
+    },
+    has(_, name) {
+      return props::has(name)
+        || !deleted::has(name) && global::has(name);
+    },
+    ownKeys() {
+      const modifiedKeys = objectKeys(props);
+      const deletedKeys = objectKeys(deleted);
+      let keys = objectKeys(global);
+      if (deletedKeys.length || modifiedKeys.length) {
+        keys = keys::filter(k => !deletedKeys::includes(k) && !modifiedKeys::includes(k));
+      }
+      return modifiedKeys.length ? [...keys, ...modifiedKeys] : keys;
+    },
+    set(_, name, value) {
+      if (unforgeableGlobals::includes(name)) return false;
+      delete deleted[name];
+      if (readonlyGlobals::includes(name) || isUnforgeableFrameIndex(name)) return true;
+      props[name] = value;
+      if (name::startsWith('on') && window::has(name)) {
+        setEventHandler(name::slice(2), value);
+      }
+      return true;
+    },
   });
+  function resolveProp(name) {
+    let value = global[name];
+    if (value === window) {
+      value = wrapper;
+    } else if (boundGlobals::includes(name)) {
+      value = new Proxy(value, boundGlobalsRunner);
+      props[name] = value;
+    }
+    return value;
+  }
+  function setEventHandler(name, value) {
+    window::removeEventListener(name, events[name]);
+    if (typeof value === 'function') {
+      // the handler will be unique so that one script couldn't remove something global
+      // like console.log set by another script
+      window::addEventListener(name, events[name] = (...args) => value.apply(window, args));
+    } else {
+      delete events[name];
+    }
+  }
   return wrapper;
+}
+
+// Adding the polyfills in Chrome (always as it doesn't provide them)
+// and in Firefox page mode (while preserving the native ones in content mode)
+// for compatibility with many [old] scripts that use these utils blindly
+function makeComponentUtils() {
+  const source = bridge.mode === INJECT_CONTENT && global;
+  return {
+    cloneInto: {
+      value: source.cloneInto || assign(
+        (obj) => obj,
+        propertyToString,
+      ),
+    },
+    createObjectIn: {
+      value: source.createObjectIn || assign(
+        (targetScope, { defineAs } = {}) => {
+          const obj = {};
+          if (defineAs) targetScope[defineAs] = obj;
+          return obj;
+        },
+        propertyToString,
+      ),
+    },
+    exportFunction: {
+      value: source.exportFunction || assign(
+        (func, targetScope, { defineAs } = {}) => {
+          if (defineAs) targetScope[defineAs] = func;
+          return func;
+        },
+        propertyToString,
+      ),
+    },
+  };
 }

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -14,13 +14,11 @@ import './tabs';
 export default function initialize(
   webId,
   contentId,
-  props,
   ua,
   isFirefox,
   invokeHost,
 ) {
   let invokeGuest;
-  bridge.props = props;
   bridge.ua = ua;
   bridge.isFirefox = isFirefox;
   if (invokeHost) {

--- a/src/injected/web/load-scripts.js
+++ b/src/injected/web/load-scripts.js
@@ -3,7 +3,7 @@ import { INJECT_CONTENT } from '#/common/consts';
 import { attachFunction } from '../utils';
 import {
   filter, map, join, defineProperty, Boolean, Promise, setTimeout, log, noop,
-  objectEntries, jsonDump,
+  objectEntries,
 } from '../utils/helpers';
 import bridge from './bridge';
 import store from './store';
@@ -136,7 +136,7 @@ function makeComponentUtilsPolyfill() {
   };${
     funcs::map(([name]) => `${name}.toString=`)::join('')
   }()=>${
-    jsonDump(propertyToString())
+    JSON.stringify(propertyToString())
   };`;
 }
 

--- a/src/injected/web/requests.js
+++ b/src/injected/web/requests.js
@@ -1,7 +1,7 @@
 import { objectPick } from '#/common/object';
 import {
   filter, includes, map, push, jsonDump, jsonLoad, objectToString, Promise, Uint8Array,
-  setAttribute, log, buffer2stringSafe, charCodeAt, shift, slice, defineProperty,
+  setAttribute, log, buffer2stringSafe, charCodeAt, shift, slice, defineProperty, describeProperty,
   createElementNS, NS_HTML,
 } from '../utils/helpers';
 import bridge from './bridge';
@@ -12,7 +12,7 @@ const queue = [];
 const { DOMParser } = global;
 const { parseFromString } = DOMParser.prototype;
 const { toLowerCase } = String.prototype;
-const getHref = Object.getOwnPropertyDescriptor(HTMLAnchorElement.prototype, 'href').get;
+const { get: getHref } = describeProperty(HTMLAnchorElement.prototype, 'href');
 
 bridge.addHandlers({
   GotRequestId(id) {


### PR DESCRIPTION
Benefits:

* faster to initialize: ~10ms delta (45 -> 35) for 10 scripts on my fast desktop computer so the difference could be bigger on a slower/older laptop. 
* less memory used: 1MB delta (5 -> 4)
* proxy handler is preserved even after defineProperty

Collateral:

* fix: sandboxing of `window.onXXX` events so one script doesn't overwrite the value set in another one
* fix: unforgeable and readonly properties to mimic native behavior of `window`
* minor simplifications

~I'll test it during the next few days with more random popular scripts.~
Seems to be working fine.

You were against `Proxy` because it can't be polyfilled but I don't see why we would need that. Do you think you'll be using this repo to update the Maxthon version?