### PR TITLE
fix: save all custom props in editor

### DIFF
--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -191,7 +191,7 @@ export default {
             notifyUpdates: notifyUpdates ? +notifyUpdates : null,
           },
           custom: {
-            ...objectPick(custom, CUSTOM_PROPS),
+            ...objectPick(custom, Object.keys(CUSTOM_PROPS)),
             ...objectPick(custom, CUSTOM_LISTS, toList),
           },
           // User created scripts MUST be marked `isNew` so that


### PR DESCRIPTION
It was broken in 796371a7 (2.12.5)