### PR TITLE
Actually use options when starting in editor

### DIFF
--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -28,7 +28,7 @@ if (!global.browser?.runtime?.sendMessage) {
           else resolve(res);
         });
       });
-      if (process.env.DEBUG) promise.catch(err => console.warn(args, err));
+      if (process.env.DEBUG) promise.catch(err => console.warn(args, err?.message || err));
       return promise;
     };
   };
@@ -80,11 +80,7 @@ if (!global.browser?.runtime?.sendMessage) {
           if (error) throw error;
           return response;
         };
-        return (data) => {
-          const promise = promisifiedSendMessage(data).then(unwrapResponse);
-          if (process.env.DEBUG) promise.catch(console.warn);
-          return promise;
-        };
+        return data => promisifiedSendMessage(data).then(unwrapResponse);
       },
     },
     storage: {

--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -142,6 +142,6 @@ if (!global.browser?.runtime?.sendMessage) {
 /* global browser */
 if (browser.tabs) {
   global.allOptions = browser.runtime.sendMessage({ cmd: 'GetAllOptions' })
-  .then(({ data }) => data)
+  .then(res => (global.chrome.app ? res.data : res)) // in Chrome we wrap `data` and `error`
   .catch(() => {});
 }

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -4,6 +4,7 @@ import {
 } from '#/common';
 import { forEachEntry, forEachValue } from '#/common/object';
 import handlers from '#/common/handlers';
+import options from '#/common/options';
 import loadZip from '#/common/zip';
 import '#/common/ui/style';
 import { store } from './utils';
@@ -50,29 +51,28 @@ function initScript(script) {
   script.$cache = { search, name, lowerName };
 }
 
-function loadData() {
-  sendCmd('GetData', null, { retry: true })
-  .then((data) => {
-    const oldCache = store.cache || {};
-    store.cache = data.cache;
-    store.sync = data.sync;
-    store.scripts = data.scripts;
-    if (store.scripts) {
-      store.scripts.forEach(initScript);
-    }
-    if (store.cache) {
-      store.cache::forEachEntry(([url, raw]) => {
-        if (oldCache[url]) {
-          store.cache[url] = oldCache[url];
-          delete oldCache[url];
-        } else {
-          store.cache[url] = cache2blobUrl(raw, { defaultType: 'image/png' });
-        }
-      });
-    }
-    oldCache::forEachValue(URL.revokeObjectURL);
-    store.loading = false;
-  });
+async function loadData() {
+  const data = await sendCmd('GetData', null, { retry: true });
+  if (!options.ready.indeed) await options.ready;
+  const oldCache = store.cache || {};
+  store.cache = data.cache;
+  store.sync = data.sync;
+  store.scripts = data.scripts;
+  if (store.scripts) {
+    store.scripts.forEach(initScript);
+  }
+  if (store.cache) {
+    store.cache::forEachEntry(([url, raw]) => {
+      if (oldCache[url]) {
+        store.cache[url] = oldCache[url];
+        delete oldCache[url];
+      } else {
+        store.cache[url] = cache2blobUrl(raw, { defaultType: 'image/png' });
+      }
+    });
+  }
+  oldCache::forEachValue(URL.revokeObjectURL);
+  store.loading = false;
 }
 
 function initMain() {


### PR DESCRIPTION
Fixes #873.

The problem was two-fold:
1. prefetching of GetAllOptions wrongly unwrapped the response to `undefined` in Firefox so a second request was sent later
2. `loadData` didn't wait for the second response of options so it wasn't used when the page started in the editor mode

Collateral: added debug logs for messaging in FF