### PR TITLE
fix: show warning if document-start is used improperly

### DIFF
--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -104,7 +104,13 @@ async function onCodeSet(item, fn) {
   if (process.env.DEBUG) {
     log('info', [bridge.mode], item.custom.name || item.meta.name || item.props.id);
   }
-  const run = () => wrapGM(item)::fn(logging.error);
+  const handleError = err => {
+    logging.error(err);
+    if (!stage && err?.name === 'TypeError' && err.message === 'document.head is null' && document.head === null) {
+      logging.warn('👆 This script may be using `document-start` improperly, if you are the script author, please read https://violentmonkey.github.io/api/metadata-block/#run-at for more details');
+    }
+  };
+  const run = () => wrapGM(item)::fn(handleError);
   const el = document::getCurrentScript();
   const wait = waiters[stage];
   if (el) el::remove();


### PR DESCRIPTION
<img width="879" alt="" src="https://user-images.githubusercontent.com/3139113/103326977-aab89600-4a8d-11eb-9156-4546757a07fe.png">

## Limitations

- Only direct usage of `document.head` can be detected, so `var doc = document; doc.head` will be ignored.
- The referred documentation has no enough information on this ATM.