### PR TITLE
Omit cookie in WebDAV requests

### DIFF
--- a/src/background/sync/base.js
+++ b/src/background/sync/base.js
@@ -311,10 +311,7 @@ export const BaseService = serviceFactory({
   },
   loadData(options) {
     const { progress } = this;
-    let { delay } = options;
-    if (delay == null) {
-      delay = this.delayTime;
-    }
+    const { delay = this.delayTime } = options;
     let lastFetch = Promise.resolve();
     if (delay) {
       lastFetch = this.lastFetch
@@ -325,17 +322,11 @@ export const BaseService = serviceFactory({
     progress.total += 1;
     onStateChange();
     return lastFetch.then(() => {
-      let { prefix } = options;
-      if (prefix == null) prefix = this.urlPrefix;
-      const headers = Object.assign({}, this.headers, options.headers);
+      options = Object.assign({}, options);
+      options.headers = Object.assign({}, this.headers, options.headers);
       let { url } = options;
-      if (url.startsWith('/')) url = prefix + url;
-      return request(url, {
-        headers,
-        method: options.method,
-        body: options.body,
-        responseType: options.responseType,
-      });
+      if (url.startsWith('/')) url = (options.prefix ?? this.urlPrefix) + url;
+      return request(url, options);
     })
     .then(({ data }) => ({ data }), error => ({ error }))
     .then(({ data, error }) => {

--- a/src/background/sync/base.js
+++ b/src/background/sync/base.js
@@ -3,7 +3,7 @@ import {
 } from '#/common';
 import { TIMEOUT_HOUR } from '#/common/consts';
 import {
-  forEachEntry, objectGet, objectSet, objectPick, objectPurify,
+  forEachEntry, objectSet, objectPick, objectPurify,
 } from '#/common/object';
 import {
   getEventEmitter, getOption, setOption, hookOptions,
@@ -579,6 +579,6 @@ export function setConfig(config) {
 }
 
 hookOptions((data) => {
-  const value = objectGet(data, 'sync.current');
+  const value = data?.['sync.current'];
   if (value) initialize();
 });

--- a/src/background/sync/index.js
+++ b/src/background/sync/index.js
@@ -30,5 +30,4 @@ export {
   getStates,
   authorize,
   revoke,
-  setConfig,
 };

--- a/src/background/sync/onedrive.js
+++ b/src/background/sync/onedrive.js
@@ -50,7 +50,7 @@ const OneDrive = BaseService.extend({
   },
   handleMetaError(res) {
     if (res.status === 404) {
-      const header = res.xhr.getResponseHeader('WWW-Authenticate') || '';
+      const header = res.headers.get('WWW-Authenticate')?.[0] || '';
       if (/^Bearer realm="OneDriveAPI"/.test(header)) {
         return this.refreshToken().then(() => this.getMeta());
       }

--- a/src/background/sync/webdav.js
+++ b/src/background/sync/webdav.js
@@ -133,6 +133,14 @@ const WebDAV = BaseService.extend({
     this.headers.Authorization = `Basic ${auth}`;
     return true;
   },
+  loadData(options) {
+    // Bypassing login CSRF protection in Nextcloud / Owncloud by not sending cookies.
+    // We are not using web UI and cookie authentication, so we don't have to worry about that.
+    // See https://github.com/violentmonkey/violentmonkey/issues/976
+    return BaseService.prototype.loadData.call(this, Object.assign({
+      credentials: 'omit',
+    }, options));
+  },
   handleMetaError(res) {
     if (![
       404, // File not exists

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -139,16 +139,21 @@ export function ensureArray(data) {
  * @return Promise
  */
 export async function request(url, options = {}) {
-  options = Object.assign({}, options);
-  const { responseType, body } = options;
-  if (body && Object.prototype.toString.call(body) === '[object Object]') {
-    options.headers = Object.assign({}, options.headers);
-    options.headers['Content-Type'] = 'application/json';
-    options.body = JSON.stringify(body);
+  const { responseType } = options;
+  const init = {
+    method: options.method,
+    body: options.body,
+    headers: options.headers,
+    credentials: options.credentials,
+  };
+  if (init.body && Object.prototype.toString.call(init.body) === '[object Object]') {
+    init.headers = Object.assign({}, init.headers);
+    init.headers['Content-Type'] = 'application/json';
+    init.body = JSON.stringify(init.body);
   }
   const result = {};
   try {
-    const resp = await fetch(url, options);
+    const resp = await fetch(url, init);
     const loadMethod = {
       arraybuffer: 'arrayBuffer',
       blob: 'blob',

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -1,5 +1,3 @@
-import { forEachEntry } from './object';
-
 // used in an unsafe context so we need to save the original functions
 const perfNow = performance.now.bind(performance);
 const { random, floor } = Math;
@@ -134,73 +132,37 @@ export function ensureArray(data) {
   return Array.isArray(data) ? data : [data];
 }
 
-const binaryTypes = [
-  'blob',
-  'arraybuffer',
-];
-
 /**
  * Make a request.
  * @param {string} url
  * @param {RequestInit} options
  * @return Promise
  */
-export function request(url, options = {}) {
-  return new Promise((resolve, reject) => {
-    const xhr = new XMLHttpRequest();
-    const { responseType } = options;
-    xhr.open(options.method || 'GET', url, true);
-    if (binaryTypes.includes(responseType)) xhr.responseType = responseType;
-    const headers = Object.assign({}, options.headers);
-    let { body } = options;
-    if (body && Object.prototype.toString.call(body) === '[object Object]') {
-      headers['Content-Type'] = 'application/json';
-      body = JSON.stringify(body);
-    }
-    headers::forEachEntry(([name, value]) => {
-      xhr.setRequestHeader(name, value);
-    });
-    xhr.onload = () => {
-      const res = getResponse(xhr, {
-        // status for `file:` protocol will always be `0`
-        status: xhr.status || 200,
-      });
-      if (res.status > 300) {
-        reject(res);
-      } else {
-        resolve(res);
-      }
-    };
-    xhr.onerror = () => {
-      const res = getResponse(xhr, { status: -1 });
-      reject(res);
-    };
-    xhr.onabort = xhr.onerror;
-    xhr.ontimeout = xhr.onerror;
-    xhr.send(body);
-  });
-
-  function getResponse(xhr, extra) {
-    const { responseType } = options;
-    let data;
-    if (binaryTypes.includes(responseType)) {
-      data = xhr.response;
-    } else {
-      data = xhr.responseText;
-    }
-    if (responseType === 'json') {
-      try {
-        data = JSON.parse(data);
-      } catch (e) {
-        // Ignore invalid JSON
-      }
-    }
-    return Object.assign({
-      url,
-      data,
-      xhr,
-    }, extra);
+export async function request(url, options = {}) {
+  options = Object.assign({}, options);
+  const { responseType, body } = options;
+  if (body && Object.prototype.toString.call(body) === '[object Object]') {
+    options.headers = Object.assign({}, options.headers);
+    options.headers['Content-Type'] = 'application/json';
+    options.body = JSON.stringify(body);
   }
+  const result = {};
+  try {
+    const resp = await fetch(url, options);
+    const loadMethod = {
+      arraybuffer: 'arrayBuffer',
+      blob: 'blob',
+      json: 'json',
+    }[responseType] || 'text';
+    // status for `file:` protocol will always be `0`
+    result.status = resp.status || 200;
+    result.headers = resp.headers;
+    result.data = await resp[loadMethod]();
+  } catch {
+    result.status = -1;
+  }
+  if (result.status > 300) throw result;
+  return result;
 }
 
 const SIMPLE_VALUE_TYPE = {

--- a/src/options/views/tab-settings/vm-sync.vue
+++ b/src/options/views/tab-settings/vm-sync.vue
@@ -19,31 +19,31 @@
     </div>
     <p v-if="state" class="mt-1" v-text="state.message"></p>
     <fieldset class="mt-1" v-if="state && state.authType === 'password'">
-      <div class="sync-server-url">
-        <label v-text="i18n('labelSyncServerUrl')"></label>
+      <label class="sync-server-url">
+        <span v-text="i18n('labelSyncServerUrl')"></span>
         <input
           type="text"
           v-model="state.userConfig.serverUrl"
           :disabled="!state.canAuthorize || state.userConfig.anonymous"
         />
-      </div>
+      </label>
       <div class="mt-1">
-        <div class="inline-block mr-2">
-          <label v-text="i18n('labelSyncUsername')"></label>
+        <label class="mr-2">
+          <span v-text="i18n('labelSyncUsername')"></span>
           <input
             type="text"
             v-model="state.userConfig.username"
             :disabled="!state.canAuthorize || state.userConfig.anonymous"
           />
-        </div>
-        <div class="inline-block mr-2">
-          <label v-text="i18n('labelSyncPassword')"></label>
+        </label>
+        <label class="inline-block mr-2">
+          <span v-text="i18n('labelSyncPassword')"></span>
           <input
             type="password"
             v-model="state.userConfig.password"
             :disabled="!state.canAuthorize || state.userConfig.anonymous"
           />
-        </div>
+        </label>
         <label class="mr-2">
           <input
             type="checkbox"


### PR DESCRIPTION
fix #976 

## Changes

- Send internal requests with `fetch`. This affects all requests in Violentmonkey except those sent by `GM_xmlhttpRequest`.
- Omit cookies for WebDAV sync service, bypassing logout/login CSRF protection in NextCloud/OwnCloud. Since we always sent authentication header explicitly in the background, there is no need to worry about CSRF.

## Additional fixes
- Reschedule sync process when sync service is changed.
- Small tweaks on style, to keep the space after colon in languages like English.