### PR TITLE
feat: show dashboard favicon in Firefox

### DIFF
--- a/src/options/index.js
+++ b/src/options/index.js
@@ -3,6 +3,7 @@ import { sendCmdDirectly, i18n, getLocaleString } from '#/common';
 import { forEachEntry } from '#/common/object';
 import handlers from '#/common/handlers';
 import options from '#/common/options';
+import ua from '#/common/ua';
 import loadZip from '#/common/zip';
 import '#/common/ui/style';
 import { store } from './utils';
@@ -21,6 +22,13 @@ initialize();
 
 function initialize() {
   initMain();
+  if (ua.isFirefox) { // Firefox doesn't show favicon
+    const icons = browser.runtime.getManifest().browser_action.default_icon;
+    const el = document.createElement('link');
+    el.rel = 'icon';
+    el.href = icons[matchMedia('screen and (min-resolution: 144dpi)').matches ? 32 : 16];
+    document.head.appendChild(el);
+  }
   const vm = new Vue({
     render: h => h(App),
   })


### PR DESCRIPTION
Firefox doesn't show dashboard tab favicon so this PR adds one explicitly.