### PR TITLE
fix: unpack flattened data in updateOptions()

### DIFF
--- a/src/common/options.js
+++ b/src/common/options.js
@@ -26,10 +26,13 @@ function setOption(key, value) {
 }
 
 function updateOptions(data) {
+  // Keys in `data` may be { flattened.like.this: 'foo' }
+  const expandedData = {};
   data::forEachEntry(([key, value]) => {
     objectSet(options, key, value);
+    objectSet(expandedData, key, value);
   });
-  hooks.fire(data);
+  hooks.fire(expandedData);
 }
 
 export default {

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -1,5 +1,5 @@
 import defaults from '#/common/options-defaults';
-import { initHooks, sendCmd, normalizeKeys } from '.';
+import { initHooks, sendCmd } from '.';
 import { forEachEntry, objectGet, objectSet } from './object';
 
 let options = {};
@@ -14,14 +14,13 @@ const ready = (global.allOptions || Promise.resolve())
 });
 
 function getOption(key) {
-  const keys = normalizeKeys(key);
-  return objectGet(options, keys) ?? objectGet(defaults, keys);
+  return objectGet(options, key) ?? objectGet(defaults, key);
 }
 
 function setOption(key, value) {
   // the updated options object will be propagated from the background script after a pause
   // so meanwhile the local code should be able to see the new value using options.get()
-  objectSet(options, normalizeKeys(key), value);
+  objectSet(options, key, value);
   sendCmd('SetOptions', { key, value });
 }
 


### PR DESCRIPTION
Follow-up to 3733bb19.

The bug manifested itself in the dashboard when trying to change filtering options.