### PR TITLE
fix: tweak and improve find/replace

### DIFF
--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -282,7 +282,7 @@ export default {
         'Shift-Ctrl-/': 'commentSelection',
       });
       cm.on('keyHandled', (_cm, _name, e) => {
-        e.stopPropagation(); // FIXME: not needed? lookupKey seems enough
+        e.stopPropagation();
       });
       this.$emit('ready', cm);
     },

--- a/src/common/ui/toggle-button.vue
+++ b/src/common/ui/toggle-button.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="toggle-button" :class="{active: value}" @click="onToggle">
+  <div class="toggle-button" :class="{active: value}"
+       tabindex="0"
+       @keypress.enter.exact="onToggle"
+       @keypress.space.exact="onToggle"
+       @click="onToggle">
     <slot></slot>
   </div>
 </template>
@@ -29,7 +33,7 @@ export default {
     color: var(--bg);
     background: var(--fill-9);
   }
-  &:hover {
+  &:focus, &:hover {
     filter: brightness(.8);
   }
 }

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -57,7 +57,7 @@
 <script>
 import CodeMirror from 'codemirror';
 import { debounce, i18n, sendCmd } from '#/common';
-import { deepCopy, deepEqual, forEachEntry, objectPick } from '#/common/object';
+import { deepCopy, deepEqual, objectPick } from '#/common/object';
 import VmCode from '#/common/ui/code';
 import options from '#/common/options';
 import { route } from '#/common/router';
@@ -123,19 +123,6 @@ const setupSavePosition = ({ id: curWndId, tabs }) => {
 let K_SAVE; // deduced from the current CodeMirror keymap
 const K_PREV_PANEL = 'Alt-PageUp';
 const K_NEXT_PANEL = 'Alt-PageDown';
-const expandKeyMap = (res, ...maps) => {
-  maps.forEach((map) => {
-    if (typeof map === 'string') map = CodeMirror.keyMap[map];
-    map::forEachEntry(([key, value]) => {
-      if (!res[key] && /^[a-z]+$/i.test(value) && CodeMirror.commands[value]) {
-        res[key] = value;
-      }
-    });
-    if (map.fallthrough) expandKeyMap(res, map.fallthrough);
-  });
-  delete res.fallthrough;
-  return res;
-};
 const compareString = (a, b) => (a < b ? -1 : a > b);
 
 export default {
@@ -229,11 +216,10 @@ export default {
     // hotkeys
     {
       const navLabels = Object.values(this.navItems);
-      const cmOpts = this.$refs.code.cm.options;
       const hotkeys = [
         [K_PREV_PANEL, ` ${navLabels.join(' < ')}`],
         [K_NEXT_PANEL, ` ${navLabels.join(' > ')}`],
-        ...Object.entries(expandKeyMap({}, cmOpts.extraKeys, cmOpts.keyMap))
+        ...Object.entries(this.$refs.code.expandKeyMap())
         .sort((a, b) => compareString(a[1], b[1]) || compareString(a[0], b[0])),
       ];
       K_SAVE = hotkeys.find(([, cmd]) => cmd === 'save')?.[0];


### PR DESCRIPTION
Several tweaks/fixes for bugs or quirks that I wanted to fix a very long time ago, trivial as they are:

* The panel is now at the bottom so it doesn't shift layout - it was distracting and disorientating. An alternative solution might be to use absolute positioning but that would cover the very first line.

* find/findNext/findPrev will continue from the current position if you change it - just like in other apps.

* findNext/findPrev won't steal focus from CM and if you closed the search UI after setting the text to search then the UI won't even show up for these commands - just like in all other apps.

* Revealing next match that is out of viewport will center it - so we can see the surrounding context.
* Fixed findFillQuery so it won't erase the current search text when invoked with nothing selected.
* Removed double-execution due to findFillQuery.
* Removed debounce - seems fast enough.
* Jump to `line:col` syntax - no tooltip but since it's a known thing in other apps people will use it I guess.
* Case-sensitivity and regex toggles are keyboard-accessible now.
* Real hotkeys for the chosen keymap are shown in tooltips.