### PR TITLE
ui: show injected-web.js in Violentmonkey entry in devtools

### DIFF
--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -78,7 +78,7 @@ export default function injectScripts(contentId, webId, data) {
   }
   if (injectPage.length) {
     inject(`(${VMInitInjection}())(${JSON.stringify(args).slice(1, -1)})`,
-      `${window.location.origin}/Violentmonkey.sandbox.js`);
+      browser.runtime.getURL('sandbox/injected-web.js'));
     bridge.post('LoadScripts', {
       ...data,
       mode: INJECT_PAGE,


### PR DESCRIPTION
Moves `injected-web.js` virtual entry from the page source tree into Violentmonkey tree.

Reason: page authors and those who use devtools to inspect sites may find it confusing and inconvenient that something is added to the original page tree. I put it there initially to keep it separate from the userscripts, but then a solution presented itself: if moved into a virtual subdirectory, it can be kept under the Violentmonkey entry, to which it rightfully belongs.

![image](https://user-images.githubusercontent.com/1310400/73563246-ec9c1f00-446d-11ea-8443-b11af2ceb5d9.png)
