### PR TITLE
Fix sandbox

### DIFF
--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -2,7 +2,10 @@
 // for DOM elements with 'id' attribute which is a standard feature, more info:
 // https://github.com/mozilla/webextension-polyfill/pull/153
 // https://html.spec.whatwg.org/multipage/window-object.html#named-access-on-the-window-object
-if (!global.browser?.runtime?.sendMessage) {
+if (!global.browser?.runtime?.sendMessage
+// Also don't redefine our `browser` on content script reinjection due to new documentElement
+// because `chrome` was already deleted by us and now it can be spoofed by a userscript
+&& window[Symbol.for(process.env.INIT_FUNC_NAME)] !== 1) {
   const { chrome, Promise } = global;
   const wrapAPIs = (source, meta = {}) => {
     return Object.entries(source)

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -110,7 +110,7 @@ export function formatTime(duration) {
 }
 
 // used in an unsafe context so we need to save the original functions
-const { hasOwnProperty } = Object.prototype;
+export const { hasOwnProperty } = Object.prototype;
 export function isEmpty(obj) {
   for (const key in obj) {
     if (obj::hasOwnProperty(key)) {

--- a/src/injected/content/clipboard.js
+++ b/src/injected/content/clipboard.js
@@ -1,5 +1,7 @@
 import { sendCmd } from '../utils';
-import { addEventListener, describeProperty, logging } from '../utils/helpers';
+import {
+  addEventListener, describeProperty, logging, removeEventListener,
+} from '../utils/helpers';
 import bridge from './bridge';
 
 // old Firefox defines it on a different prototype so we'll just grab it from document directly
@@ -7,7 +9,6 @@ const { execCommand } = document;
 const { setData } = DataTransfer.prototype;
 const { get: getClipboardData } = describeProperty(ClipboardEvent.prototype, 'clipboardData');
 const { preventDefault, stopImmediatePropagation } = Event.prototype;
-const { removeEventListener } = EventTarget.prototype;
 
 let clipboardData;
 

--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -6,7 +6,7 @@ import {
 } from '../utils/helpers';
 import bridge from './bridge';
 import './clipboard';
-import injectScripts from './inject';
+import { injectPageSandbox, injectScripts } from './inject';
 import './notifications';
 import './requests';
 import './tabs';
@@ -18,13 +18,18 @@ const menus = {};
 const { split } = String.prototype;
 
 export default async function initialize(contentId, webId) {
-  const data = await sendCmd('GetInjected', null, { retry: true });
+  // injecting right now before site scripts can mangle globals or intercept our contentId
+  // except for XML documents as their appearance breaks, but first we're sending
+  // a request for the data because injectPageSandbox takes ~5ms
+  const dataPromise = sendCmd('GetInjected', null, { retry: true });
+  const isXml = document instanceof XMLDocument;
+  if (!isXml) injectPageSandbox(contentId, webId);
+  const data = await dataPromise;
   // 1) bridge.post may be overridden in injectScripts
   // 2) cloneInto is provided by Firefox in content scripts to expose data to the page
   bridge.post = bindEvents(contentId, webId, bridge.onHandle, global.cloneInto);
-  bridge.destId = webId;
   bridge.isFirefox = data.isFirefox;
-  if (data.scripts) injectScripts(contentId, webId, data);
+  if (data.scripts) injectScripts(contentId, webId, data, isXml);
   getPopup();
   setBadge();
 }

--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -17,7 +17,9 @@ const menus = {};
 // Make sure to call obj::method() in code that may run after INJECT_CONTENT userscripts
 const { split } = String.prototype;
 
-export default async function initialize(contentId, webId) {
+(async () => {
+  const contentId = getUniqId();
+  const webId = getUniqId();
   // injecting right now before site scripts can mangle globals or intercept our contentId
   // except for XML documents as their appearance breaks, but first we're sending
   // a request for the data because injectPageSandbox takes ~5ms
@@ -32,7 +34,7 @@ export default async function initialize(contentId, webId) {
   if (data.scripts) injectScripts(contentId, webId, data, isXml);
   getPopup();
   setBadge();
-}
+})();
 
 bridge.addBackgroundHandlers({
   Command(data) {

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -9,7 +9,7 @@ import { sendCmd } from '#/common';
 
 import {
   forEach, join, append, createElementNS, defineProperty, NS_HTML,
-  charCodeAt, fromCharCode,
+  charCodeAt, fromCharCode, replace, remove,
 } from '../utils/helpers';
 import bridge from './bridge';
 
@@ -20,8 +20,6 @@ const VMInitInjection = window[Symbol.for(process.env.INIT_FUNC_NAME)];
 defineProperty(window, Symbol.for(process.env.INIT_FUNC_NAME), { value: 1 });
 
 const { encodeURIComponent } = global;
-const { replace } = String.prototype;
-const { remove } = Element.prototype;
 
 bridge.addHandlers({
   Inject: injectScript,

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -8,14 +8,16 @@ import {
 import { sendCmd } from '#/common';
 
 import {
-  forEach, join, append, createElementNS, NS_HTML,
+  forEach, join, append, createElementNS, defineProperty, NS_HTML,
   charCodeAt, fromCharCode,
 } from '../utils/helpers';
 import bridge from './bridge';
 
 // Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1408996
-const VMInitInjection = window[process.env.INIT_FUNC_NAME];
-delete window[process.env.INIT_FUNC_NAME];
+const VMInitInjection = window[Symbol.for(process.env.INIT_FUNC_NAME)];
+// To avoid running repeatedly due to new `document.documentElement`
+// (the symbol is undeletable so a userscript can't fool us on reinjection)
+defineProperty(window, Symbol.for(process.env.INIT_FUNC_NAME), { value: 1 });
 
 const { encodeURIComponent } = global;
 const { replace } = String.prototype;

--- a/src/injected/utils/helpers.js
+++ b/src/injected/utils/helpers.js
@@ -3,7 +3,7 @@
 // eslint-disable-next-line no-restricted-properties
 export const {
   // types
-  Blob, Boolean, Error, Promise, Uint8Array,
+  Boolean, Error, Promise, Uint8Array,
   // props and methods
   atob, isFinite, setTimeout,
 } = global;
@@ -15,15 +15,16 @@ export const {
 
 export const {
   keys: objectKeys, values: objectValues, entries: objectEntries,
-  assign, defineProperty, defineProperties, getOwnPropertyDescriptor: describeProperty,
+  assign, defineProperty, getOwnPropertyDescriptor: describeProperty,
 } = Object;
-export const { charCodeAt, match, slice } = String.prototype;
+export const {
+  charCodeAt, match, slice, replace,
+} = String.prototype;
 export const { toString: objectToString } = Object.prototype;
 const { toString: numberToString } = Number.prototype;
-const { replace } = String.prototype;
 export const { fromCharCode } = String;
 export const { addEventListener, removeEventListener } = EventTarget.prototype;
-export const { append, setAttribute } = Element.prototype;
+export const { append, remove, setAttribute } = Element.prototype;
 export const { createElementNS } = Document.prototype;
 export const logging = assign({}, console);
 

--- a/src/injected/utils/index.js
+++ b/src/injected/utils/index.js
@@ -16,14 +16,3 @@ export function bindEvents(srcId, destId, handle, cloneInto) {
     document::dispatchEvent(e);
   };
 }
-
-// it's injected as a string so only the page functions can be used
-export function attachFunction(id, cb) {
-  Object.defineProperty(window, id, {
-    value(...args) {
-      cb.apply(this, args);
-      delete window[id];
-    },
-    configurable: true,
-  });
-}

--- a/src/injected/web/gm-wrapper.js
+++ b/src/injected/web/gm-wrapper.js
@@ -1,8 +1,9 @@
+import { hasOwnProperty as has } from '#/common';
 import { INJECT_CONTENT, METABLOCK_RE } from '#/common/consts';
 import bridge from './bridge';
 import {
   concat, filter, forEach, includes, indexOf, map, match, push, slice,
-  defineProperty, describeProperty, objectKeys,
+  defineProperty, describeProperty, objectKeys, replace,
   addEventListener, removeEventListener,
 } from '../utils/helpers';
 import { makeGmApi } from './gm-api';
@@ -10,8 +11,7 @@ import { makeGmApi } from './gm-api';
 const { Proxy } = global;
 const { getOwnPropertyNames, getOwnPropertySymbols } = Object;
 const { splice } = Array.prototype;
-const { hasOwnProperty: has } = Object.prototype;
-const { replace, startsWith } = String.prototype;
+const { startsWith } = String.prototype;
 
 let gmApi;
 let gm4Api;

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -14,13 +14,9 @@ import './tabs';
 export default function initialize(
   webId,
   contentId,
-  ua,
-  isFirefox,
   invokeHost,
 ) {
   let invokeGuest;
-  bridge.ua = ua;
-  bridge.isFirefox = isFirefox;
   if (invokeHost) {
     bridge.mode = INJECT_CONTENT;
     bridge.post = (cmd, data) => invokeHost({ cmd, data }, INJECT_CONTENT);
@@ -30,6 +26,11 @@ export default function initialize(
   } else {
     bridge.mode = INJECT_PAGE;
     bridge.post = bindEvents(webId, contentId, bridge.onHandle);
+    bridge.addHandlers({
+      Ping() {
+        bridge.post('Pong');
+      },
+    });
   }
   document.addEventListener('DOMContentLoaded', async () => {
     store.state = 1;

--- a/src/injected/web/load-scripts.js
+++ b/src/injected/web/load-scripts.js
@@ -2,6 +2,7 @@ import { getUniqId } from '#/common';
 import { INJECT_CONTENT } from '#/common/consts';
 import {
   filter, map, defineProperty, describeProperty, Boolean, Promise, setTimeout, log, noop,
+  remove,
 } from '../utils/helpers';
 import bridge from './bridge';
 import store from './store';
@@ -10,7 +11,6 @@ import { deletePropsCache, wrapGM } from './gm-wrapper';
 const { concat } = Array.prototype;
 const { document } = global;
 const { get: getCurrentScript } = describeProperty(Document.prototype, 'currentScript');
-const { remove } = Element.prototype;
 
 bridge.addHandlers({
   LoadScripts(data) {


### PR DESCRIPTION
Problem:

Currently VMInitInjection is called after GetInjected response which happens after the page started running its inline scripts so the globals (and prototypes that we use) may be already compromised, or the page could steal contentId and abuse it, see the team chat for more info.

Fix:

* VMInitInjection will run immediately at document_start before any page scripts.

Collateral:

* sandboxing is refactored a bit so it doesn't use unsafe Object.defineProperty from the page.
* Proxy trap for ownKeys is fixed + Symbols are handled properly