### PR TITLE
fix: `chrome` is cleared by injected/web

### DIFF
--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -141,7 +141,8 @@ if (!global.browser?.runtime?.sendMessage) {
 // prefetch the options while the current extension page loads
 /* global browser */
 if (browser.tabs) {
+  const isChrome = !!global.chrome?.app; // saving it now before injected/web clears it
   global.allOptions = browser.runtime.sendMessage({ cmd: 'GetAllOptions' })
-  .then(res => (global.chrome.app ? res.data : res)) // in Chrome we wrap `data` and `error`
+  .then(res => (isChrome ? res.data : res)) // in Chrome we wrap `data` and `error`
   .catch(() => {});
 }


### PR DESCRIPTION
Follow-up to df2e856ee6c03e4fae751d173293778fa8e76b3e to fix its bug in content mode.