### PR TITLE
fix: set global as this for getters

### DIFF
--- a/src/injected/web/gm-wrapper.js
+++ b/src/injected/web/gm-wrapper.js
@@ -220,7 +220,13 @@ function makeGlobalWrapper(local) {
         if (!desc) return;
         if (desc.value === window) desc.value = wrapper;
         // preventing spec violation by duplicating ~10 props like NaN, Infinity, etc.
-        if (!ownDesc && !desc.configurable) defineProperty(local, name, desc);
+        if (!ownDesc && !desc.configurable) {
+          const { get } = desc;
+          if (typeof get === 'function') {
+            desc.get = (...args) => global::get(...args);
+          }
+          defineProperty(local, name, desc);
+        }
         return desc;
       }
     },


### PR DESCRIPTION
When getters are invoked with incorrect `this` reference, we get `Uncaught TypeError: Illegal invocation`. This PR fixes it by passing `global` as `this` explicitly.

Minimum reproduction:

```js
// ==UserScript==
// @name        New script - violentmonkey.github.io
// @namespace   Violentmonkey Scripts
// @match       https://violentmonkey.github.io/
// @grant       GM_info
// @version     1.0
// @author      -
// @description 2/3/2020, 1:44:43 PM
// ==/UserScript==

// trigger Proxy#getOwnPropertyDescriptor so that properties get shimmed
const a = Object.keys(window);
// trigger getter with `this === gmWrapper` implicitly
console.log(document);
```