### PR TITLE
fix: only process the source frame in injectScript

### DIFF
--- a/src/background/utils/script.js
+++ b/src/background/utils/script.js
@@ -13,9 +13,10 @@ Object.assign(commands, {
     return id;
   },
   /** @return {Promise<Array>} */
-  InjectScript(code, src) {
-    return browser.tabs.executeScript(src.tab.id, {
+  InjectScript(code, { tab, frameId }) {
+    return browser.tabs.executeScript(tab.id, {
       code,
+      frameId,
       runAt: 'document_start',
     });
   },


### PR DESCRIPTION
Fixes a very old bug with the `InjectScript` command: it always injected into the main frame.