### PR TITLE
feat: instant inject via synchronous XHR

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -351,6 +351,10 @@ labelInjectionMode:
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
   message: Installing script
+labelInstantInject:
+  message: Use instant injection mode (not recommended)
+labelInstantInjectHint:
+  message: Runs scripts at the real <document-start> reliably. Don't enable unless you do have a script that needs to run before the page starts loading and Violentmonkey is currently running it too late. This mode will be using the deprecated synchronous XHR so you'll see warnings in devtools console, although you can safely ignore them as the adverse affects it warns about are negligible in this case and you can hide the warnings for good by right-clicking one.
 labelKeepOriginal:
   description: Option to keep the original match or ignore rules.
   message: Keep original

--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -27,6 +27,7 @@ export default {
   version: null,
   /** @type 'auto' | 'page' | 'content' */
   defaultInjectInto: INJECT_AUTO,
+  instantInject: false,
   filters: {
     /** @type 'name' | 'code' | 'all' */
     searchScope: 'name',

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -83,6 +83,14 @@
       <section>
         <h3 v-text="i18n('labelGeneral')"></h3>
         <div class="mb-1">
+          <label class="mr-2" >
+            <setting-check name="instantInject" />
+            <tooltip :content="i18n('labelInstantInjectHint')">
+              <span v-text="i18n('labelInstantInject')"></span>
+            </tooltip>
+          </label>
+        </div>
+        <div class="mb-1">
           <label>
             <span v-text="i18n('labelInjectionMode')"></span>
             <select v-model="settings.defaultInjectInto">


### PR DESCRIPTION
Related: #420.

Our [upcoming 2.12.8 release](https://github.com/violentmonkey/violentmonkey/releases) is already sufficiently fast so until proven otherwise we probably shouldn't add this feature but I'm sharing this PR anyway, just in case. As they say, TBD.

FWIW, there seems to be a better alternative for Chrome: inject the prepared data in webNavigation.**onCommitted** via executeScript + run_at:document_start - turns out this runs before the main content scripts in default mode (that is without chrome.declarativeContent). It requires `webNavigation` permission though, which will disable the extension on update, most likely.