### PR TITLE
fix: value change notifications + broadcast only changes

### DIFF
--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -24,9 +24,8 @@ export function makeGmApi() {
       const values = loadValues(id);
       const oldRaw = values[key];
       delete values[key];
-      dumpValue({
-        id, key, oldRaw,
-      });
+      // using `undefined` to match the documentation and TM for GM_addValueChangeListener
+      dumpValue(id, key, undefined, null, oldRaw);
     },
     GM_getValue(key, def) {
       const raw = loadValues(this.id)[key];
@@ -42,9 +41,7 @@ export function makeGmApi() {
       const values = loadValues(id);
       const oldRaw = values[key];
       values[key] = raw;
-      dumpValue({
-        id, key, val, raw, oldRaw,
-      });
+      dumpValue(id, key, val, raw, oldRaw);
     },
     /**
      * @callback GMValueChangeListener

--- a/src/options/views/edit/values.vue
+++ b/src/options/views/edit/values.vue
@@ -124,13 +124,8 @@ export default {
     },
     updateValue({ key, value, isNew }) {
       const rawValue = value ? `o${value}` : '';
-      return sendCmd('UpdateValue', {
-        id: this.script.props.id,
-        update: {
-          key,
-          value: rawValue,
-        },
-      })
+      const { id } = this.script.props;
+      return sendCmd('UpdateValue', { id, key, value: rawValue })
       .then(() => {
         if (value) {
           this.$set(this.values, key, rawValue);


### PR DESCRIPTION
Fixes #839.
The problem was in changedRemotely - it didn't check if the key is actually hooked.
There was also a null/undefined mix-up.

Collateral: reduces the amount of tab messages and their size by broadcasting only the changed values in response to GM_xxxValue, whereas previously the entire script's value storage was sent every time.