### PR TITLE
feat: support containers and more options in GM_openInTab

### DIFF
--- a/src/injected/content/tabs.js
+++ b/src/injected/content/tabs.js
@@ -1,4 +1,3 @@
-import { getFullUrl } from '#/common';
 import { sendCmd } from '../utils';
 import bridge from './bridge';
 
@@ -8,7 +7,6 @@ const realms = {};
 
 bridge.addHandlers({
   async TabOpen({ key, data }, realm) {
-    data.url = getFullUrl(data.url, window.location.href);
     const { id } = await sendCmd('TabOpen', data);
     tabIds[key] = id;
     tabKeys[id] = key;


### PR DESCRIPTION
Fixes #556.

`GM_openInTab(url, opts)`, new properties in opts:

* `pinned` *boolean*
* `container` *number*
  * `0` = default container
  * `1`, `2`, etc. = internal container index
  * not specified = use tab's container