### PR TITLE
fix: prevent data loss on exiting/reloading editor

### DIFF
--- a/src/common/object.js
+++ b/src/common/object.js
@@ -79,3 +79,28 @@ export function forEachKey(func) {
 export function forEachValue(func) {
   if (this) Object.values(this).forEach(func);
 }
+
+// Needed for Firefox's browser.storage API which fails on Vue observables
+export function deepCopy(src) {
+  return src && (
+    Array.isArray(src) && src.map(deepCopy)
+    || typeof src === 'object' && src::mapEntry(([, val]) => deepCopy(val))
+  ) || src;
+}
+
+// Simplified deep equality checker
+export function deepEqual(a, b) {
+  let res;
+  if (!a || !b || typeof a !== typeof b || typeof a !== 'object') {
+    res = a === b;
+  } else if (Array.isArray(a)) {
+    res = a.length === b.length
+      && a.every((item, i) => deepEqual(item, b[i]));
+  } else {
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    res = keysA.length === keysB.length
+      && keysA.every(key => keysB.includes(key) && deepEqual(a[key], b[key]));
+  }
+  return res;
+}

--- a/src/common/router.js
+++ b/src/common/router.js
@@ -1,5 +1,5 @@
-function parse(pathInfo) {
-  const [pathname, search = ''] = pathInfo.split('?');
+function parse(hash) {
+  const [pathname, search = ''] = hash.split('?');
   const query = search.split('&').reduce((res, seq) => {
     if (seq) {
       const [key, val] = seq.split('=');
@@ -8,7 +8,9 @@ function parse(pathInfo) {
     return res;
   }, {});
   const paths = pathname.split('/');
-  return { pathname, query, paths };
+  return {
+    hash, pathname, paths, query,
+  };
 }
 
 const stack = [];
@@ -18,7 +20,13 @@ export const lastRoute = () => stack[stack.length - 1] || {};
 updateRoute();
 
 function updateRoute() {
-  Object.assign(route, parse(window.location.hash.slice(1)));
+  const hash = window.location.hash.slice(1);
+  if (!route.pinned) {
+    Object.assign(route, parse(hash));
+  } else if (route.hash !== hash) {
+    // restore the pinned route
+    setRoute(route.hash);
+  }
 }
 
 // popstate should be the first to ensure hashchange listeners see the correct lastRoute

--- a/src/options/utils/index.js
+++ b/src/options/utils/index.js
@@ -13,6 +13,7 @@ export function showMessage(message) {
     on: {
       dismiss() {
         modal.close();
+        message.onDismiss?.();
       },
     },
   }), {
@@ -49,6 +50,7 @@ export function showConfirmation(text, { ok, cancel, input = false } = {}) {
         { text: i18n('buttonCancel'), onClick: reject, ...cancel },
       ],
       onBackdropClick: reject,
+      onDismiss: reject, // Esc key
     });
   });
 }


### PR DESCRIPTION
* Displays a modal confirmation before reloading (<kbd>Ctrl-R</kbd>, <kbd>F5</kbd>) or leaving the page via history back/forward navigation. The former is a browser's built-in modal, the latter is an emulation based on pinning the current route.
* Calculates `canSave` based on deep object comparison so the real state is correctly reflected in the UI when the user undoes all changes manually.