### PR TITLE
feat: prettify JSON value, show parsing errors

### DIFF
--- a/src/common/ui/style/style.css
+++ b/src/common/ui/style/style.css
@@ -110,14 +110,6 @@ textarea {
   &:focus {
     border-color: var(--fill-7);
   }
-  &.has-error {
-    // reminder: make sure all colors are readable in light/dark schemes
-    border-color: #8008;
-    background: #f002;
-    &:focus {
-      border-color: #f008;
-    }
-  }
 }
 code {
   padding: 0 .2em;
@@ -345,6 +337,15 @@ body .vl-tooltip {
   padding: 1rem;
   background: var(--bg);
   box-shadow: 0 0 40px #000;
+}
+
+.has-error {
+  // reminder: make sure all colors are readable in light/dark schemes
+  border-color: #8008;
+  background: #f002;
+  &:focus {
+    border-color: #f008;
+  }
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -202,3 +202,16 @@ export function request(url, options = {}) {
     }, extra);
   }
 }
+
+const SIMPLE_VALUE_TYPE = {
+  string: 's',
+  number: 'n',
+  boolean: 'b',
+};
+
+export function dumpScriptValue(value, jsonDump = JSON.stringify) {
+  if (value !== undefined) {
+    const simple = SIMPLE_VALUE_TYPE[typeof value];
+    return `${simple || 'o'}${simple ? value : jsonDump(value)}`;
+  }
+}

--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -1,4 +1,4 @@
-import { cache2blobUrl, getUniqId, isEmpty } from '#/common';
+import { cache2blobUrl, dumpScriptValue, getUniqId, isEmpty } from '#/common';
 import { downloadBlob } from '#/common/download';
 import {
   defineProperty, objectEntries, objectKeys, objectPick, objectValues,
@@ -43,8 +43,7 @@ export function makeGmApi() {
     },
     GM_setValue(key, val) {
       const { id } = this;
-      const dumped = jsonDump(val);
-      const raw = dumped ? `o${dumped}` : null;
+      const raw = dumpScriptValue(val, jsonDump) || null;
       const values = loadValues(id);
       const oldRaw = values[key];
       values[key] = raw;

--- a/src/injected/web/gm-values.js
+++ b/src/injected/web/gm-values.js
@@ -10,7 +10,6 @@ export const changeHooks = {};
 
 const dataDecoders = {
   o: jsonLoad,
-  // deprecated
   n: Number,
   b: val => val === 'true',
 };


### PR DESCRIPTION
Error state is shown on the `Save` button in order not to frighten the user by repeated reddening of the huge textarea while they type. The button also gets disabled on error so it can't be pressed until the error is fixed.

![image](https://user-images.githubusercontent.com/1310400/76150121-df4f0180-60b7-11ea-9f06-d0e851b50083.png)

The values are properly parsed as JSON now so the spaces are trimmed, for example. Previously `     "foo"   ` would save all this unnecessary space. There was also a trivial UI bug that an all-space value like `      ` wouldn't be recognized as an attempt to delete the value (it was properly deleted though internally so it vanished on reopening of the editor).

I've also "undeprecated" simple types in storage (`n`, `b`, `s`) because there should be no need to re-encode everything via JSON. Ideally, I want to store all values directly so numbers are stored as numbers, strings as strings, objects as objects, and so on as there's no need to store the type. The motivation is that there is a double or triple re-encoding going on on each access to db because most/many scripts still use JSON.stringify on objects in GM_setValue just in case. The only thing's stopping me is that this will preclude easy downgrades to a previous version of the extension and it makes me sad...