### PR TITLE
Add code auto formatting on save using Prettier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@babel/runtime": "^7.9.2",
     "codemirror": "^5.52.2",
     "core-js": "^3.6.4",
+    "prettier": "^2.0.4",
     "tldjs": "^2.3.1",
     "vue": "^2.6.11",
     "vueleton": "^1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7904,6 +7904,11 @@ prettier@^1.18.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
+prettier@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.4.tgz#2d1bae173e355996ee355ec9830a7a1ee05457ef"
+  integrity sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==
+
 pretty-bytes@^5.1.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.3.0.tgz#f2849e27db79fb4d6cfe24764fc4134f165989f2"


### PR DESCRIPTION
This PR implements a common behavior adopted by developers of having the document automatically formatted once hitting Save.

Hooking up to CM's save I was able to run prettier on the code right before actually saving the content. Pretty simple.

It's pretty rudimentary and probably requires more polishing. I come from React and have no Vue experience, so sorry if what I did doesn't make perfect sense.  

I expressed my concerns in the code, looks for `// TODO:` within the diff.

This addresses the [following isssue](https://github.com/violentmonkey/violentmonkey/issues/971).