### PR TITLE
fix: always set each script's `window` to its own wrapper

### DIFF
--- a/src/injected/web/gm-wrapper.js
+++ b/src/injected/web/gm-wrapper.js
@@ -329,7 +329,7 @@ function makeGlobalWrapper(local) {
     },
   });
   for (const [name, desc] of unforgeables) {
-    if (desc.get && (name === 'window' || name === 'top' && IS_TOP)) {
+    if (name === 'window' || name === 'top' && IS_TOP) {
       delete desc.get;
       delete desc.set;
       desc.value = wrapper;


### PR DESCRIPTION
This was bad... RC was reusing `window` of the first script in all subsequent ones.