### PR TITLE
feat: import from Tampermonkey and via drag'n'drop

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -91,7 +91,7 @@ function handleCommandMessage(req, src) {
       return { data };
     }, (error) => {
       if (process.env.DEBUG) console.error(error);
-      return { error };
+      return { error: error instanceof Error ? error.stack : error };
     });
   }
   // `undefined` is ignored so we're sending `null` instead

--- a/src/background/utils/db.js
+++ b/src/background/utils/db.js
@@ -233,12 +233,6 @@ export async function dumpValueStores(valueDict) {
   return valueDict;
 }
 
-/** @return {Promise<?Object>} */
-export async function dumpValueStore(where, valueStore) {
-  const id = where.id || getScript(where)?.props.id;
-  return id && dumpValueStores({ [id]: valueStore });
-}
-
 const gmValues = [
   'GM_getValue', 'GM.getValue',
   'GM_setValue', 'GM.setValue',
@@ -576,6 +570,12 @@ export async function vacuum() {
  * @property {Boolean | null} notifyUpdates - stored as 0 or 1 or null (default) which means "use global setting"
  */
 /** @typedef VMScriptCustom *
+ * @property {string} name
+ * @property {string} downloadURL
+ * @property {string} homepageURL
+ * @property {string} lastInstallURL
+ * @property {string} updateURL
+ * @property {'auto' | 'page' | 'content'} injectInto
  * @property {string[]} exclude
  * @property {string[]} excludeMatch
  * @property {string[]} include

--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -41,7 +41,7 @@ if (!global.browser?.runtime?.sendMessage) {
         sendResponse({ data });
       }, (error) => {
         if (process.env.DEBUG) console.warn(error);
-        sendResponse({ error });
+        sendResponse({ error: error instanceof Error ? error.stack : error });
       })
       .catch(() => {}); // Ignore sendResponse error
       return true;

--- a/src/options/utils/index.js
+++ b/src/options/utils/index.js
@@ -1,4 +1,5 @@
 import Modal from 'vueleton/lib/modal/bundle';
+import { i18n } from '#/common';
 import { route } from '#/common/router';
 import Message from '../views/message';
 
@@ -25,4 +26,26 @@ export function showMessage(message) {
       modal.close();
     }, 2000);
   }
+}
+
+/**
+ * @param {string} text - the text to display in the modal
+ * @param {Object} cfg
+ * @param {string | false} [cfg.input=false] if not false, shows a text input with this string
+ * @param {Object} [cfg.ok] additional props for the Ok button
+ * @param {Object} [cfg.cancel] additional props for the Cancel button
+ * @return {Promise<?string>} resolves on Ok to `false` or the entered string, rejects otherwise
+ */
+export function showConfirmation(text, { ok, cancel, input = false } = {}) {
+  return new Promise((resolve, reject) => {
+    showMessage({
+      input,
+      text,
+      buttons: [
+        { text: i18n('buttonOK'), onClick: resolve, ...ok },
+        { text: i18n('buttonCancel'), onClick: reject, ...cancel },
+      ],
+      onBackdropClick: reject,
+    });
+  });
 }

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -61,11 +61,11 @@
 </template>
 
 <script>
-import { i18n, sendCmd, noop } from '#/common';
+import { i18n, sendCmd } from '#/common';
 import { objectPick } from '#/common/object';
 import VmCode from '#/common/ui/code';
 import { route } from '#/common/router';
-import { store, showMessage } from '../../utils';
+import { store, showConfirmation, showMessage } from '../../utils';
 import VmSettings from './settings';
 import VmValues from './values';
 import VmHelp from './help';
@@ -200,30 +200,15 @@ export default {
         showMessage({ text: err });
       }
     },
-    close({ fromCM } = {}) {
+    async close({ fromCM } = {}) {
       if (fromCM && this.nav !== 'code') {
         this.nav = 'code';
         return;
       }
-      (this.canSave ? Promise.reject() : Promise.resolve())
-      .catch(() => new Promise((resolve, reject) => {
-        showMessage({
-          input: false,
-          text: i18n('confirmNotSaved'),
-          buttons: [
-            {
-              text: i18n('buttonOK'),
-              onClick: resolve,
-            },
-            {
-              text: i18n('buttonCancel'),
-              onClick: reject,
-            },
-          ],
-          onBackdropClick: reject,
-        });
-      }))
-      .then(() => this.$emit('close'), noop);
+      try {
+        if (this.canSave) await showConfirmation(i18n('confirmNotSaved'));
+        this.$emit('close');
+      } catch (e) { /* NOP */ }
     },
     saveClose() {
       this.save().then(this.close);

--- a/src/options/views/tab-settings/vm-import.vue
+++ b/src/options/views/tab-settings/vm-import.vue
@@ -23,7 +23,7 @@ import { forEachEntry } from '#/common/object';
 import options from '#/common/options';
 import SettingCheck from '#/common/ui/setting-check';
 import loadZip from '#/common/zip';
-import { showMessage } from '../../utils';
+import { showConfirmation, showMessage } from '../../utils';
 
 let zip;
 
@@ -166,9 +166,14 @@ function initDragDrop(targetElement) {
   const onDrop = async evt => {
     evt.preventDefault();
     showAllowedState(false);
-    targetElement.disabled = true;
-    await importData(evt.dataTransfer.files[0]);
-    targetElement.disabled = false;
+    try {
+      // storing it now because `files` will be null after await
+      const file = evt.dataTransfer.files[0];
+      await showConfirmation(i18n('buttonImportData'));
+      targetElement.disabled = true;
+      await importData(file);
+      targetElement.disabled = false;
+    } catch (e) { /* NOP */ }
   };
   return () => {
     const isSettingsTab = window.location.hash === '#settings';


### PR DESCRIPTION
Fixes #832.
+ import Tampermonkey backup zips
+ allow drag'n'dropping backup zip onto settings page
+ indicate drop-allowed state on the import button
+ show import errors in the UI
+ convert stuff to async

P.S. should I join the non-fix commits after dragndrop into one? (2 refactors, tm import, ui report)

![image](https://user-images.githubusercontent.com/1310400/73131118-476ceb00-4016-11ea-8660-bd627ca4af85.png)