### PR TITLE
fix: substitute more special chars in sourceURL name

### DIFF
--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -124,8 +124,8 @@ function injectScript(data) {
     ...codeSlices,
     `,"${vCallbackId}");`,
   ];
-  // replace characters that have special meaning in a URL with their fullwidth forms
-  const name = encodeURIComponent(scriptName::replace(/[#/:?]/g, replaceWithFullWidthForm));
+  // using fullwidth forms for special chars and those added by the newer RFC3986 spec for URI
+  const name = encodeURIComponent(scriptName::replace(/[#&',/:;?@=]/g, replaceWithFullWidthForm));
   const sourceUrl = browser.extension.getURL(`${name}.user.js#${scriptId}`);
   if (mode === INJECT_CONTENT) {
     injectedCode.push(


### PR DESCRIPTION
Problem:

Scripts with some special chars like `'` in the name aren't listed under Violentmonkey tree.
This is because encodeURIComponent still implements the ancient RFC2396.

Fix:

Use fullwidth forms for more reserved characters as defined in the newer RFC3986.