### PR TITLE
Proposal: beta releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Violentmonkey
-=============
+# Violentmonkey
 
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/v/jinjaccalgkegednnccohejagnlnfdag.svg)](https://chrome.google.com/webstore/detail/violentmonkey/jinjaccalgkegednnccohejagnlnfdag)
 [![Firefox Add-ons](https://img.shields.io/amo/v/violentmonkey.svg)](https://addons.mozilla.org/firefox/addon/violentmonkey)
@@ -12,14 +11,17 @@ It works on browsers with [WebExtensions](https://developer.mozilla.org/en-US/Ad
 
 More details can be found [here](https://violentmonkey.github.io/).
 
-Related projects
----
+## Related projects
+
 - [Violentmonkey for Opera Presto](https://github.com/violentmonkey/violentmonkey-oex)
 - [Violentmonkey for Maxthon](https://github.com/violentmonkey/violentmonkey-mx)
 
-Development
----
-Make sure [Node.js](https://nodejs.org/) greater than v10.0 is installed.
+## Workflows
+
+### Development
+
+Make sure [Node.js](https://nodejs.org/) greater than v10.0 and Yarn v1.x is installed.
+
 ``` sh
 # Install dependencies
 $ yarn
@@ -27,10 +29,37 @@ $ yarn
 # Watch and compile
 $ yarn dev
 ```
+
 Then load the extension from 'dist/'.
 
-Build
----
+### Building
+
+After a new (pre)release is created, we should build the project and upload to web stores.
+
 ``` sh
+# Build for normal releases
 $ yarn build
+
+# Build for self-hosted release that has an update_url
+$ yarn build:selfHosted
+```
+
+### Prerelease
+
+```sh
+$ yarn bump
+```
+
+### Release
+
+```sh
+$ yarn version --patch
+```
+
+### Announcing updates
+
+Create a new `updates.json` so that self-hosted versions can be updated to the new version.
+
+```sh
+$ yarn update:selfHosted
 ```

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "2.12.7",
   "scripts": {
     "dev": "gulp dev",
-    "prebuild": "yarn lint",
+    "prebuild": "yarn ci",
     "build": "cross-env NODE_ENV=production gulp build",
-    "build:firefox": "cross-env TARGET=firefox yarn build",
+    "build:selfHosted": "cross-env TARGET=selfHosted yarn build",
     "analyze": "cross-env RUN_ENV=analyze npm run build",
     "i18n": "gulp i18n",
     "copyI18n": "gulp copyI18n",
@@ -14,7 +14,11 @@
     "lint:yml": "gulp check",
     "svgo": "plaid svgo",
     "test": "cross-env BABEL_ENV=test tape -r ./test/mock/register 'test/**/*.test.js'",
-    "transform": "locky yarn yarn"
+    "ci": "yarn lint && yarn test",
+    "transform": "locky yarn yarn",
+    "bump": "yarn ci && gulp bump --commit",
+    "preversion": "yarn ci && gulp bump --reset",
+    "update:selfHosted": "gulp updateVersions"
   },
   "description": "Violentmonkey",
   "devDependencies": {


### PR DESCRIPTION
This is a proposal workflow for self-hosted releases or beta releases that can be published more frequently and tested by power users.

Since we don't have a lot of developers and we are unlikely to develop many features concurrently, I don't think it necessary to have multiple channels like in tremendous projects as Chrome and Firefox. So this proposal is actually prereleases + milestone like releases.

1. version numbers
    Web extensions do not support semver (maybe supported by some, but not all), we can use more dot separated numbers as version numbers. An extra number is added to make this work.
    For example, say `2.12.7` is a release, the following prereleases can be `2.12.7.1`, `2.12.7.2`, etc. And when it comes to a next release, the extra number can be removed (or reset to 0 and omitted), i.e. `2.12.8`.

2. making prereleases
    A new command is added to create prereleases: `yarn bump`.
    Under the hood it just increases `beta` (the extra number) in `package.json` and creates a commit with a prerelease tag.

3. making releases
    There is no change in the command, which should be `yarn version --patch`. Just that when `version` is changed, the `beta` field will be removed.

4. self-hosted release
    In Chrome, a separate extension is supposed to be created and named *Violentmonkey BETA*, released with an extra version number as mentioned above.
    In Firefox we can use self-hosted channel for testing purpose as recommended by AMO.
    The self-hosted version will be built with `yarn build:selfHosted`. The difference is that an `update_url` will be inserted to `manifest` for update checking.
    Another command `yarn update:selfHosted` will update the version list file on GitHub, so that the self-hosted extension can get a list of the latest (pre)releases there.

Caveats:

- Why not use semver prereleases?
    First, not all browsers support prereleases. Another problem is that, if we transform semver to a string with dot separated numbers, we need to change the first 3 numbers to that from the last release. For example, `2.12.8-1` should be transformed to `2.12.7.1` because `2.12.8` is not created yet. But I guess it's not so easy to find the last release number. So it's much simpler to use an extra number rather than change `version` directly.