### PR TITLE
fix: gmxhr handling of user-specified loadend callback

### DIFF
--- a/src/background/utils/requests.js
+++ b/src/background/utils/requests.js
@@ -16,7 +16,6 @@ Object.assign(commands, {
   ConfirmInstall: confirmInstall,
   /** @return {string} */
   GetRequestId(eventsToNotify = []) {
-    eventsToNotify.push('loadend');
     const id = getUniqId();
     requests[id] = {
       id,
@@ -252,6 +251,7 @@ async function httpRequest(details, src, cb) {
     }
     const callback = xhrCallbackWrapper(req);
     req.eventsToNotify.forEach(evt => { xhr[`on${evt}`] = callback; });
+    xhr.onloadend = callback; // always send it for the internal cleanup
     const body = data ? decodeBody(data) : null;
     HeaderInjector.add(id, vmHeaders);
     xhr.send(body);

--- a/src/injected/web/requests.js
+++ b/src/injected/web/requests.js
@@ -42,7 +42,7 @@ export function onRequestCreate(details, scriptId) {
       'abort',
       'error',
       'load',
-      // 'loadend' will always be sent for internal cleanup
+      'loadend',
       'progress',
       'readystatechange',
       'timeout',


### PR DESCRIPTION
Fixes decoding of blobs when the user specified only `onloadend` but no `onload`.