### PR TITLE
fix: [FF68+] track local file URLs in script installer

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -216,6 +216,9 @@ installOptionClose:
 installOptionTrack:
   description: Option to track the loading local file before window is closed.
   message: Track local file before this window is closed
+installOptionTrackTooltip:
+  description: Tooltip in Firefox 68+ for the option to track the loading local file before window is closed.
+  message: The source file tab should be kept open in Firefox 68 and newer.
 labelAbout:
   description: Label shown on top of the about page.
   message: About Violentmonkey


### PR DESCRIPTION
* Fixes tracking of `file://` URLs in Firefox 68+ as it disabled fetching of such URLs in extension pages due to [CVE-2019-11730](https://www.mozilla.org/en-US/security/advisories/mfsa2019-21/#CVE-2019-11730).

* If the source tab was inactive, the installer tab will be inactive too.

* Switched to `javascript:void 0` to cancel the request.

* Moved `bypass` to `cache`.

* Refactored the onBeforeRequest listener by splitting out the async part and flattening nested conditions.