### PR TITLE
fix: show injectable frames on non-injectable pages

### DIFF
--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -48,7 +48,7 @@
       <code v-text="store.blacklisted" v-if="store.blacklisted" class="ellipsis inline-block"/>
     </div>
     <div
-      v-for="scope in store.injectable && injectionScopes"
+      v-for="scope in injectionScopes"
       class="menu menu-scripts"
       :class="{ expand: activeMenu === scope.name }"
       :data-type="scope.name"
@@ -146,9 +146,11 @@ export default {
       const { sort, enabledFirst, hideDisabled } = this.options.filtersPopup;
       const isSorted = sort === 'alpha' || enabledFirst;
       return [
-        ['scripts', i18n('menuMatchedScripts')],
+        store.injectable && ['scripts', i18n('menuMatchedScripts')],
         ['frameScripts', i18n('menuMatchedFrameScripts')],
-      ].map(([name, title]) => {
+      ]
+      .filter(Boolean)
+      .map(([name, title]) => {
         let list = this.store[name];
         const numTotal = list.length;
         const numEnabled = list.reduce((num, script) => num + script.config.enabled, 0);


### PR DESCRIPTION
The built-in new tab page in Chrome creates an injectable iframe after the user hovers the grid icon in the top right corner of the page. The same should apply to any other built-in browser pages with web iframes.

![image](https://user-images.githubusercontent.com/1310400/75756841-5e53db00-5d42-11ea-9a25-139615f21d02.png)
