### PR TITLE
update resources on script update/save and display errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,5 +26,12 @@ module.exports = {
       js: 'never',
       vue: 'never',
     }],
+    // copied from airbnb-base, replaced 4 with 8
+    'object-curly-newline': ['error', {
+      ObjectExpression: { minProperties: 8, multiline: true, consistent: true },
+      ObjectPattern: { minProperties: 8, multiline: true, consistent: true },
+      ImportDeclaration: { minProperties: 8, multiline: true, consistent: true },
+      ExportDeclaration: { minProperties: 8, multiline: true, consistent: true },
+    }],
   },
 };

--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -459,6 +459,9 @@ menuScriptEnabled:
 msgCheckingForUpdate:
   description: Message shown when a script is being checked for updates by version numbers.
   message: Checking for updates...
+msgErrorFetchingResource:
+  description: Message shown when Violentmonkey fails fetching a resource/require/icon of the script.
+  message: Error fetching resource!
 msgErrorFetchingScript:
   description: Message shown when Violentmonkey fails fetching a new version of the script.
   message: Error fetching script!

--- a/src/background/utils/db.js
+++ b/src/background/utils/db.js
@@ -473,14 +473,14 @@ function buildPathMap(script, base) {
 }
 
 /** @return {Promise<?string>} resolves to error text if `resourceCache` is absent */
-export async function fetchResources(script, fetchOptions, resourceCache) {
+export async function fetchResources(script, reqOptions, resourceCache) {
   const { custom: { pathMap }, meta } = script;
   const snatch = (url, type, validator) => {
     url = pathMap[url] || url;
     const contents = resourceCache?.[type][url];
     return contents != null && !validator
       ? storage[type].set(url, contents) && null
-      : storage[type].fetch(url, fetchOptions, validator).catch(err => err);
+      : storage[type].fetch(url, reqOptions, validator).catch(err => err);
   };
   const errors = await Promise.all([
     ...meta.require.map(url => snatch(url, 'require')),

--- a/src/background/utils/db.js
+++ b/src/background/utils/db.js
@@ -445,7 +445,7 @@ export async function parseScript(src) {
   if (src.position) script.props.position = +src.position;
   buildPathMap(script, src.url);
   await saveScript(script, src.code);
-  fetchResources(script, {}, src);
+  fetchResources(script, src);
   Object.assign(result.update, script, src.update);
   result.where = { id: script.props.id };
   sendCmd(cmd, result);
@@ -473,7 +473,7 @@ function buildPathMap(script, base) {
 }
 
 /** @return {Promise<?string>} resolves to error text if `resourceCache` is absent */
-export async function fetchResources(script, reqOptions, resourceCache) {
+export async function fetchResources(script, resourceCache, reqOptions) {
   const { custom: { pathMap }, meta } = script;
   const snatch = (url, type, validator) => {
     url = pathMap[url] || url;

--- a/src/background/utils/storage-fetch.js
+++ b/src/background/utils/storage-fetch.js
@@ -1,0 +1,54 @@
+import { buffer2string, request } from '#/common';
+import storage from '#/common/storage';
+
+/** @type { function(url, options, check): Promise<void> } or throws on error */
+storage.cache.fetch = cacheOrFetch({
+  init(options) {
+    return { ...options, responseType: 'arraybuffer' };
+  },
+  async transform(response, url, options, check) {
+    const contentType = (response.xhr.getResponseHeader('content-type') || '').split(';')[0];
+    await check?.(url, response.data, contentType);
+    return `${contentType},${btoa(buffer2string(response.data))}`;
+  },
+});
+
+/** @type { function(url, options): Promise<void> } or throws on error */
+storage.require.fetch = cacheOrFetch();
+
+function cacheOrFetch(handlers = {}) {
+  const requests = {};
+  const { init, transform } = handlers;
+  /** @this storage.<area> */
+  return function cacheOrFetchHandler(...args) {
+    const [url] = args;
+    const promise = requests[url] || (requests[url] = this::doFetch(...args));
+    return promise;
+  };
+  /** @this storage.<area> */
+  async function doFetch(...args) {
+    const [url, options] = args;
+    try {
+      const res = await request(url, init?.(options) || options);
+      if (await isModified(res.xhr, url)) {
+        const result = transform ? await transform(res, ...args) : res.data;
+        await this.set(url, result);
+      }
+    } catch (err) {
+      if (process.env.DEBUG) console.error(`Error fetching: ${url}`, err);
+      throw err;
+    } finally {
+      delete requests[url];
+    }
+  }
+}
+
+async function isModified(xhr, url) {
+  const mod = xhr.getResponseHeader('etag')?.trim()
+  || +new Date(xhr.getResponseHeader('last-modified'))
+  || +new Date(xhr.getResponseHeader('date'));
+  if (!mod || mod !== await storage.mod.getOne(url)) {
+    if (mod) await storage.mod.set(url, mod);
+    return true;
+  }
+}

--- a/src/background/utils/update.js
+++ b/src/background/utils/update.js
@@ -50,7 +50,7 @@ async function doCheckUpdate(script) {
     if (process.env.DEBUG) console.error(update);
   } finally {
     if (resOpts) {
-      msgErr = await fetchResources(script, resOpts);
+      msgErr = await fetchResources(script, null, resOpts);
       if (process.env.DEBUG && msgErr) console.error(msgErr);
     }
     if (msgOk || msgErr) {

--- a/src/background/utils/update.js
+++ b/src/background/utils/update.js
@@ -34,7 +34,7 @@ async function doCheckUpdate(script) {
   const { id } = script.props;
   let msgOk;
   let msgErr;
-  let resOpts;
+  let resourceOpts;
   try {
     const { update } = await parseScript({
       id,
@@ -42,15 +42,15 @@ async function doCheckUpdate(script) {
       update: { checking: false },
     });
     msgOk = canNotify(script) && i18n('msgScriptUpdated', [update.meta.name || i18n('labelNoName')]);
-    resOpts = { headers: NO_HTTP_CACHE };
+    resourceOpts = { headers: NO_HTTP_CACHE };
     return true;
   } catch (update) {
     // Either proceed with normal fetch on no-update or skip it altogether on error
-    resOpts = !update.error && !update.checking && {};
+    resourceOpts = !update.error && !update.checking && {};
     if (process.env.DEBUG) console.error(update);
   } finally {
-    if (resOpts) {
-      msgErr = await fetchResources(script, null, resOpts);
+    if (resourceOpts) {
+      msgErr = await fetchResources(script, null, resourceOpts);
       if (process.env.DEBUG && msgErr) console.error(msgErr);
     }
     if (msgOk || msgErr) {

--- a/src/background/utils/update.js
+++ b/src/background/utils/update.js
@@ -1,8 +1,6 @@
-import {
-  i18n, request, compareVersion, sendCmd,
-} from '#/common';
+import { i18n, request, compareVersion, sendCmd, trueJoin } from '#/common';
 import { CMD_SCRIPT_UPDATE } from '#/common/consts';
-import { getScriptById, getScripts, parseScript } from './db';
+import { fetchResources, getScriptById, getScripts, parseScript } from './db';
 import { parseMeta } from './script';
 import { getOption, setOption } from './options';
 import { commands, notify } from './message';
@@ -25,15 +23,6 @@ const processes = {};
 const NO_HTTP_CACHE = {
   'Cache-Control': 'no-cache, no-store, must-revalidate',
 };
-const OPTIONS = {
-  meta: {
-    headers: { ...NO_HTTP_CACHE, Accept: 'text/x-userscript-meta' },
-  },
-  script: {
-    headers: NO_HTTP_CACHE,
-  },
-};
-
 // resolves to true if successfully updated
 export default function checkUpdate(script) {
   const { id } = script.props;
@@ -43,61 +32,63 @@ export default function checkUpdate(script) {
 
 async function doCheckUpdate(script) {
   const { id } = script.props;
+  let msgOk;
+  let msgErr;
+  let resOpts;
   try {
     const { update } = await parseScript({
       id,
       code: await downloadUpdate(script),
       update: { checking: false },
     });
-    if (canNotify(script)) {
+    msgOk = canNotify(script) && i18n('msgScriptUpdated', [update.meta.name || i18n('labelNoName')]);
+    resOpts = { headers: NO_HTTP_CACHE };
+    return true;
+  } catch (update) {
+    // Either proceed with normal fetch on no-update or skip it altogether on error
+    resOpts = !update.error && !update.checking && {};
+    if (process.env.DEBUG) console.error(update);
+  } finally {
+    if (resOpts) {
+      msgErr = await fetchResources(script, resOpts);
+      if (process.env.DEBUG && msgErr) console.error(msgErr);
+    }
+    if (msgOk || msgErr) {
       notify({
         title: i18n('titleScriptUpdated'),
-        body: i18n('msgScriptUpdated', [update.meta.name || i18n('labelNoName')]),
+        body: [msgOk, msgErr]::trueJoin('\n'),
       });
     }
-    return true;
-  } catch (error) {
-    if (process.env.DEBUG) console.error(error);
-  } finally {
     delete processes[id];
   }
 }
 
-async function downloadUpdate(script) {
-  const downloadURL = (
-    script.custom.downloadURL
-    || script.meta.downloadURL
-    || script.custom.lastInstallURL
-  );
-  const updateURL = (
-    script.custom.updateURL
-    || script.meta.updateURL
-    || downloadURL
-  );
+async function downloadUpdate({ props: { id }, meta, custom }) {
+  const downloadURL = custom.downloadURL || meta.downloadURL || custom.lastInstallURL;
+  const updateURL = custom.updateURL || meta.updateURL || downloadURL;
   if (!updateURL) throw false;
-  let checkingMeta = true;
+  let errorMessage;
   const update = {};
-  const result = { update, where: { id: script.props.id } };
+  const result = { update, where: { id } };
   announce(i18n('msgCheckingForUpdate'));
   try {
-    const { data } = await request(updateURL, OPTIONS.meta);
-    const meta = parseMeta(data);
-    if (compareVersion(script.meta.version, meta.version) >= 0) {
+    const { data } = await request(updateURL, {
+      headers: { ...NO_HTTP_CACHE, Accept: 'text/x-userscript-meta' },
+    });
+    const { version } = parseMeta(data);
+    if (compareVersion(meta.version, version) >= 0) {
       announce(i18n('msgNoUpdate'), { checking: false });
     } else if (!downloadURL) {
       announce(i18n('msgNewVersion'), { checking: false });
     } else {
       announce(i18n('msgUpdating'));
-      checkingMeta = false;
-      return (await request(downloadURL, OPTIONS.script)).data;
+      errorMessage = i18n('msgErrorFetchingScript');
+      return (await request(downloadURL, { headers: NO_HTTP_CACHE })).data;
     }
   } catch (error) {
-    announce(
-      checkingMeta ? i18n('msgErrorFetchingUpdateInfo') : i18n('msgErrorFetchingScript'),
-      { error },
-    );
+    announce(errorMessage || i18n('msgErrorFetchingUpdateInfo'), { error });
   }
-  throw update.error;
+  throw update;
   function announce(message, { error, checking = !error } = {}) {
     Object.assign(update, {
       message,

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -155,3 +155,7 @@ export function makePause(ms) {
     ? Promise.resolve()
     : new Promise(resolve => setTimeout(resolve, ms));
 }
+
+export function trueJoin(separator) {
+  return this.filter(Boolean).join(separator);
+}

--- a/src/confirm/views/app.vue
+++ b/src/confirm/views/app.vue
@@ -194,7 +194,7 @@ export default {
         url: this.info.url,
         from: this.info.from,
         require: this.require,
-        resources: this.resources,
+        cache: this.resources,
       })
       .then((result) => {
         this.message = `${result.update.message}[${this.getTimeString()}]`;

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -95,6 +95,7 @@ function initMain() {
       const index = store.scripts.findIndex(item => item.props.id === data.where.id);
       if (index >= 0) {
         const updated = Object.assign({}, store.scripts[index], data.update);
+        if (updated.error && !data.update.error) updated.error = null;
         Vue.set(store.scripts, index, updated);
         initScript(updated);
       }

--- a/src/options/utils/index.js
+++ b/src/options/utils/index.js
@@ -22,9 +22,12 @@ export function showMessage(message) {
     // TODO: implement proper keyboard navigation, autofocus, and Enter/Esc in Modal module
     document.querySelector('.vl-modal button').focus();
   } else {
-    setTimeout(() => {
-      modal.close();
-    }, 2000);
+    const timer = setInterval(() => {
+      if (!document.querySelector('.vl-modal .modal-content:hover')) {
+        clearInterval(timer);
+        modal.close();
+      }
+    }, message.timeout || 2000);
   }
 }
 

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -133,6 +133,12 @@ export default {
     code() {
       this.canSave = true;
     },
+    // usually errors for resources
+    'initial.error'(error) {
+      if (error) {
+        showMessage({ text: `${this.initial.message}\n\n${error}` });
+      }
+    },
     settings: {
       deep: true,
       handler() {

--- a/src/options/views/message.vue
+++ b/src/options/views/message.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="message modal-content">
+  <div class="message modal-content" :class="{ multiline: /\n/.test(message.text) }">
     <div class="mb-1" v-if="message.text" v-text="message.text"></div>
     <form v-if="message.buttons" @submit.prevent>
       <input class="mb-1" type="text" v-if="message.input !== false" v-model="message.input">
@@ -67,9 +67,19 @@ export default {
 <style>
 .message {
   width: 18rem;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
   border-bottom-left-radius: .2rem;
   border-bottom-right-radius: .2rem;
   box-shadow: 0 0 .2rem rgba(0,0,0,.2);
+  &.multiline {
+    width: auto;
+    max-width: 50vw;
+    &::first-line {
+      font-weight: bold;
+      text-decoration: underline;
+    }
+  }
   input {
     width: 100%;
   }


### PR DESCRIPTION
Fixes #876.

Main changes:

* always fetch from network and rely on browser caching  
  (but the installer page still uses cache for resiliency)
* force no-cache HTTP header on script update (both manual or automatic)
* display errors for resource fetches when saving in editor (modal message) or updating in dashboard or in a notification for an updated script

Minor changes:
* keep modal message on screen while it's hovered
* preserve line breaks in modal message + show the first line in bold font

Collateral:
* ESLint: allow more props in one-line literal objects.

  This one really has been driving me mad all this time because with air-bnb's limit at `4` I constantly have to break imports into three lines just because a fourth import was added. Ditto for object literals. Such a low limit would only make sense if it was based on line length or visual complexity (e.g. presence of value specifiers or sub-properties), but we mostly use { shorthand } syntax anyway.