### PR TITLE
fix: flatten key path to preserve option's parent

### DIFF
--- a/src/background/utils/options.js
+++ b/src/background/utils/options.js
@@ -40,7 +40,11 @@ let initPending = browser.storage.local.get('options')
 preInitialize.push(initPending);
 
 function fireChange(keys, value) {
-  objectSet(changes, keys, value);
+  // Flattening key path so the subscribers can update nested values without overwriting the parent
+  const key = keys.join('.');
+  // Ensuring the correct order when updates were mixed like this: foo.bar=1; foo={bar:2}; foo.bar=3
+  delete changes[key];
+  changes[key] = value;
   callHooksLater();
 }
 


### PR DESCRIPTION
Turns out changing an option inside an object like `filtersPopup` resets the entire object when `updateOptions` command is sending back the changes in an object like `filtersPopup: {option: value}` so objectSet() was overwriting the entire filtersPopup object with this mini-object!