### PR TITLE
feat: use browser.contentScripts API

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,4 +1,4 @@
-import { sendCmd, sendTabCmd } from '#/common';
+import { sendCmd } from '#/common';
 import { TIMEOUT_24HOURS, TIMEOUT_MAX } from '#/common/consts';
 import ua from '#/common/ua';
 import * as sync from './sync';
@@ -19,7 +19,6 @@ import './utils/tabs';
 import './utils/tester';
 import './utils/update';
 
-const popupTabs = {}; // { tabId: 1 }
 let isApplied;
 
 hookOptions((changes) => {
@@ -40,13 +39,9 @@ Object.assign(commands, {
   async GetInjected(_, src) {
     const { frameId, tab, url } = src;
     if (!frameId) resetValueOpener(tab.id);
-    const res = {
-      ua,
-      isFirefox: ua.isFirefox,
-      isPopupShown: popupTabs[tab.id],
-    };
+    const res = {};
     if (isApplied) {
-      const data = await getInjectedScripts(url, !frameId);
+      const data = await getInjectedScripts(url, tab.id, frameId);
       addValueOpener(tab.id, frameId, data.withValueIds);
       setBadge(data.enabledIds, src);
       Object.assign(res, data.inject);
@@ -93,21 +88,8 @@ function autoUpdate() {
   autoUpdate.timer = setTimeout(autoUpdate, Math.min(TIMEOUT_MAX, interval - elapsed));
 }
 
-function onPopupOpened(port) {
-  const tabId = +port.name;
-  popupTabs[tabId] = 1;
-  sendTabCmd(tabId, 'PopupShown', true);
-  port.onDisconnect.addListener(onPopupClosed);
-}
-
-function onPopupClosed({ name }) {
-  delete popupTabs[name];
-  sendTabCmd(+name, 'PopupShown', false);
-}
-
 initialize(() => {
   browser.runtime.onMessage.addListener(handleCommandMessage);
-  browser.runtime.onConnect.addListener(onPopupOpened);
   isApplied = getOption('isApplied');
   setTimeout(autoUpdate, 2e4);
   sync.initialize();

--- a/src/background/utils/popup-tracker.js
+++ b/src/background/utils/popup-tracker.js
@@ -1,0 +1,20 @@
+import { sendTabCmd } from '#/common';
+import { postInitialize } from './init';
+
+export const popupTabs = {}; // { tabId: 1 }
+
+postInitialize.push(() => {
+  browser.runtime.onConnect.addListener(onPopupOpened);
+});
+
+function onPopupOpened(port) {
+  const tabId = +port.name;
+  popupTabs[tabId] = 1;
+  sendTabCmd(tabId, 'PopupShown', true);
+  port.onDisconnect.addListener(onPopupClosed);
+}
+
+function onPopupClosed({ name }) {
+  delete popupTabs[name];
+  sendTabCmd(+name, 'PopupShown', false);
+}


### PR DESCRIPTION
The complementary feature to early injection in Chrome, this one is using Firefox's browser.contentScripts API to pass the script data directly and thus implement the _real_ `document_start` for page mode scripts in Firefox.

Content mode seems to require more trickery (maybe rewriting `InjectionFeedback`) so I don't want to do it in this simple PR. The content mode gets somewhat faster anyway because the data is received earlier now.

Related: #374, #420.