### PR TITLE
feat: group .user.js in FF devtools

### DIFF
--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -89,6 +89,8 @@ function checkInjectable() {
 const replaceWithFullWidthForm = s => fromCharCode(s::charCodeAt(0) - 0x20 + 0xFF00);
 
 function injectScript([codeSlices, mode, scriptId, scriptName]) {
+  // Firefox lists .user.js among our own content scripts so a space at start will group them
+  if (bridge.isFirefox) scriptName = ` ${scriptName}`;
   // using fullwidth forms for special chars and those added by the newer RFC3986 spec for URI
   const name = encodeURIComponent(scriptName::replace(/[#&',/:;?@=]/g, replaceWithFullWidthForm));
   const sourceUrl = browser.extension.getURL(`${name}.user.js#${scriptId}`);


### PR DESCRIPTION
Firefox lists .user.js among our own content scripts so a space at start will group them:

![image](https://user-images.githubusercontent.com/1310400/74173082-81f39c00-4c42-11ea-8dd1-034170133e7d.png)

Another solution would be to place all userjs in a subfolder but that's less convenient as the list will be collapsed so an additional click would be required.