### PR TITLE
editor tweaks and accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.8.3",
-    "codemirror": "^5.52.0",
+    "codemirror": "^5.52.2",
     "core-js": "^3.6.4",
     "tldjs": "^2.3.1",
     "vue": "^2.6.11",

--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -90,6 +90,7 @@ if (!global.browser?.runtime?.sendMessage) {
         set: wrapAsync,
         remove: wrapAsync,
       },
+      onChanged: true,
     },
     tabs: {
       onCreated: true,

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -492,7 +492,14 @@ $selectionDarkBg: rgba(73, 72, 62, .99);
   }
 }
 
+.cm-matchhighlight {
+  background-color: hsla(168, 100%, 50%, 0.15);
+}
+
 @media (prefers-color-scheme: dark) {
+  .cm-matchhighlight {
+    background-color: hsla(40, 100%, 50%, 0.1);
+  }
   // mostly copied from Monokai theme
   .cm-s-eclipse {
     &.CodeMirror {

--- a/src/options/views/edit/help.vue
+++ b/src/options/views/edit/help.vue
@@ -7,12 +7,10 @@
     </div>
     <div class="keyboard">
       <h3 v-text="i18n('editHelpKeyboard')"/>
-      <table>
-        <tr v-for="([key, cmd]) of hotkeys" :key="key">
-          <th class="monospace-font">{{key}}</th>
-          <td>{{cmd}}</td>
-        </tr>
-      </table>
+      <dl v-for="([key, cmd]) of hotkeys" :key="key">
+        <dt class="monospace-font" v-text="key"></dt>
+        <dd v-text="cmd"></dd>
+      </dl>
     </div>
   </div>
 </template>
@@ -22,16 +20,24 @@ import CodeMirror from 'codemirror';
 import { forEachEntry } from '#/common/object';
 
 export default {
-  props: ['target'],
+  props: ['active', 'navLabels', 'target'],
   data() {
     return {
       hotkeys: null,
     };
   },
-  mounted() {
-    const cmOpts = this.target.cm.options;
-    this.hotkeys = Object.entries(expandKeyMap({}, cmOpts.extraKeys, cmOpts.keyMap))
-    .sort((a, b) => compareString(a, b, 1) || compareString(a, b, 0));
+  watch: {
+    active(val) {
+      if (val && !this.hotkeys) {
+        const cmOpts = this.target.cm.options;
+        this.hotkeys = [
+          ['Alt-PageUp', ` ${this.navLabels.join(' < ')}`],
+          ['Alt-PageDown', ` ${this.navLabels.join(' > ')}`],
+          ...Object.entries(expandKeyMap({}, cmOpts.extraKeys, cmOpts.keyMap))
+          .sort((a, b) => compareString(a, b, 1) || compareString(a, b, 0)),
+        ];
+      }
+    },
   },
 };
 
@@ -63,13 +69,20 @@ function expandKeyMap(res, ...maps) {
     margin: .5em 0;
   }
   .keyboard {
-    column-width: 20em;
+    column-width: 25em;
     h3 {
       column-span: all;
     }
-    th {
+    dl {
+      display: flex;
+      align-items: center;
+      padding: .25em 0;
+    }
+    dt {
       text-align: right;
       padding-right: .5em;
+      flex: 0 40%;
+      font-weight: bold;
     }
   }
 }

--- a/src/options/views/edit/settings.vue
+++ b/src/options/views/edit/settings.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="edit-settings">
+  <div class="edit-settings" ref="container">
     <h4 v-text="i18n('editLabelSettings')"></h4>
     <div class="form-group">
       <label>
@@ -100,7 +100,7 @@ import { i18n } from '#/common';
 import { objectGet } from '#/common/object';
 
 export default {
-  props: ['value', 'settings'],
+  props: ['active', 'settings', 'value'],
   components: {
     Tooltip,
   },
@@ -119,6 +119,13 @@ export default {
         updateURL: objectGet(value, 'meta.updateURL') || i18n('hintUseDownloadURL'),
         downloadURL: objectGet(value, 'meta.downloadURL') || objectGet(value, 'custom.lastInstallURL'),
       };
+    },
+  },
+  watch: {
+    active(val) {
+      if (val) {
+        this.$refs.container.querySelector('input').focus();
+      }
     },
   },
 };
@@ -147,6 +154,9 @@ export default {
     > textarea {
       min-height: 5em;
     }
+  }
+  label:focus-within span {
+    text-decoration: underline;
   }
 }
 </style>

--- a/src/options/views/script-item.vue
+++ b/src/options/views/script-item.vue
@@ -8,7 +8,7 @@
     }"
     :draggable="draggable"
     @keydownEnter="onEdit">
-    <img class="script-icon hidden-xs" :src="safeIcon">
+    <img class="script-icon hidden-xs" :src="safeIcon" @click="onEdit">
     <div class="script-info flex">
       <div class="script-name ellipsis flex-auto" v-text="script.$cache.name"></div>
       <template v-if="canRender">
@@ -356,6 +356,7 @@ $removedItemHeight: calc(
     width: $iconSize;
     height: $iconSize;
     top: 1rem;
+    cursor: pointer;
     .disabled &,
     .removed & {
       filter: grayscale(.8);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2377,10 +2377,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codemirror@^5.52.0:
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.52.0.tgz#4dbd6aef7f0e63db826b9a23922f0c03ac75c0a7"
-  integrity sha512-K2UB6zjscrfME03HeRe/IuOmCeqNpw7PLKGHThYpLbZEuKf+ZoujJPhxZN4hHJS1O7QyzEsV7JJZGxuQWVaFCg==
+codemirror@^5.52.2:
+  version "5.52.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.52.2.tgz#c29e1f7179f85eb0dd17c0586fa810e4838ff584"
+  integrity sha512-WCGCixNUck2HGvY8/ZNI1jYfxPG5cRHv0VjmWuNzbtCLz8qYA5d+je4QhSSCtCaagyeOwMi/HmmPTjBgiTm2lQ==
 
 collection-map@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
* Fixes #919: auto-refresh values in editor.
* Fixes #922: actually define match-highlight color.

* Feature: open editor on clicking the script icon in the dashboard
* update CodeMirror

* Limited the global codemirror keydown listener to the code panel. Previously we used it in other panels to enable <kbd>Esc</kbd> key to return to the code panel. Now it's handled by switchPanel.

* keyboard accessibility: navigate in value list via <kbd>Tab</kbd>
* keyboard accessibility: <kbd>Ctrl-Del</kbd> to delete the value focused by the above method
* keyboard accessibility: <kbd>Alt-PageUp/Down</kbd> to switch code-settings-values-help panels

* Fixed the `?` tab so it shows columns in FF: turns out the new spec edition ignores table elements.