### PR TITLE
fix: use RFC algo for UUID

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -66,10 +66,6 @@ export function throttle(func, time) {
 
 export function noop() {}
 
-export function getRnd4() {
-  return Math.floor((1 + Math.random()) * 0x10000).toString(16).slice(-4);
-}
-
 export function getUniqId(prefix = 'VM') {
   const now = perfNow();
   return prefix


### PR DESCRIPTION
Fixes #1087.

The advantage is that it's specification-compliant and a single crypto.getRandomValues is faster than multiple Math.random.
The only drawback is that we lose 6 bits of randomness out of 96 we had previously but I think we can live with that :-)