### PR TITLE
fix: set `this` to `window` for grant-none scripts

### DIFF
--- a/src/background/utils/preinject.js
+++ b/src/background/utils/preinject.js
@@ -1,5 +1,7 @@
 import { getUniqId } from '#/common';
-import { INJECT_CONTENT, INJECTABLE_TAB_URL_RE, METABLOCK_RE } from '#/common/consts';
+import {
+  GRANT_NONE_ARGS, INJECT_CONTENT, INJECTABLE_TAB_URL_RE, METABLOCK_RE,
+} from '#/common/consts';
 import ua from '#/common/ua';
 import cache from './cache';
 import { getScriptsByURL } from './db';
@@ -87,9 +89,15 @@ function prepareScript(script, index, scripts) {
   // adding `;` on a new line in case some required script ends with a line comment
   const reqsSlices = reqs ? [].concat(...reqs.map(req => [req, '\n;'])) : [];
   const hasReqs = reqsSlices.length;
+  const { grant } = meta;
+  const grantNone = !grant?.length || grant.length === 1 && grant[0] === 'none';
   const injectedCode = [
+    `window.${dataKey}=function(${dataKey}`,
+    grantNone ? `,${GRANT_NONE_ARGS.join(',')}` : '',
+    '){try{',
+    grantNone ? '' : 'with(this)',
     // hiding module interface from @require'd scripts so they don't mistakenly use it
-    `window.${dataKey}=function(log){try{with(this)((define,module,exports)=>{`,
+    '((define,module,exports)=>{',
     ...reqsSlices,
     // adding a nested IIFE to support 'use strict' in the code when there are @requires
     hasReqs ? '(()=>{' : '',
@@ -99,13 +107,14 @@ function prepareScript(script, index, scripts) {
     code.endsWith('\n') ? '' : '\n',
     hasReqs ? '})()' : '',
     // Firefox lists .user.js among our own content scripts so a space at start will group them
-    '})()}catch(e){log(e)}}',
+    `})()}catch(e){${dataKey}(e)}}`,
     `\n//# sourceURL=${extensionRoot}${ua.isFirefox ? '%20' : ''}${name}.user.js#${id}`,
   ].join('');
   cache.put(dataKey, injectedCode, TIME_KEEP_DATA);
   scripts[index] = {
     ...script,
     dataKey,
+    grantNone,
     code: isContent ? '' : injectedCode,
     metaStr: code.match(METABLOCK_RE)[1] || '',
     values: values[id],

--- a/src/common/consts.js
+++ b/src/common/consts.js
@@ -11,6 +11,15 @@ export const INJECT_MAPPING = {
   [INJECT_CONTENT]: [INJECT_CONTENT],
 };
 
+export const GRANT_NONE_ARGS = [
+  'GM',
+  'GM_info',
+  'unsafeWindow',
+  'cloneInto',
+  'createObjectIn',
+  'exportFunction',
+];
+
 export const CMD_SCRIPT_ADD = 'AddScript';
 export const CMD_SCRIPT_UPDATE = 'UpdateScript';
 

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -1,9 +1,9 @@
 import { INJECT_PAGE, INJECT_CONTENT } from '#/common/consts';
 import { defineProperty, describeProperty } from '#/common/object';
 import { bindEvents } from '../utils';
-import { forEach, log, logging, remove, Promise } from '../utils/helpers';
+import { forEach, log, remove, Promise } from '../utils/helpers';
 import bridge from './bridge';
-import { wrapGM } from './gm-wrapper';
+import { wrapGmAndRun } from './gm-wrapper';
 import store from './store';
 import './gm-values';
 import './notifications';
@@ -104,5 +104,5 @@ async function onCodeSet(item, fn) {
   if (item.action === 'wait') {
     await bridge.load;
   }
-  wrapGM(item)::fn(logging.error);
+  wrapGmAndRun(item, fn);
 }


### PR DESCRIPTION
Fixes #966 (only in `@grant none` script of course).

The actual execution of script code is moved into wrapGM to avoid transferring and unpacking of arguments. Any objections? Maybe wrapGM should be renamed?