### PR TITLE
feat: implement document-body for content mode

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,4 +1,4 @@
-import { sendCmd } from '#/common';
+import { makePause, sendCmd } from '#/common';
 import { TIMEOUT_24HOURS, TIMEOUT_MAX } from '#/common/consts';
 import { deepCopy, forEachEntry, objectSet } from '#/common/object';
 import ua from '#/common/ua';
@@ -95,6 +95,14 @@ Object.assign(commands, {
         });
       }
     });
+  },
+  /**
+   * Timers in content scripts are shared with the web page so it can clear them.
+   * await sendCmd('SetTimeout', 100) in injected/content
+   * await bridge.send('SetTimeout', 100) in injected/web
+   */
+  SetTimeout(ms) {
+    return ms > 0 && makePause(ms);
   },
 });
 

--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -92,6 +92,7 @@ bridge.addHandlers({
     return styleId;
   },
   CheckScript: sendCmd,
+  SetTimeout: sendCmd,
 });
 
 function sendSetPopup() {

--- a/src/injected/web/bridge.js
+++ b/src/injected/web/bridge.js
@@ -6,7 +6,6 @@ const handlers = {};
 const callbacks = {};
 const bridge = {
   callbacks,
-  load: () => {},
   addHandlers(obj) {
     assign(handlers, obj);
   },

--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -16,7 +16,7 @@ import {
 } from '../utils/helpers';
 
 const {
-  atob, setTimeout,
+  atob,
   Blob, Error, TextDecoder, Uint8Array,
   Array: { prototype: { findIndex, indexOf } },
   Document: { prototype: { getElementById } },
@@ -234,15 +234,14 @@ function getResource(context, name, isBlob) {
   }
 }
 
-function downloadBlob(res) {
+async function downloadBlob(res) {
   const { context: { name, onload }, response } = res;
   const url = createObjectURL(response);
   const a = document::createElementNS(NS_HTML, 'a');
   a::setAttribute('href', url);
   if (name) a::setAttribute('download', name);
   a::dispatchEvent(new MouseEvent('click'));
-  setTimeout(() => {
-    revokeObjectURL(url);
-    onload?.(res);
-  }, 3000);
+  await bridge.send('SetTimeout', 3000);
+  revokeObjectURL(url);
+  onload?.(res);
 }


### PR DESCRIPTION
Also:

* run `document-idle` content mode scripts after `document-idle` page mode scripts (previously they ran at document-end)
* run each `document-idle` script after its own individual setTimeout so that several big scripts don't create a super long task.
* run `setTimeout` in background context for reliability