### PR TITLE
fix: prevent data loss on exiting/reloading editor

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -512,6 +512,13 @@ msgNewVersion:
 msgNoUpdate:
   description: Message shown when there is no new version of a script.
   message: No update found.
+msgNotSaved:
+  description: >-
+    Message shown when there are unsaved script modifications and the user clicks browser Back button,
+    which we cannot prevent due to technical reasons so we can only show this reminder.
+  message: |-
+    Modifications are not saved!
+    You can reopen the editor now and click the "save" button.
 msgSavedBlacklist:
   description: Message shown when blacklist are saved.
   message: Blacklist updated.

--- a/src/common/object.js
+++ b/src/common/object.js
@@ -79,3 +79,28 @@ export function forEachKey(func) {
 export function forEachValue(func) {
   if (this) Object.values(this).forEach(func);
 }
+
+// Needed for Firefox's browser.storage API which fails on Vue observables
+export function deepCopy(src) {
+  return src && (
+    Array.isArray(src) && src.map(deepCopy)
+    || typeof src === 'object' && src::mapEntry(([, val]) => deepCopy(val))
+  ) || src;
+}
+
+// Simplified deep equality checker
+export function deepEqual(a, b) {
+  let res;
+  if (!a || !b || typeof a !== typeof b || typeof a !== 'object') {
+    res = a === b;
+  } else if (Array.isArray(a)) {
+    res = a.length === b.length
+      && a.every((item, i) => deepEqual(item, b[i]));
+  } else {
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    res = keysA.length === keysB.length
+      && keysA.every(key => keysB.includes(key) && deepEqual(a[key], b[key]));
+  }
+  return res;
+}

--- a/src/options/utils/index.js
+++ b/src/options/utils/index.js
@@ -42,9 +42,17 @@ export function showConfirmation(text, { ok, cancel, input = false } = {}) {
       input,
       text,
       buttons: [
-        { text: i18n('buttonOK'), onClick: resolve, ...ok },
-        { text: i18n('buttonCancel'), onClick: reject, ...cancel },
-      ],
+        ok !== false && {
+          text: i18n('buttonOK'),
+          onClick: resolve,
+          ...ok,
+        },
+        cancel !== false && {
+          text: i18n('buttonCancel'),
+          onClick: reject,
+          ...cancel,
+        },
+      ].filter(Boolean),
       onBackdropClick: reject,
     });
   });


### PR DESCRIPTION
* Autosaves the editor state every minute and when the user attempts to a) leave the page by reloading it via F5 or b) actually leaves it by using the back button.
* Displays a standard browser confirmation in case `a` or showConfirmation in case `b`
  >Modifications are not saved!  
  >You can reopen the editor now and click the "save" button.
* Restores the recovery info on editing the same script
* Restores the "clean" state when the user undoes all changes manually so the UI is updated accordingly

P.S. Now I know why history.replaceState was used instead of pushState - moving back in history loses the edits.