### PR TITLE
let script installed from http localhost support check for update

### DIFF
--- a/src/background/utils/db.js
+++ b/src/background/utils/db.js
@@ -455,7 +455,7 @@ export async function parseScript(src) {
   if (!meta.homepageURL && !script.custom.homepageURL && isRemote(src.from)) {
     script.custom.homepageURL = src.from;
   }
-  if (isRemote(src.url)) script.custom.lastInstallURL = src.url;
+  if (/^https?:\/\//.test(src.url)) script.custom.lastInstallURL = src.url;
   if (src.position) script.props.position = +src.position;
   buildPathMap(script, src.url);
   await saveScript(script, src.code);


### PR DESCRIPTION
Close #1020 

I'm a tad uncertain whether there is some unintended consequence, because the old logic explicitly blocks scripts from `http://localhost` from supporting check for update (by the check `isRemote()`).

https://github.com/violentmonkey/violentmonkey/blob/a466ca34233ef3f58aee59f1ccb6bfc8ba697263/src/common/index.js#L112-L114