### PR TITLE
ui: group settings for popup/icon in a new section

### DIFF
--- a/src/options/views/app.vue
+++ b/src/options/views/app.vue
@@ -29,7 +29,9 @@
         </div>
       </div>
     </aside>
-    <component :is="tabComponent" class="tab flex-auto"></component>
+    <keep-alive>
+      <component :is="tabComponent" class="tab flex-auto"/>
+    </keep-alive>
   </div>
 </template>
 

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -11,33 +11,6 @@
       </div>
       <div class="mb-1">
         <label>
-          <setting-check name="notifyUpdates" />
-          <span v-text="i18n('labelNotifyUpdates')"></span>
-        </label>
-        <label class="ml-2">
-          <setting-check name="notifyUpdatesGlobal" />
-          <span v-text="i18n('labelNotifyUpdatesGlobal')"></span>
-        </label>
-      </div>
-      <div class="mb-1">
-        <label>
-          <locale-group i18n-key="labelAutoUpdate">
-            <input v-model="settings.autoUpdate" type="number" min=0 max=365 step=1 />
-          </locale-group>
-        </label>
-      </div>
-      <div class="mb-1">
-        <label>
-          <span v-text="i18n('labelBadge')"></span>
-          <select v-model="settings.showBadge">
-            <option value="" v-text="i18n('labelBadgeNone')" />
-            <option value="unique" v-text="i18n('labelBadgeUnique')" />
-            <option value="total" v-text="i18n('labelBadgeTotal')" />
-          </select>
-        </label>
-      </div>
-      <div class="mb-1">
-        <label>
           <locale-group i18n-key="labelPopupSort">
             <select v-model="settings['filtersPopup.sort']">
               <option value="exec" v-text="i18n('filterExecutionOrder')" />
@@ -52,6 +25,36 @@
         <label class="ml-2">
           <setting-check name="filtersPopup.hideDisabled" />
           <span v-text="i18n('optionPopupHideDisabled')"></span>
+        </label>
+      </div>
+      <div class="mb-1">
+        <label>
+          <span v-text="i18n('labelBadge')"></span>
+          <select v-model="settings.showBadge">
+            <option value="" v-text="i18n('labelBadgeNone')" />
+            <option value="unique" v-text="i18n('labelBadgeUnique')" />
+            <option value="total" v-text="i18n('labelBadgeTotal')" />
+          </select>
+        </label>
+      </div>
+    </section>
+    <section>
+      <h3 v-text="i18n('titleScriptUpdated')"/>
+      <div class="mb-1">
+        <label>
+          <locale-group i18n-key="labelAutoUpdate">
+            <input v-model="settings.autoUpdate" type="number" min=0 max=365 step=1/>
+          </locale-group>
+        </label>
+      </div>
+      <div class="mb-1">
+        <label>
+          <setting-check name="notifyUpdates"/>
+          <span v-text="i18n('labelNotifyUpdates')"/>
+        </label>
+        <label class="ml-2">
+          <setting-check name="notifyUpdatesGlobal"/>
+          <span v-text="i18n('labelNotifyUpdatesGlobal')"/>
         </label>
       </div>
     </section>


### PR DESCRIPTION
This is a trivial cosmetic change to offload the main options block so it'll look like this:
![image](https://user-images.githubusercontent.com/1310400/78371881-3c63a780-75d1-11ea-8137-3b96d20ef15f.png)

I've enabled keep-alive on the component switcher as there seems to be no need to rebuild the state. Maybe we could switch to the same component switching in the editor instead of its currently hardwired switcher which is overly verbose and thus not easy to extend/maintain because it needs explicit managing of the switch state.