### PR TITLE
fix: restore wrappedJSObject workaround

### DIFF
--- a/src/injected/web/gm-wrapper.js
+++ b/src/injected/web/gm-wrapper.js
@@ -136,6 +136,10 @@ if (global !== window) {
     }
   });
 }
+// FF doesn't expose wrappedJSObject as own property so we add it explicitly
+if (global.wrappedJSObject) {
+  globalKeys.push('wrappedJSObject');
+}
 const inheritedKeys = new Set([
   ...getOwnPropertyNames(EventTarget.prototype),
   ...getOwnPropertyNames(Object.prototype),


### PR DESCRIPTION
Restores the fix for #765 which was lost in a2cb1c67.