### PR TITLE
feat: show extras menu in popup (remove + homepage)

### DIFF
--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -184,7 +184,7 @@ footer {
   border-top: 1px dashed var(--fill-2);
   > * {
     position: relative;
-    &:not(:hover) > .submenu-buttons {
+    &:not(:hover):not(.extras-shown) > .submenu-buttons {
       visibility: hidden;
     }
     .menu-item {
@@ -194,11 +194,15 @@ footer {
   &-buttons {
     display: flex;
     position: absolute;
-    top: .3rem;
-    right: $itemPaddingX;
+    top: 0;
+    right: 0;
+    opacity: .5;
+    &:hover {
+      opacity: 1;
+    }
   }
   &-button {
-    padding: .2rem;
+    padding: .5rem;
     background: var(--bg);
     cursor: pointer;
     &:hover {
@@ -243,4 +247,46 @@ footer {
   code {
     max-width: 100%;
   }
+}
+
+.extras-menu {
+  display: none;
+  position: absolute;
+  right: 0;
+  box-shadow: 1px 1px 10px #0008;
+  z-index: 100;
+  background: var(--bg);
+  color: var(--fg);
+  & > * {
+    cursor: pointer;
+    display: block;
+    padding: .25rem 1rem;
+    text-decoration: none;
+    &:first-child {
+      padding-top: .75rem;
+    }
+    &:last-child {
+      padding-bottom: .75rem;
+    }
+    &:hover {
+      color: var(--bg);
+      background: cornflowerblue;
+    }
+  }
+  a:hover {
+    text-decoration: underline;
+  }
+}
+
+.extras-shown {
+  .script-name {
+    text-decoration: underline;
+  }
+  .extras-menu {
+    display: block;
+  }
+}
+
+.removed {
+  text-decoration: line-through;
 }

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -254,11 +254,12 @@ footer {
 
 .extras-menu {
   position: fixed;
-  right: 0;
+  right: 1rem;
   box-shadow: 1px 1px 10px #0008;
   z-index: 100;
   background: var(--bg);
   color: var(--fg);
+  border: 1px solid var(--fill-6);
   & > * {
     cursor: pointer;
     display: block;

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -144,8 +144,11 @@ footer {
     > .flex-1 {
       padding-right: 2rem;
     }
-    .failed {
+    .failed & {
       text-decoration: line-through red;
+    }
+    .removed & {
+      text-decoration: line-through;
     }
   }
   &-find {
@@ -250,8 +253,7 @@ footer {
 }
 
 .extras-menu {
-  display: none;
-  position: absolute;
+  position: fixed;
   right: 0;
   box-shadow: 1px 1px 10px #0008;
   z-index: 100;
@@ -278,15 +280,11 @@ footer {
   }
 }
 
-.extras-shown {
-  .script-name {
-    text-decoration: underline;
-  }
-  .extras-menu {
-    display: block;
-  }
+.extras-shown .script-name {
+  text-decoration: underline;
 }
 
-.removed {
-  text-decoration: line-through;
+.block-scroll {
+  pointer-events: none;
+  user-select: none;
 }

--- a/src/resources/svg/more.svg
+++ b/src/resources/svg/more.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="512" cy="150" r="100"/>
+  <circle cx="512" cy="512" r="100"/>
+  <circle cx="512" cy="874" r="100"/>
+</svg>


### PR DESCRIPTION
Fixes #1000.

* Homepage if present
* Remove (or Restore)

I wonder if showing the version number at the top of the new menu would make sense? As for update check, it would require quite a few changes apparently so ain't gonna add it here.