### PR TITLE
feat: make exposing via window.external optional

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -290,6 +290,9 @@ labelExcludeMatch:
 labelExportScriptData:
   description: Option to export script data along with scripts.
   message: Export script data
+labelExposeStatus:
+  description: Option in advanced settings.
+  message: 'Expose installed version on userscript catalog sites: $1'
 labelFeedback:
   description: Label of link to feedback page.
   message: Feedback

--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -9,6 +9,10 @@ export default {
   /** @type 'unique' | 'total' | '' */
   showBadge: 'unique',
   exportValues: true,
+  expose: { // use percent-encoding for '.'
+    'greasyfork%2Eorg': true,
+    'sleazyfork%2Eorg': false,
+  },
   closeAfterInstall: false,
   trackLocalFile: false,
   autoReload: false,

--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -38,6 +38,7 @@ const { split } = String.prototype;
   bridge.post = bindEvents(contentId, webId, bridge.onHandle, global.cloneInto);
   bridge.isFirefox = data.isFirefox;
   if (data.scripts) injectScripts(contentId, webId, data, isXml);
+  if (data.expose) bridge.post('Expose');
   isPopupShown = data.isPopupShown;
   sendSetPopup();
 })().catch(IS_FIREFOX && console.error); // Firefox can't show exceptions in content scripts

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -35,9 +35,6 @@ export default function initialize(
         bridge.post('Pong');
       },
     });
-    if (window.location.host === 'greasyfork.org' || window.location.host === 'sleazyfork.org') {
-      exposeVM();
-    }
   }
   bridge.load = new Promise(resolve => {
     // waiting for the page handlers to run first
@@ -68,6 +65,18 @@ bridge.addHandlers({
       }
     }
   },
+  Expose() {
+    const Violentmonkey = {};
+    defineProperty(Violentmonkey, 'version', {
+      value: process.env.VM_VER,
+    });
+    defineProperty(Violentmonkey, 'isInstalled', {
+      value: (name, namespace) => bridge.send('CheckScript', { name, namespace }),
+    });
+    defineProperty(window.external, 'Violentmonkey', {
+      value: Violentmonkey,
+    });
+  },
 });
 
 function createScriptData(item) {
@@ -96,17 +105,4 @@ async function onCodeSet(item, fn) {
     await bridge.load;
   }
   wrapGM(item)::fn(logging.error);
-}
-
-function exposeVM() {
-  const Violentmonkey = {};
-  defineProperty(Violentmonkey, 'version', {
-    value: process.env.VM_VER,
-  });
-  defineProperty(Violentmonkey, 'isInstalled', {
-    value: (name, namespace) => bridge.send('CheckScript', { name, namespace }),
-  });
-  defineProperty(window.external, 'Violentmonkey', {
-    value: Violentmonkey,
-  });
 }

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -84,6 +84,15 @@
             <a class="ml-1" href="https://violentmonkey.github.io/posts/inject-into-context/" target="_blank" rel="noopener noreferrer" v-text="i18n('learnInjectionMode')"></a>
           </label>
         </div>
+        <div class="mb-1">
+          <locale-group i18n-key="labelExposeStatus">
+            <label v-for="([key, host]) in expose" :key="host" class="mr-1 valign-tb">
+              <setting-check :name="`expose.${key}`"/>
+              <span v-text="host" class="mr-1"/>
+              <a :href="`https://${host}`" target="_blank" rel="noopener noreferrer">&nearr;</a>
+            </label>
+          </locale-group>
+        </div>
       </section>
       <vm-editor />
       <vm-template />
@@ -162,6 +171,7 @@ export default {
   data() {
     return {
       showAdvanced: false,
+      expose: null,
       settings,
       injectIntoOptions,
     };
@@ -183,6 +193,7 @@ export default {
       this.revokers.push(hookSetting(name, val => { settings[name] = normalize(val); }));
       this.$watch(() => settings[name], debounce(this.getUpdater(item), 300));
     });
+    this.expose = Object.keys(options.get('expose')).map(k => [k, decodeURIComponent(k)]);
   },
   beforeDestroy() {
     this.revokers.forEach((revoke) => { revoke(); });
@@ -197,6 +208,9 @@ export default {
     display: inline-block;
     > * {
       vertical-align: middle;
+    }
+    &.valign-tb * {
+      vertical-align: text-bottom;
     }
   }
   textarea {


### PR DESCRIPTION
Tried several approaches, ended up with a predefined object in options: 

```js
expose: { // use percent-encoding for '.'
  'greasyfork%2Eorg': true,
  'sleazyfork%2Eorg': false,
},
```

![image](https://user-images.githubusercontent.com/1310400/79047473-5891c500-7c1f-11ea-914e-72a1bdb9dbbb.png)

For #959 the info might be something like this

> To facilitate script installation Violentmonkey may expose the version of an installed script when "Expose installed version on userscript catalog sites" option in advanced settings is enabled for these popular sites: https://greasyfork.org (enabled by default) and https://sleazyfork.org (disabled by default). The enabled sites will be the only ones where Violentmonkey makes its presence explicitly apparent by exposing this information. Other than that, the only way for an arbitrary site to guess Violentmonkey might be present would be for you to have a userscript running on that site in [page mode](https://violentmonkey.github.io/posts/inject-into-context/).