### PR TITLE
feat: [editor] support autocomplete

### DIFF
--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -494,6 +494,26 @@ $selectionDarkBg: rgba(73, 72, 62, .99);
   }
 }
 
+/* CodeMirror show-hints fix to work here */
+.CodeMirror-hints {
+  z-index: 9999;
+  /* consistent font with the rest, copied from .monospace-font rule from style/style.css */
+  font-family: "Fira Code", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", Courier, monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  .CodeMirror-hints {
+    background: var(--bg);
+  }
+  .CodeMirror-hint {
+    color: var(--fg);
+  }
+  li.CodeMirror-hint-active {
+    background:white ;
+    color: #08f;
+  }
+}
+
 /* fix contenteditable selection color bug */
 .cm-s-eclipse .CodeMirror-line {
   ::selection {

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -507,8 +507,8 @@ $selectionDarkBg: rgba(73, 72, 62, .99);
     color: var(--fg);
   }
   li.CodeMirror-hint-active {
-    background:white ;
-    color: #08f;
+    background: white ;
+    color: var(--fg);
   }
 }
 

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -102,19 +102,12 @@ CodeMirror.commands.insertTab = cm => (
   cm.options.indentWithTabs ? insertTab(cm) : insertSoftTab(cm)
 );
 
-function autoHintWithFallback(cm, options) {
-  var result = null;
-  var hintFn = cm.getHelper(cm.getCursor(), 'hint');
-  if (hintFn) {
-    result = hintFn(cm, options);
-  }
-  // fallback to anyword if default returns nothing
-  if (!result || result.list.length < 1) {
-    result = CodeMirror.hint.anyword(cm, options);
-  }
-  return result;
+function autoHintWithFallback(cm, opts) {
+  const result = cm.getHelper(cm.getCursor(), 'hint')?.(cm, opts);
+  // fallback to anyword if default returns nothing (or no default)
+  return result?.list.length ? result : CodeMirror.hint.anyword(cm, opts);
 }
-CodeMirror.registerHelper('hint', 'autoHintWithFallback',  autoHintWithFallback);
+CodeMirror.registerHelper('hint', 'autoHintWithFallback', autoHintWithFallback);
 
 CodeMirror.commands.autocomplete = (cm) => {
   cm.showHint({ hint: CodeMirror.hint.autoHintWithFallback });

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -497,9 +497,6 @@ $selectionDarkBg: rgba(73, 72, 62, .99);
 /* CodeMirror show-hints fix to work here */
 .CodeMirror-hints {
   z-index: 9999;
-  /* consistent font with the rest, copied from .monospace-font rule from style/style.css */
-  font-family: "Fira Code", Menlo, Monaco, Consolas, "Liberation Mono"
-                , "Courier New", Courier, monospace;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -67,8 +67,8 @@ import 'codemirror/addon/search/searchcursor';
 import 'codemirror/addon/selection/active-line';
 import 'codemirror/keymap/sublime';
 import 'codemirror/addon/hint/show-hint.css';
-import 'codemirror/addon/hint/show-hint.js';
-import 'codemirror/addon/hint/anyword-hint.js';
+import 'codemirror/addon/hint/show-hint';
+import 'codemirror/addon/hint/anyword-hint';
 import CodeMirror from 'codemirror';
 import Tooltip from 'vueleton/lib/tooltip/bundle';
 import ToggleButton from '#/common/ui/toggle-button';
@@ -102,7 +102,7 @@ CodeMirror.commands.insertTab = cm => (
 );
 
 CodeMirror.commands.autocomplete = (cm) => {
-  cm.showHint({hint: CodeMirror.hint.anyword});
+  cm.showHint({ hint: CodeMirror.hint.anyword });
 };
 
 export const cmOptions = {
@@ -308,7 +308,7 @@ export default {
       cm.setOption('extraKeys', {
         Esc: 'cancel',
         F1: 'showHelp',
-        "Ctrl-Space": "autocomplete",
+        'Ctrl-Space': 'autocomplete',
       });
       Object.assign(CodeMirror.commands, {
         cancel: () => {
@@ -498,7 +498,8 @@ $selectionDarkBg: rgba(73, 72, 62, .99);
 .CodeMirror-hints {
   z-index: 9999;
   /* consistent font with the rest, copied from .monospace-font rule from style/style.css */
-  font-family: "Fira Code", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", Courier, monospace;
+  font-family: "Fira Code", Menlo, Monaco, Consolas, "Liberation Mono"
+                , "Courier New", Courier, monospace;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -522,8 +522,8 @@ $selectionDarkBg: rgba(73, 72, 62, .99);
     color: var(--fg);
   }
   li.CodeMirror-hint-active {
-    background: white ;
-    color: var(--fg);
+    background: var(--fg);
+    color: var(--bg);
   }
 }
 

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -68,6 +68,7 @@ import 'codemirror/addon/selection/active-line';
 import 'codemirror/keymap/sublime';
 import 'codemirror/addon/hint/show-hint.css';
 import 'codemirror/addon/hint/show-hint';
+import 'codemirror/addon/hint/javascript-hint';
 import 'codemirror/addon/hint/anyword-hint';
 import CodeMirror from 'codemirror';
 import Tooltip from 'vueleton/lib/tooltip/bundle';
@@ -101,8 +102,22 @@ CodeMirror.commands.insertTab = cm => (
   cm.options.indentWithTabs ? insertTab(cm) : insertSoftTab(cm)
 );
 
+function autoHintWithFallback(cm, options) {
+  var result = null;
+  var hintFn = cm.getHelper(cm.getCursor(), 'hint');
+  if (hintFn) {
+    result = hintFn(cm, options);
+  }
+  // fallback to anyword if default returns nothing
+  if (!result || result.list.length < 1) {
+    result = CodeMirror.hint.anyword(cm, options);
+  }
+  return result;
+}
+CodeMirror.registerHelper('hint', 'autoHintWithFallback',  autoHintWithFallback);
+
 CodeMirror.commands.autocomplete = (cm) => {
-  cm.showHint({ hint: CodeMirror.hint.anyword });
+  cm.showHint({ hint: CodeMirror.hint.autoHintWithFallback });
 };
 
 export const cmOptions = {

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -66,6 +66,9 @@ import 'codemirror/addon/search/match-highlighter';
 import 'codemirror/addon/search/searchcursor';
 import 'codemirror/addon/selection/active-line';
 import 'codemirror/keymap/sublime';
+import 'codemirror/addon/hint/show-hint.css';
+import 'codemirror/addon/hint/show-hint.js';
+import 'codemirror/addon/hint/anyword-hint.js';
 import CodeMirror from 'codemirror';
 import Tooltip from 'vueleton/lib/tooltip/bundle';
 import ToggleButton from '#/common/ui/toggle-button';
@@ -97,6 +100,10 @@ const { insertTab, insertSoftTab } = CodeMirror.commands;
 CodeMirror.commands.insertTab = cm => (
   cm.options.indentWithTabs ? insertTab(cm) : insertSoftTab(cm)
 );
+
+CodeMirror.commands.autocomplete = (cm) => {
+  cm.showHint({hint: CodeMirror.hint.anyword});
+};
 
 export const cmOptions = {
   continueComments: true,
@@ -301,6 +308,7 @@ export default {
       cm.setOption('extraKeys', {
         Esc: 'cancel',
         F1: 'showHelp',
+        "Ctrl-Space": "autocomplete",
       });
       Object.assign(CodeMirror.commands, {
         cancel: () => {

--- a/src/common/ui/style/style.css
+++ b/src/common/ui/style/style.css
@@ -318,7 +318,8 @@ li {
 }
 
 .monospace-font,
-.editor-code .CodeMirror {
+.editor-code .CodeMirror,
+.CodeMirror-hints.eclipse /* use .eclipse as a workaround to override default CodeMirror-hints style */ {
   /* Use `Courier New` to ensure `&nbsp;` has the same width as an original space. */
   font-family: "Fira Code", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", Courier, monospace;
 }


### PR DESCRIPTION
Support basic autocomplete using `Ctrl-Space`.

The main logic comes from CodeMirror's auto complete: https://codemirror.net/demo/anywordhint.html

UI on violentmonkey's script editor:
![image](https://user-images.githubusercontent.com/250644/87231532-ca87c080-c36c-11ea-9273-f384cc09ef70.png)
![image](https://user-images.githubusercontent.com/250644/87231538-d5425580-c36c-11ea-8125-9126c740cbfb.png)
