### PR TITLE
feat: add a note in UI about using custom CM themes

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -122,6 +122,10 @@ descEditorOptions:
     them may not work in Violentmonkey. See <a
     href="https://codemirror.net/doc/manual.html#config" target="_blank"
     rel="noopener noreferrer">full list</a>.
+    To use a custom CodeMirror theme, specify its file name like
+    <code>"theme": "3024-day"</code> here and paste the
+    <a href="https://github.com/codemirror/CodeMirror/tree/master/theme" target="_blank"
+    rel="noopener noreferrer">actual theme's CSS</a> in "Custom Style" input below.
 editHelpDocumention:
   description: Label in the editor help tab for the documentation link.
   message: 'Documentation on userscript metadata block and <code>GM</code> API:'


### PR DESCRIPTION
Now that thanks to d1539d3 themes can be used as is, without editing them, this PR adds a simple how-to:

> Custom options for CodeMirror and addons in JSON object like `{"indentUnit":2, "smartIndent":true}` however note that some of them may not work in Violentmonkey. See [full list](https://codemirror.net/doc/manual.html#config). To use a custom CodeMirror theme, specify its file name like `"theme": "3024-day"` here and paste the [actual theme's CSS](https://github.com/codemirror/CodeMirror/tree/master/theme) in "Custom Style" input below.