### PR TITLE
feat: faster load of popup, editor, dashboard

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,6 +1,6 @@
 import { sendCmd } from '#/common';
 import { TIMEOUT_24HOURS, TIMEOUT_MAX } from '#/common/consts';
-import { forEachEntry, objectSet } from '#/common/object';
+import { deepCopy, forEachEntry, objectSet } from '#/common/object';
 import ua from '#/common/ua';
 import * as sync from './sync';
 import { commands } from './utils';
@@ -53,8 +53,8 @@ hookOptions((changes) => {
 
 Object.assign(commands, {
   /** @return {Promise<Object>} */
-  async GetData() {
-    const data = await getData();
+  async GetData(ids) {
+    const data = await getData(ids);
     data.sync = sync.getStates();
     return data;
   },
@@ -137,6 +137,8 @@ function autoUpdate() {
 }
 
 initialize(() => {
+  global.handleCommandMessage = handleCommandMessage;
+  global.deepCopy = deepCopy;
   browser.runtime.onMessage.addListener(
     ua.isFirefox // in FF a rejected Promise value is transferred only if it's an Error object
       ? (...args) => (

--- a/src/background/utils/cache.js
+++ b/src/background/utils/cache.js
@@ -12,6 +12,9 @@ Object.assign(commands, {
   CacheHit(data) {
     cache.hit(data.key, data.lifetime);
   },
+  CachePop(key) {
+    return cache.pop(key) || null;
+  },
 });
 
 export default cache;

--- a/src/background/utils/db.js
+++ b/src/background/utils/db.js
@@ -331,9 +331,10 @@ function getIconUrls() {
  * @desc Get data for dashboard.
  * @return {Promise<{ scripts: VMScript[], cache: Object }>}
  */
-export async function getData() {
+export async function getData(ids) {
+  const { scripts } = store;
   return {
-    scripts: store.scripts,
+    scripts: ids ? ids.map(getScriptById) : scripts,
     cache: await storage.cache.getMulti(getIconUrls()),
   };
 }

--- a/src/background/utils/popup-tracker.js
+++ b/src/background/utils/popup-tracker.js
@@ -1,10 +1,16 @@
-import { sendTabCmd } from '#/common';
+import { getActiveTab, sendTabCmd } from '#/common';
+import cache from './cache';
 import { postInitialize } from './init';
+import { commands } from './message';
 
 export const popupTabs = {}; // { tabId: 1 }
 
 postInitialize.push(() => {
   browser.runtime.onConnect.addListener(onPopupOpened);
+  browser.webRequest.onBeforeRequest.addListener(prefetchSetPopup, {
+    urls: [browser.runtime.getURL(browser.runtime.getManifest().browser_action.default_popup)],
+    types: ['main_frame'],
+  });
 });
 
 function onPopupOpened(port) {
@@ -12,9 +18,19 @@ function onPopupOpened(port) {
   popupTabs[tabId] = 1;
   sendTabCmd(tabId, 'PopupShown', true);
   port.onDisconnect.addListener(onPopupClosed);
+  delete commands.SetPopup;
 }
 
 function onPopupClosed({ name }) {
   delete popupTabs[name];
   sendTabCmd(+name, 'PopupShown', false);
+}
+
+async function prefetchSetPopup() {
+  const tabId = (await getActiveTab()).id;
+  sendTabCmd(tabId, 'PopupShown', true);
+  commands.SetPopup = async (data, src) => {
+    data.metas = commands.GetMetas(data.ids);
+    cache.put('SetPopup', Object.assign({ [src.frameId]: [data, src] }, cache.get('SetPopup')));
+  };
 }

--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -116,7 +116,7 @@ if (!global.browser?.runtime?.sendMessage) {
   global.browser = wrapAPIs(chrome, meta);
 } else if (process.env.DEBUG && !global.chrome.app) {
   let counter = 0;
-  const { runtime } = browser;
+  const { runtime } = global.browser;
   const { sendMessage, onMessage } = runtime;
   const log = (type, args, id, isResponse) => console.info(
     `%c${type}Message#%d${isResponse ? ' response' : ''}`,
@@ -143,10 +143,4 @@ if (!global.browser?.runtime?.sendMessage) {
     .then(data => log('on', [data], id, true), console.warn);
     return result;
   });
-}
-
-// prefetch the options while the current extension page loads
-/* global browser */
-if (browser.tabs) {
-  global.allOptions = browser.runtime.sendMessage({ cmd: 'GetAllOptions' }).catch(() => {});
 }

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -145,7 +145,7 @@ export function decodeFilename(filename) {
 export async function getActiveTab() {
   const [tab] = await browser.tabs.query({
     active: true,
-    lastFocusedWindow: true, // also gets incognito windows
+    windowId: -2, // chrome.windows.WINDOW_ID_CURRENT works when debugging the popup in devtools
   });
   return tab;
 }

--- a/src/common/load-script-icon.js
+++ b/src/common/load-script-icon.js
@@ -1,0 +1,43 @@
+const images = {};
+
+/**
+ * Sets script's safeIcon property after the image is successfully loaded
+ * @param {VMScript} script
+ * @param {Object} [_]
+ * @param {?string} [_.default]
+ * @param {string} [_.key]
+ * @param {Object} [_.cache]
+ * @returns {Promise<boolean>}
+ */
+export function loadScriptIcon(script, {
+  default: defaultIcon = null,
+  key = 'safeIcon',
+  cache = {},
+} = {}) {
+  const { icon } = script.meta;
+  const url = script.custom?.pathMap?.[icon] || icon;
+  const isNewUrl = url !== script[key];
+  let promise = isNewUrl && url ? images[url] : Promise.resolve(false);
+  if (!promise) {
+    promise = Promise.resolve(cache?.[url] || fetchImage(url));
+    images[url] = promise;
+  }
+  if (isNewUrl || !url) {
+    // creates an observable property so Vue will see the change in then()
+    script[key] = defaultIcon;
+    promise.then(ok => {
+      script[key] = ok ? url : defaultIcon;
+    });
+  }
+  return promise;
+}
+
+async function fetchImage(url) {
+  try {
+    const blob = await (await fetch(url)).blob();
+    await createImageBitmap(blob);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -1,14 +1,11 @@
 import defaults from '#/common/options-defaults';
-import { initHooks, sendCmd } from '.';
+import { initHooks, sendCmdDirectly } from '.';
 import { forEachEntry, objectGet, objectSet } from './object';
 
 let options = {};
 const hooks = initHooks();
-const ready = (global.allOptions || Promise.resolve())
-.then((data) => data || sendCmd('GetAllOptions', null, { retry: true }))
+const ready = sendCmdDirectly('GetAllOptions', null, { retry: true })
 .then((data) => {
-  delete global.allOptions;
-  ready.indeed = true; // a workaround for inability to query native Promise state
   options = data;
   if (data) hooks.fire(data);
 });
@@ -21,7 +18,7 @@ function setOption(key, value) {
   // the updated options object will be propagated from the background script after a pause
   // so meanwhile the local code should be able to see the new value using options.get()
   objectSet(options, key, value);
-  sendCmd('SetOptions', { key, value });
+  sendCmdDirectly('SetOptions', { key, value });
 }
 
 function updateOptions(data) {

--- a/src/common/ui/setting-check.vue
+++ b/src/common/ui/setting-check.vue
@@ -34,8 +34,7 @@ export default {
       this.$emit('change', value);
     },
   },
-  async created() {
-    if (!options.ready.indeed) await options.ready;
+  created() {
     this.revoke = hookSetting(this.name, val => { this.value = val; });
     this.$watch('value', this.onChange);
   },

--- a/src/common/ui/setting-text.vue
+++ b/src/common/ui/setting-text.vue
@@ -31,8 +31,7 @@ export default {
       error: null,
     };
   },
-  async created() {
-    if (!options.ready.indeed) await options.ready;
+  created() {
     const handle = this.json
       ? (value => JSON.stringify(value, null, '  '))
       // XXX compatible with old data format

--- a/src/options/views/script-item.vue
+++ b/src/options/views/script-item.vue
@@ -98,30 +98,12 @@
 <script>
 import Tooltip from 'vueleton/lib/tooltip/bundle';
 import { sendCmd, getLocaleString, formatTime } from '#/common';
-import { objectGet } from '#/common/object';
+import { loadScriptIcon } from '#/common/load-script-icon';
 import Icon from '#/common/ui/icon';
 import { store } from '../utils';
 import enableDragging from '../utils/dragging';
 
 const DEFAULT_ICON = '/public/images/icon48.png';
-const images = {};
-function loadImage(url) {
-  if (!url) return Promise.reject();
-  let promise = images[url];
-  if (!promise) {
-    const cache = store.cache[url];
-    promise = cache
-      ? Promise.resolve(cache)
-      : new Promise((resolve, reject) => {
-        const img = new Image();
-        img.onload = () => resolve(url);
-        img.onerror = () => reject(url);
-        img.src = url;
-      });
-    images[url] = promise;
-  }
-  return promise;
-}
 
 export default {
   props: [
@@ -198,17 +180,8 @@ export default {
     },
   },
   mounted() {
-    const { icon } = this.script.meta;
-    if (icon && icon !== this.safeIcon) {
-      const pathMap = objectGet(this.script, 'custom.pathMap') || {};
-      const fullUrl = pathMap[icon] || icon;
-      loadImage(fullUrl)
-      .then((url) => {
-        this.safeIcon = url;
-      }, () => {
-        this.safeIcon = DEFAULT_ICON;
-      });
-    }
+    loadScriptIcon(this.script, { default: DEFAULT_ICON, cache: store.cache })
+    .then(() => { this.safeIcon = this.script.safeIcon; });
     enableDragging(this.$el, {
       onDrop: (from, to) => this.$emit('move', { from, to }),
     });

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -137,6 +137,7 @@ import LocaleGroup from '#/common/ui/locale-group';
 import { forEachKey } from '#/common/object';
 import { setRoute, lastRoute } from '#/common/router';
 import storage from '#/common/storage';
+import { loadData } from '#/options';
 import ScriptItem from './script-item';
 import Edit from './edit';
 import { store, showConfirmation, showMessage } from '../utils';
@@ -348,7 +349,10 @@ export default {
         this.script = nid && this.scripts.find(script => script.props.id === nid);
         if (!this.script) {
           // First time showing the list we need to tell v-if to keep it forever
-          this.canRenderScripts = true;
+          if (!this.canRenderScripts) {
+            loadData();
+            this.canRenderScripts = true;
+          }
           this.debouncedRender();
           // Strip the invalid id from the URL so |App| can render the aside,
           // which was hidden to avoid flicker on initial page load directly into the editor.

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -204,9 +204,8 @@ export default {
       };
     },
   },
-  async created() {
+  created() {
     this.revokers = [];
-    if (!options.ready.indeed) await options.ready;
     items.forEach((item) => {
       const { name, normalize } = item;
       this.revokers.push(hookSetting(name, val => { settings[name] = normalize(val); }));

--- a/src/popup/utils/index.js
+++ b/src/popup/utils/index.js
@@ -1,4 +1,5 @@
 export const store = {
+  cache: {},
   scripts: [],
   frameScripts: [],
   commands: [],

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -67,7 +67,7 @@
           <div
             class="menu-item menu-area"
             @click="onToggleScript(item)">
-            <img class="script-icon" :src="scriptIconUrl(item)" @error="scriptIconError">
+            <img class="script-icon" :src="item.data.safeIcon" @error="scriptIconError">
             <icon :name="getSymbolCheck(item.data.config.enabled)"></icon>
             <div class="flex-auto ellipsis" v-text="item.name"
                  :class="{failed: item.data.failed}"
@@ -214,10 +214,6 @@ export default {
     },
     getSymbolCheck(bool) {
       return `toggle-${bool ? 'on' : 'off'}`;
-    },
-    scriptIconUrl(item) {
-      const { icon } = item.data.meta;
-      return (item.data.custom.pathMap || {})[icon] || icon || null;
     },
     scriptIconError(event) {
       event.target.removeAttribute('src');


### PR DESCRIPTION
It bugged me for a while that the popup is initially rendered with an empty script list for a fraction of a second. So, I've tried to find a way to improve it. The result is that now all UI loads faster by fetching the data directly from the background page which is synchronous.

Additional speedups:

* dashboard: replaced the very slow `cache2blobUrl` with a data URI.
* editor when launched from popup: `GetData` sends only the edited script at first
* popup: `SetPopup` data is prefetched by the background script when the popup starts loading.

The no longer needed prefetch for options in browser.js was removed.