### PR TITLE
revert setting `this` to `window` for grant-none scripts 

### DIFF
--- a/src/background/utils/preinject.js
+++ b/src/background/utils/preinject.js
@@ -89,7 +89,7 @@ function prepareScript(script, index, scripts) {
   const hasReqs = reqsSlices.length;
   const injectedCode = [
     // hiding module interface from @require'd scripts so they don't mistakenly use it
-    `window.${dataKey}=function(log){try{with(this)((define,module,exports)=>{`,
+    `window.${dataKey}=function(${dataKey}){try{with(this)((define,module,exports)=>{`,
     ...reqsSlices,
     // adding a nested IIFE to support 'use strict' in the code when there are @requires
     hasReqs ? '(()=>{' : '',
@@ -99,7 +99,7 @@ function prepareScript(script, index, scripts) {
     code.endsWith('\n') ? '' : '\n',
     hasReqs ? '})()' : '',
     // Firefox lists .user.js among our own content scripts so a space at start will group them
-    '})()}catch(e){log(e)}}',
+    `})()}catch(e){${dataKey}(e)}}`,
     `\n//# sourceURL=${extensionRoot}${ua.isFirefox ? '%20' : ''}${name}.user.js#${id}`,
   ].join('');
   cache.put(dataKey, injectedCode, TIME_KEEP_DATA);

--- a/src/common/consts.js
+++ b/src/common/consts.js
@@ -11,15 +11,6 @@ export const INJECT_MAPPING = {
   [INJECT_CONTENT]: [INJECT_CONTENT],
 };
 
-export const GRANT_NONE_ARGS = [
-  'GM',
-  'GM_info',
-  'unsafeWindow',
-  'cloneInto',
-  'createObjectIn',
-  'exportFunction',
-];
-
 export const CMD_SCRIPT_ADD = 'AddScript';
 export const CMD_SCRIPT_UPDATE = 'UpdateScript';
 

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -1,9 +1,9 @@
 import { INJECT_PAGE, INJECT_CONTENT } from '#/common/consts';
 import { defineProperty, describeProperty } from '#/common/object';
 import { bindEvents } from '../utils';
-import { forEach, log, remove, Promise } from '../utils/helpers';
+import { forEach, log, logging, remove, Promise } from '../utils/helpers';
 import bridge from './bridge';
-import { wrapGmAndRun } from './gm-wrapper';
+import { wrapGM } from './gm-wrapper';
 import store from './store';
 import './gm-values';
 import './notifications';
@@ -104,5 +104,5 @@ async function onCodeSet(item, fn) {
   if (item.action === 'wait') {
     await bridge.load;
   }
-  wrapGmAndRun(item, fn);
+  wrapGM(item)::fn(logging.error);
 }


### PR DESCRIPTION
Turns out Tampermonkey sets `this` to the miniwrapper so I'm reverting d4b6805 thus restoring the old VM's behavior. TM also doesn't define unsafeWindow but since no one complained about this in VM I'm leaving it unchanged.

AFAICT, either behavior is fine and compatible with userscripts in grant-less mode but a) my improvement wasn't improving anything since no one expected it anyway and b) it was adding complexity to the code.