### PR TITLE
fix: accept any MIME type on update check + show error info

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -205,6 +205,8 @@ filterScopeCode:
 filterScopeName:
   description: Option in dashboard's search scope filter.
   message: Name
+genericError:
+  message: Error
 genericOff:
   description: 'To indicate something is turned off or disabled, similar to "no".'
   message: 'off'

--- a/src/background/utils/update.js
+++ b/src/background/utils/update.js
@@ -73,7 +73,7 @@ async function downloadUpdate({ props: { id }, meta, custom }) {
   announce(i18n('msgCheckingForUpdate'));
   try {
     const { data } = await request(updateURL, {
-      headers: { ...NO_HTTP_CACHE, Accept: 'text/x-userscript-meta' },
+      headers: { ...NO_HTTP_CACHE, Accept: 'text/x-userscript-meta,*/*' },
     });
     const { version } = parseMeta(data);
     if (compareVersion(meta.version, version) >= 0) {

--- a/src/background/utils/update.js
+++ b/src/background/utils/update.js
@@ -94,8 +94,8 @@ async function downloadUpdate({ props: { id }, meta, custom }) {
     Object.assign(update, {
       message,
       checking,
-      // `null` is sendable in Chrome unlike `undefined`
-      error: error?.url || error || null,
+      error: error ? `${i18n('genericError')} ${error.status}, ${error.url}` : null,
+      // `null` is transferable in Chrome unlike `undefined`
     });
     sendCmd(CMD_SCRIPT_UPDATE, result);
   }

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -211,7 +211,7 @@ export async function request(url, options = {}) {
     init.headers['Content-Type'] = 'application/json';
     init.body = JSON.stringify(init.body);
   }
-  const result = {};
+  const result = { url, status: -1 };
   try {
     const resp = await fetch(url, init);
     const loadMethod = {
@@ -223,9 +223,7 @@ export async function request(url, options = {}) {
     result.status = resp.status || 200;
     result.headers = resp.headers;
     result.data = await resp[loadMethod]();
-  } catch {
-    result.status = -1;
-  }
+  } catch { /* NOP */ }
   if (result.status < 0 || result.status > 300) throw result;
   return result;
 }

--- a/src/options/views/script-item.vue
+++ b/src/options/views/script-item.vue
@@ -325,7 +325,7 @@ $removedItemHeight: calc(
       fill: #f00;
     }
     .script-message {
-      color: #f00a;
+      color: #f00;
     }
   }
   &-buttons {


### PR DESCRIPTION
* Fixes #1090.

* Restores the correct tooltip with the error details (the `error.url` was lost in 80cde6da0ac731d5a3d13aaedfe2c67db2df0d8a)

  ![image](https://user-images.githubusercontent.com/1310400/97101762-1149be00-16b1-11eb-8ffe-1a40625ce682.png)

* ~shows an instruction how to open devtools of the background page to debug the network problems:~

  <details>
  ![image](https://user-images.githubusercontent.com/1310400/97101993-c6c94100-16b2-11eb-8c37-e1cd5c602c25.png)

  In Firefox the instruction is slightly different, it also doesn't allow extensions to open `about:debugging`.
  </details>