### PR TITLE
fix: chunked response may be sent in `progress` event

### DIFF
--- a/src/injected/content/requests.js
+++ b/src/injected/content/requests.js
@@ -6,7 +6,7 @@ const requests = {};
 bridge.addHandlers({
   async GetRequestId(eventsToNotify, realm) {
     const id = await sendCmd('GetRequestId', eventsToNotify);
-    requests[id] = realm;
+    requests[id] = { realm };
     return id;
   },
   HttpRequest: sendCmd,
@@ -15,13 +15,18 @@ bridge.addHandlers({
 
 bridge.addBackgroundHandlers({
   HttpRequested(msg) {
-    const { id, numChunks } = msg;
-    const realm = requests[id];
-    if (realm) {
-      bridge.post('HttpRequested', msg, realm);
-      if (msg.isLastChunk || msg.type === 'loadend' && (!numChunks || numChunks === 1)) {
-        delete requests[id];
+    const { id, numChunks, type } = msg;
+    const req = requests[id];
+    if (req) {
+      bridge.post('HttpRequested', msg, req.realm);
+      // chunks may be sent in progress/load/loadend events
+      if (type === 'loadend') {
+        req.ended = true;
+        req.allChunks = !numChunks || numChunks === 1;
+      } else {
+        req.allChunks = msg.isLastChunk;
       }
+      if (req.ended && req.allChunks) delete requests[id];
     }
   },
 });


### PR DESCRIPTION
I went with the verbose/explicit state props because my initial implementation below was too cryptic, right?

```js
req.done += msg.type === 'loadend' && (1 + ((numChunks || 1) === 1)) + !!msg.isLastChunk;
if (req.done === 2) delete requests[id];
```

