### PR TITLE
feat: option to open editor in new window from popup

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -590,6 +590,15 @@ msgUpdating:
 noValues:
   description: Label shown when there is no value for current script.
   message: No value is stored
+optionEditorWindow:
+  description: Label for the option in settings
+  message: Open editor from popup in a new window
+optionEditorWindowHint:
+  description: Tooltip for optionEditorWindow in case the browser doesn't support onBoundsChanged
+  message: Editor window position will be remembered only on resizing or saving
+optionEditorWindowSimple:
+  description: Label for the editor window type
+  message: Hide omnibox
 optionPopupEnabledFirst:
   description: Option to show enabled scripts first in popup.
   message: Enabled first

--- a/src/background/utils/tabs.js
+++ b/src/background/utils/tabs.js
@@ -1,7 +1,8 @@
-import { getActiveTab, sendTabCmd, getFullUrl } from '#/common';
+import { getActiveTab, noop, sendTabCmd, getFullUrl } from '#/common';
 import ua from '#/common/ua';
 import { extensionRoot } from './init';
 import { commands } from './message';
+import { getOption } from './options';
 
 const openers = {};
 
@@ -12,6 +13,7 @@ Object.assign(commands, {
     active = true,
     container,
     insert = true,
+    maybeInWindow = false,
     pinned,
   }, src = {}) {
     // src.tab may be absent when invoked from popup (e.g. edit/create buttons)
@@ -21,23 +23,40 @@ Object.assign(commands, {
     const isInternal = !srcUrl || srcUrl.startsWith(extensionRoot);
     // only incognito storeId may be specified when opening in an incognito window
     const { incognito, windowId } = srcTab;
+    // Chrome can't open chrome-xxx: URLs in incognito windows
+    const canOpenIncognito = !incognito || ua.isFirefox || !/^(chrome[-\w]*):/.test(url);
     let storeId = srcTab.cookieStoreId;
     if (storeId && !incognito) {
       storeId = getContainerId(isInternal ? 0 : container) || storeId;
     }
+    if (storeId) storeId = { cookieStoreId: storeId };
     if (!url.startsWith('blob:')) {
       // URL needs to be expanded to check the protocol for 'chrome' below
       if (!isInternal) url = getFullUrl(url, srcUrl);
       else if (!/^\w+:/.test(url)) url = browser.runtime.getURL(url);
     }
-    const { id, windowId: newWindowId } = await browser.tabs.create({
+    let newTab;
+    if (maybeInWindow && browser.windows && getOption('editorWindow')) {
+      const wndOpts = {
+        url,
+        incognito: canOpenIncognito && incognito,
+        ...getOption('editorWindowSimple') && { type: 'popup' },
+        ...ua.isChrome && { focused: !!active }, // FF doesn't support this
+        ...storeId,
+      };
+      const pos = getOption('editorWindowPos');
+      const hasPos = pos && 'top' in pos;
+      const wnd = await browser.windows.create({ ...wndOpts, ...pos }).catch(hasPos && noop)
+        || hasPos && await browser.windows.create(wndOpts);
+      newTab = wnd.tabs[0];
+    }
+    const { id, windowId: newWindowId } = newTab || await browser.tabs.create({
       url,
       // normalizing as boolean because the API requires strict types
       active: !!active,
       pinned: !!pinned,
-      ...storeId && { cookieStoreId: storeId },
-      // Chrome can't open chrome-xxx: URLs in incognito windows
-      ...(!incognito || ua.isFirefox || !/^(chrome[-\w]*):/.test(url)) && {
+      ...storeId,
+      ...canOpenIncognito && {
         windowId,
         ...insert && { index: srcTab.index + 1 },
         ...ua.openerTabIdSupported && { openerTabId: srcTab.id },

--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -108,6 +108,8 @@ if (!global.browser?.runtime?.sendMessage) {
     },
     webRequest: true,
     windows: {
+      create: wrapAsync,
+      getCurrent: wrapAsync,
       update: wrapAsync,
     },
   };

--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -46,6 +46,9 @@ export default {
     tabSize: 2,
     undoDepth: 200,
   },
+  editorWindow: false, // whether popup opens editor in a new window
+  editorWindowPos: {}, // { left, top, width, height }
+  editorWindowSimple: true, // whether to open a simplified popup or a normal browser window
   scriptTemplate: `\
 // ==UserScript==
 // @name        New script {{name}}

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -10,6 +10,18 @@
         </label>
       </div>
       <div class="mb-1">
+        <label class="mr-2" >
+          <setting-check name="editorWindow" />
+          <tooltip :content="editorWindowHint" :disabled="!editorWindowHint">
+            <span v-text="i18n('optionEditorWindow')"></span>
+          </tooltip>
+        </label>
+        <label>
+          <setting-check name="editorWindowSimple" />
+          <span v-text="i18n('optionEditorWindowSimple')"></span>
+        </label>
+      </div>
+      <div class="mb-1">
         <label>
           <locale-group i18n-key="labelPopupSort">
             <select v-model="settings['filtersPopup.sort']">
@@ -103,6 +115,7 @@
 </template>
 
 <script>
+import Tooltip from 'vueleton/lib/tooltip/bundle';
 import { debounce } from '#/common';
 import {
   INJECT_AUTO,
@@ -167,6 +180,7 @@ export default {
     VmCss,
     SettingCheck,
     LocaleGroup,
+    Tooltip,
   },
   data() {
     return {
@@ -175,6 +189,11 @@ export default {
       settings,
       injectIntoOptions,
     };
+  },
+  computed: {
+    editorWindowHint() {
+      return global.chrome.windows?.onBoundsChanged ? null : this.i18n('optionEditorWindowHint');
+    },
   },
   methods: {
     getUpdater({ name, normalize }) {

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -239,6 +239,7 @@ export default {
     onEditScript(item) {
       sendCmd('TabOpen', {
         url: `/options/index.html#scripts/${item.data.props.id}`,
+        maybeInWindow: true,
       });
       window.close();
     },
@@ -274,6 +275,7 @@ export default {
       });
       sendCmd('TabOpen', {
         url: `/options/index.html#scripts/_new${id ? `/${id}` : ''}`,
+        maybeInWindow: true,
       });
       window.close();
     },


### PR DESCRIPTION
Fixes #1058.

The option is added in general section:

`[x] Open editor from popup in a new window`

The size/position of such a separate window is remembered automatically. In browsers that don't support chrome.windows.onBoundsChanged (only Chrome 86+ at the moment) a tooltip is displayed:

`Editor window position will be remembered only on resizing or saving`