### PR TITLE
implement run-at: document-body

### DIFF
--- a/src/_locales/de/messages.yml
+++ b/src/_locales/de/messages.yml
@@ -408,7 +408,7 @@ labelReplace:
   message: 'Ersetzen mit: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Ausführen bei (Run-At):'
+  message: 'Ausführen bei (Run-At): '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Standard)

--- a/src/_locales/el/messages.yml
+++ b/src/_locales/el/messages.yml
@@ -387,7 +387,7 @@ labelReplace:
   message: 'Αντικατάσταση με: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Εκτέλεση κατά:'
+  message: 'Εκτέλεση κατά: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Προκαθορισμένο)

--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -398,7 +398,7 @@ labelReplace:
   message: 'Replace with: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Run-At:'
+  message: 'Run-At: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Default)

--- a/src/_locales/es_419/messages.yml
+++ b/src/_locales/es_419/messages.yml
@@ -413,7 +413,7 @@ labelReplace:
   message: 'Remplazar con: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Ejecutar en:'
+  message: 'Ejecutar en: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Predeterminado)

--- a/src/_locales/fi/messages.yml
+++ b/src/_locales/fi/messages.yml
@@ -381,7 +381,7 @@ labelReplace:
   message: 'Korvaa: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Ajoaika:'
+  message: 'Ajoaika: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Oletus)

--- a/src/_locales/fr/messages.yml
+++ b/src/_locales/fr/messages.yml
@@ -410,7 +410,7 @@ labelReplace:
   message: "Remplacer par\_: "
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: "Lancer à\_:"
+  message: "Lancer à\_: "
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Défaut)

--- a/src/_locales/hr/messages.yml
+++ b/src/_locales/hr/messages.yml
@@ -381,7 +381,7 @@ labelReplace:
   message: 'Zamijeni sa: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Run-At:'
+  message: 'Run-At: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Default)

--- a/src/_locales/id/messages.yml
+++ b/src/_locales/id/messages.yml
@@ -402,7 +402,7 @@ labelReplace:
   message: 'Ganti dengan: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Run-At:'
+  message: 'Run-At: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Bawaan)

--- a/src/_locales/it/messages.yml
+++ b/src/_locales/it/messages.yml
@@ -403,7 +403,7 @@ labelReplace:
   message: 'Sostituisci con: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Esegui-In:'
+  message: 'Esegui-In: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Default)

--- a/src/_locales/nl/messages.yml
+++ b/src/_locales/nl/messages.yml
@@ -401,7 +401,7 @@ labelReplace:
   message: 'Vervangen door: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Uitvoeren op:'
+  message: 'Uitvoeren op: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (standaard)

--- a/src/_locales/pl/messages.yml
+++ b/src/_locales/pl/messages.yml
@@ -413,7 +413,7 @@ labelReplace:
   message: 'Zamień na: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Moment uruchomienia:'
+  message: 'Moment uruchomienia: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (domyślny)

--- a/src/_locales/pt_BR/messages.yml
+++ b/src/_locales/pt_BR/messages.yml
@@ -383,7 +383,7 @@ labelReplace:
   message: 'Substituir por: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Executar em:'
+  message: 'Executar em: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Padrão)

--- a/src/_locales/pt_PT/messages.yml
+++ b/src/_locales/pt_PT/messages.yml
@@ -389,7 +389,7 @@ labelReplace:
   message: 'Substituir por: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Executar em:'
+  message: 'Executar em: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Predefinido)

--- a/src/_locales/ro/messages.yml
+++ b/src/_locales/ro/messages.yml
@@ -128,7 +128,7 @@ editHelpDocumention:
   description: Label in the editor help tab for the documentation link.
   message: >-
     Documentație cu privire la blockurile metadatelor usescripturilor și
-    API-urile <code>GM</code>: 
+    API-urile <code>GM</code>:
 editHelpKeyboard:
   description: Label in the editor help tab for the keyboard shortcuts.
   message: Comenzi rapide de la tastatură
@@ -410,7 +410,7 @@ labelReplace:
   message: 'Înlocuiește cu: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Momentul rulării:'
+  message: 'Momentul rulării: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Implicit)

--- a/src/_locales/sk/messages.yml
+++ b/src/_locales/sk/messages.yml
@@ -405,7 +405,7 @@ labelReplace:
   message: 'Nahradiť: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Spustiť pri:'
+  message: 'Spustiť pri: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Predvolené)

--- a/src/_locales/sr/messages.yml
+++ b/src/_locales/sr/messages.yml
@@ -380,10 +380,10 @@ labelRemovedAt:
   message: ''
 labelReplace:
   description: Label for replace input in search box.
-  message: 'Замени са:'
+  message: 'Замени са: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Покрени:'
+  message: 'Покрени: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Подразумевано)

--- a/src/_locales/tr/messages.yml
+++ b/src/_locales/tr/messages.yml
@@ -112,7 +112,7 @@ descEditorOptions:
   description: Description of editor options JSON section.
   message: >-
     CodeMirror  ve JSON eklentileri için <code>{"indentUnit":2,
-    "smartIndent":true}1</code> gibi özelleştirilmiş ayarlar, ancak bazıları 
+    "smartIndent":true}1</code> gibi özelleştirilmiş ayarlar, ancak bazıları
     Violentmonkey'de çalışmayabililir. Tüm listeyi görmek için <a
     href="https://codemirror.net/doc/manual.html#config" target="_blank"
     rel="noopener noreferrer">tıklayın</a>
@@ -392,7 +392,7 @@ labelReplace:
   message: 'Değiştir: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Çalışma yeri:'
+  message: 'Çalışma yeri: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Varsayılan)

--- a/src/_locales/uk/messages.yml
+++ b/src/_locales/uk/messages.yml
@@ -385,7 +385,7 @@ labelReplace:
   message: 'Замінити на: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Виконувати:'
+  message: 'Виконувати: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (за замовчуванням)

--- a/src/_locales/vi/messages.yml
+++ b/src/_locales/vi/messages.yml
@@ -388,7 +388,7 @@ labelReplace:
   message: 'Thay thế bằng: '
 labelRunAt:
   description: Label of script @run-at properties in custom meta data.
-  message: 'Chạy khi:'
+  message: 'Chạy khi: '
 labelRunAtDefault:
   description: Shown when custom @run-at is not assigned.
   message: (Mặc định)

--- a/src/background/utils/db.js
+++ b/src/background/utils/db.js
@@ -661,4 +661,8 @@ export async function vacuum() {
  * @property {string} uri
  * @property {string} uuid
  */
-/** @typedef {'document-start' | 'document-end' | 'document-idle'} VMScriptRunAt */
+/**
+ * @typedef {
+   'document-start' | 'document-body' | 'document-end' | 'document-idle'
+ } VMScriptRunAt
+ */

--- a/src/options/views/edit/settings.vue
+++ b/src/options/views/edit/settings.vue
@@ -28,6 +28,7 @@
         <select v-model="custom.runAt">
           <option value="" v-text="i18n('labelRunAtDefault')"></option>
           <option value="document-start">document-start</option>
+          <option value="document-body">document-body</option>
           <option value="document-end">document-end</option>
           <option value="document-idle">document-idle</option>
         </select>

--- a/src/options/views/tab-settings/vm-import.vue
+++ b/src/options/views/tab-settings/vm-import.vue
@@ -168,7 +168,7 @@ async function importBackup(file) {
         downloadURL: typeof meta.file_url === 'string' ? meta.file_url : undefined,
         // customizing of @noframes isn't implemented yet
         noframes: !!ovr.noframes || (ovr.noframes == null ? undefined : false),
-        runAt: /^document-(start|end|idle)$/.test(opts.run_at) ? opts.run_at : undefined,
+        runAt: /^document-(start|body|end|idle)$/.test(opts.run_at) ? opts.run_at : undefined,
         exclude: toStringArray(ovr.use_excludes),
         include: toStringArray(ovr.use_includes),
         match: toStringArray(ovr.use_matches),


### PR DESCRIPTION
* implement `@run-at document-body`, related: #1137
* add the missing space in labelRunAt for letter-based languages

1. How do I/we update files on transifex for this change? I can do it manually I guess but I'd prefer to upload in one click.
2. Maybe we could instead just check for unicode range of the message in `i18n` and add the space after ASCII colon `:` automatically?