### PR TITLE
fix: use the default CM theme in default light mode

### DIFF
--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -51,7 +51,6 @@
 
 <script>
 import 'codemirror/lib/codemirror.css';
-import 'codemirror/theme/eclipse.css';
 import 'codemirror-js-mixed/mode/javascript-mixed/javascript-mixed';
 import 'codemirror/addon/comment/continuecomment';
 import 'codemirror/addon/comment/comment';
@@ -118,7 +117,7 @@ export const cmOptions = {
   styleActiveLine: true,
   foldGutter: true,
   gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
-  theme: 'eclipse',
+  theme: 'default',
   mode: 'javascript-mixed',
   lineNumbers: true,
   matchBrackets: true,
@@ -521,7 +520,7 @@ $selectionDarkBg: rgba(73, 72, 62, .99);
 }
 
 /* fix contenteditable selection color bug */
-.cm-s-eclipse .CodeMirror-line {
+.CodeMirror .CodeMirror-line {
   ::selection {
     background: $selectionBg;
   }
@@ -540,7 +539,7 @@ $selectionDarkBg: rgba(73, 72, 62, .99);
     background-color: hsla(40, 100%, 50%, 0.1);
   }
   // mostly copied from Monokai theme
-  .cm-s-eclipse {
+  .CodeMirror-wrap {
     &.CodeMirror {
       color: var(--fg);
       background: var(--bg);

--- a/src/common/ui/style/style.css
+++ b/src/common/ui/style/style.css
@@ -319,7 +319,7 @@ li {
 
 .monospace-font,
 .editor-code .CodeMirror,
-.CodeMirror-hints.eclipse /* use .eclipse as a workaround to override default CodeMirror-hints style */ {
+.CodeMirror-hints.default /* CSS specificity hack to override default CM style */ {
   /* Use `Courier New` to ensure `&nbsp;` has the same width as an original space. */
   font-family: "Fira Code", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", Courier, monospace;
 }


### PR DESCRIPTION
Fixes #1067.

CodeMirror no longer uses the bad pure green `#00ff00`, it switched to `#00bb00` so we can revert to the `default` theme now.