### PR TITLE
Use contentScripts API in FF + various fixes/tweaks

### DIFF
--- a/src/background/utils/popup-tracker.js
+++ b/src/background/utils/popup-tracker.js
@@ -1,0 +1,20 @@
+import { sendTabCmd } from '#/common';
+import { postInitialize } from './init';
+
+export const popupTabs = {}; // { tabId: 1 }
+
+postInitialize.push(() => {
+  browser.runtime.onConnect.addListener(onPopupOpened);
+});
+
+function onPopupOpened(port) {
+  const tabId = +port.name;
+  popupTabs[tabId] = 1;
+  sendTabCmd(tabId, 'PopupShown', true);
+  port.onDisconnect.addListener(onPopupClosed);
+}
+
+function onPopupClosed({ name }) {
+  delete popupTabs[name];
+  sendTabCmd(+name, 'PopupShown', false);
+}

--- a/src/background/utils/preinject.js
+++ b/src/background/utils/preinject.js
@@ -4,7 +4,6 @@ import ua from '#/common/ua';
 import cache from './cache';
 import { getScriptsByURL } from './db';
 import { extensionRoot, postInitialize } from './init';
-import { commands } from './message';
 import { getOption, hookOptions } from './options';
 import { popupTabs } from './popup-tracker';
 
@@ -23,26 +22,6 @@ hookOptions(changes => {
 postInitialize.push(() => {
   injectInto = getOption('defaultInjectInto');
   togglePreinject(getOption('isApplied'));
-});
-
-Object.assign(commands, {
-  InjectionFeedback(feedback, { tab, frameId }) {
-    feedback.forEach(([key, action]) => {
-      if (action === 'done') {
-        cache.del(key);
-        return;
-      }
-      const code = cache.pop(key);
-      // see TIME_KEEP_DATA comment
-      if (code) {
-        browser.tabs.executeScript(tab.id, {
-          code,
-          frameId,
-          runAt: 'document_start',
-        });
-      }
-    });
-  },
 });
 
 /** @return {Promise<Object>} */

--- a/src/background/utils/preinject.js
+++ b/src/background/utils/preinject.js
@@ -66,7 +66,7 @@ async function prepare(url, tabId, frameId, isLate) {
   inject.ua = ua;
   inject.isFirefox = ua.isFirefox;
   inject.isPopupShown = popupTabs[tabId];
-  if (!isLate && injectInto !== INJECT_CONTENT && browser.contentScripts) {
+  if (!isLate && browser.contentScripts) {
     registerScriptDataFF(data, url, !!frameId);
   }
   return data;

--- a/src/background/utils/preinject.js
+++ b/src/background/utils/preinject.js
@@ -6,6 +6,7 @@ import { getScriptsByURL } from './db';
 import { extensionRoot, postInitialize } from './init';
 import { commands } from './message';
 import { getOption, hookOptions } from './options';
+import { popupTabs } from './popup-tracker';
 
 const API_CONFIG = {
   urls: ['*://*/*'], // `*` scheme matches only http and https
@@ -57,8 +58,8 @@ Object.assign(commands, {
 });
 
 /** @return {Promise<Object>} */
-export function getInjectedScripts(url, isTop) {
-  return cache.pop(getKey(url, isTop)) || prepare(url, isTop);
+export function getInjectedScripts(url, tabId, frameId) {
+  return cache.pop(getKey(url, !frameId)) || prepare(url, tabId, frameId, true);
 }
 
 function getKey(url, isTop) {
@@ -74,7 +75,7 @@ function togglePreinject(enable) {
   browser.webRequest.onHeadersReceived[onOff](prolong, config);
 }
 
-function preinject({ url, frameId }) {
+function preinject({ url, tabId, frameId }) {
   if (!INJECTABLE_TAB_URL_RE.test(url)) return;
   const isTop = !frameId;
   const key = getKey(url, isTop);
@@ -82,7 +83,7 @@ function preinject({ url, frameId }) {
     // GetInjected message will be sent soon by the content script
     // and it may easily happen while getScriptsByURL is still waiting for browser.storage
     // so we'll let GetInjected await this pending data by storing Promise in the cache
-    cache.put(key, prepare(url, isTop), TIME_AFTER_SEND);
+    cache.put(key, prepare(url, tabId, frameId), TIME_AFTER_SEND);
   }
 }
 
@@ -90,10 +91,17 @@ function prolong({ url, frameId }) {
   cache.hit(getKey(url, !frameId), TIME_AFTER_RECEIVE);
 }
 
-async function prepare(url, isTop) {
-  const data = await getScriptsByURL(url, isTop);
-  data.inject.scripts.forEach(prepareScript, data);
-  data.inject.injectInto = injectInto;
+async function prepare(url, tabId, frameId, isLate) {
+  const data = await getScriptsByURL(url, !frameId);
+  const { inject } = data;
+  inject.scripts.forEach(prepareScript, data);
+  inject.injectInto = injectInto;
+  inject.ua = ua;
+  inject.isFirefox = ua.isFirefox;
+  inject.isPopupShown = popupTabs[tabId];
+  if (!isLate && injectInto !== INJECT_CONTENT && browser.contentScripts) {
+    registerScriptDataFF(data, url, !!frameId);
+  }
   return data;
 }
 
@@ -140,4 +148,15 @@ function prepareScript(script, index, scripts) {
 function replaceWithFullWidthForm(s) {
   // fullwidth range starts at 0xFF00, normal range starts at space char code 0x20
   return String.fromCharCode(s.charCodeAt(0) - 0x20 + 0xFF00);
+}
+
+function registerScriptDataFF(data, url, allFrames) {
+  data.registration = browser.contentScripts.register({
+    allFrames,
+    js: [{
+      code: `resolveData(${JSON.stringify(data.inject)})`,
+    }],
+    matches: url.split('#', 1),
+    runAt: 'document_start',
+  });
 }

--- a/src/background/utils/preinject.js
+++ b/src/background/utils/preinject.js
@@ -134,7 +134,7 @@ function prepareScript(script, index, scripts) {
     '})()}).call',
   ];
   // Firefox lists .user.js among our own content scripts so a space at start will group them
-  const sourceUrl = `\n//# sourceURL=${extensionRoot}${ua.isFirefox ? ' ' : ''}${name}.user.js#${id}`;
+  const sourceUrl = `\n//# sourceURL=${extensionRoot}${ua.isFirefox ? '%20' : ''}${name}.user.js#${id}`;
   cache.put(dataKey, [slices, sourceUrl], TIME_KEEP_DATA);
   scripts[index] = {
     ...script,

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -73,19 +73,19 @@ export function injectScripts(contentId, webId, data, isXml) {
     const desiredRealm = custom.injectInto || meta.injectInto || data.injectInto;
     const internalRealm = INJECT_MAPPING[desiredRealm] || INJECT_MAPPING[INJECT_AUTO];
     const realm = internalRealm.find(key => realms[key]?.injectable());
+    let needsInjection;
     // If the script wants this specific realm, which is unavailable, we won't inject it at all
-    if (!realm) return [dataKey, 'done'];
-    const { ids, lists } = realms[realm];
-    let runAt = bornReady ? 'start'
-      : `${custom.runAt || meta.runAt || ''}`.replace(/^document-/, '');
-    const list = lists[runAt] || lists[runAt = 'end'];
-    const action = realm === INJECT_PAGE && 'done'
-      || runAt !== 'start' && 'wait'
-      || '';
-    script.action = action;
-    ids::push(script.props.id);
-    list::push(script);
-    return [dataKey, action];
+    if (realm) {
+      const { ids, lists } = realms[realm];
+      let runAt = bornReady ? 'start'
+        : `${custom.runAt || meta.runAt || ''}`.replace(/^document-/, '');
+      const list = lists[runAt] || lists[runAt = 'end'];
+      script.action = realm === INJECT_CONTENT && (runAt === 'start' ? runAt : 'wait');
+      needsInjection = !!script.action;
+      ids::push(script.props.id);
+      list::push(script);
+    }
+    return [dataKey, needsInjection];
   };
   const feedback = data.scripts.map(triage);
   setupContentInvoker(realms, contentId, webId);

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -1,7 +1,7 @@
 import { INJECT_PAGE, INJECT_CONTENT } from '#/common/consts';
 import { defineProperty, describeProperty } from '#/common/object';
 import { bindEvents } from '../utils';
-import { forEach, log, remove, Promise } from '../utils/helpers';
+import { forEach, log, logging, remove, Promise } from '../utils/helpers';
 import bridge from './bridge';
 import { wrapGM } from './gm-wrapper';
 import store from './store';
@@ -74,7 +74,7 @@ function createScriptData(item) {
   store.values[item.props.id] = item.values;
   defineProperty(window, item.dataKey, {
     configurable: true,
-    get() {
+    async set(fn) {
       // deleting now to prevent interception via DOMNodeRemoved on el::remove()
       delete window[item.dataKey];
       if (process.env.DEBUG) {
@@ -82,9 +82,10 @@ function createScriptData(item) {
       }
       const el = document::getCurrentScript();
       if (el) el::remove();
-      return item.action === 'wait'
-        ? (async () => await bridge.load && wrapGM(item))()
-        : wrapGM(item);
+      if (item.action === 'wait') {
+        await bridge.load;
+      }
+      wrapGM(item)::fn(logging.error);
     },
   });
 }

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -54,7 +54,7 @@ bridge.addHandlers({
   Callback({ callbackId, payload }) {
     bridge.callbacks[callbackId]?.(payload);
   },
-  ScriptData({ info, items }) {
+  ScriptData({ info, items, runAt }) {
     if (info) {
       bridge.isFirefox = info.isFirefox;
       bridge.ua = info.ua;
@@ -62,6 +62,10 @@ bridge.addHandlers({
     }
     if (items) {
       items::forEach(createScriptData);
+      // FF bug workaround to enable processing of sourceURL in injected page scripts
+      if (bridge.isFirefox && bridge.mode === INJECT_PAGE) {
+        bridge.post('InjectList', runAt);
+      }
     }
   },
 });


### PR DESCRIPTION
The complementary feature to early injection in Chrome, this one is using Firefox's browser.contentScripts API to pass the script data directly and thus implement the _real_ `document_start` for page mode scripts in Firefox.

Content mode seems to require more trickery (maybe rewriting `InjectionFeedback`) so I don't want to do it in this simple PR. The content mode gets somewhat faster anyway because the data is received earlier now.

Related: #374, #420.

### Additional fixes:

* sourceURL can't use normal space for grouping
* FF bug workaround for sourceURL