### PR TITLE
fix: workaround for badge update bug in FF

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -68,7 +68,10 @@ Object.assign(commands, {
     if (isApplied) {
       const data = await getInjectedScripts(url, tab.id, frameId);
       addValueOpener(tab.id, frameId, data.withValueIds);
-      setBadge(data.enabledIds, src);
+      const badgeData = [data.enabledIds, src];
+      setBadge(...badgeData);
+      // FF bug: the badge is reset because sometimes tabs get their real/internal url later
+      if (ua.isFirefox) cache.put(`badge:${tab.id}${url}`, badgeData);
       Object.assign(res, data.inject);
       data.registration?.then(r => r.unregister());
       // Injecting known content mode scripts without waiting for InjectionFeedback

--- a/src/background/utils/icon.js
+++ b/src/background/utils/icon.js
@@ -2,6 +2,7 @@ import { i18n, noop } from '#/common';
 import ua from '#/common/ua';
 import { INJECTABLE_TAB_URL_RE } from '#/common/consts';
 import { objectPick } from '#/common/object';
+import cache from './cache';
 import { postInitialize } from './init';
 import { forEachTab } from './message';
 import { getOption, hookOptions } from './options';
@@ -67,10 +68,15 @@ browser.tabs.onRemoved.addListener((id) => {
 });
 
 browser.tabs.onUpdated.addListener((tabId, info, tab) => {
+  const { url } = info;
+  if (url && ua.isFirefox) {
+    const badgeData = cache.pop(`badge:${tabId}${url}`);
+    if (badgeData) setBadge(...badgeData);
+  }
   if (info.status === 'loading'
       // at least about:newtab in Firefox may open without 'loading' status
       || info.favIconUrl && tab.url.startsWith('about:')) {
-    updateState(tab, info.url);
+    updateState(tab, url);
   }
 });
 


### PR DESCRIPTION
In FF, tab injection sometimes starts before the tab receives its `url` internally. So our `GetInjected` sets the badge, then url is assigned internally and the badge is reset. Fixes #1037.