### PR TITLE
fix: data passing for bridge in invoke mode

### DIFF
--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -66,7 +66,7 @@ export function injectScripts(contentId, webId, data, isXml) {
     const postViaBridge = bridge.post;
     bridge.invokableIds.push(...injectContent.map(({ script }) => script.props.id));
     bridge.post = (cmd, params, realm) => {
-      (realm === INJECT_CONTENT ? invokeGuest : postViaBridge)({ cmd, data: params });
+      (realm === INJECT_CONTENT ? invokeGuest : postViaBridge)(cmd, params);
     };
     bridge.post('LoadScripts', {
       ...data,

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -20,7 +20,7 @@ export default function initialize(
   if (invokeHost) {
     bridge.mode = INJECT_CONTENT;
     bridge.post = (cmd, data) => invokeHost({ cmd, data }, INJECT_CONTENT);
-    invokeGuest = bridge.onHandle;
+    invokeGuest = (cmd, data) => bridge.onHandle({ cmd, data });
     global.chrome = undefined;
     global.browser = undefined;
   } else {


### PR DESCRIPTION
Follow-up to 91a6e71f to fix data passing for bridge in invoke mode: bridge.post (and its aliases invokeHost/invokeGuest) use separate parameters, bridge.onHandle uses an object { cmd, data }.