### PR TITLE
fix: explicitly clear preinject cache when DB changes

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -9,7 +9,7 @@ import { getData, checkRemove } from './utils/db';
 import { setBadge } from './utils/icon';
 import { initialize } from './utils/init';
 import { getOption, hookOptions } from './utils/options';
-import { getInjectedScripts } from './utils/preinject';
+import { clearPreinjectData, getInjectedScripts } from './utils/preinject';
 import { SCRIPT_TEMPLATE, resetScriptTemplate } from './utils/template-hook';
 import { resetValueOpener, addValueOpener } from './utils/values';
 import './utils/clipboard';
@@ -124,9 +124,12 @@ const commandsToSyncIfTruthy = [
 async function handleCommandMessage(req, src) {
   const { cmd } = req;
   const res = await commands[cmd]?.(req.data, src);
-  if (commandsToSync.includes(cmd)
-  || res && commandsToSyncIfTruthy.includes(cmd)) {
+  const maybeChanged = commandsToSync.includes(cmd);
+  if (maybeChanged || res && commandsToSyncIfTruthy.includes(cmd)) {
     sync.sync();
+  }
+  if (maybeChanged) {
+    clearPreinjectData();
   }
   // `undefined` is not transferable, but `null` is
   return res ?? null;

--- a/src/common/cache.js
+++ b/src/common/cache.js
@@ -17,7 +17,7 @@ export default function initCache({
   // eslint-disable-next-line no-return-assign
   const getNow = () => batchStarted && batchStartTime || (batchStartTime = performance.now());
   return {
-    batch, get, pop, put, del, has, hit, destroy,
+    batch, get, getValues, pop, put, del, has, hit, destroy,
   };
   function batch(enable) {
     batchStarted = enable;
@@ -26,6 +26,9 @@ export default function initCache({
   function get(key, def) {
     const item = cache[key];
     return item ? item.value : def;
+  }
+  function getValues() {
+    return Object.values(cache).map(item => item.value);
   }
   function pop(key, def) {
     const value = get(key, def);


### PR DESCRIPTION
I *think* this PR fixes #1159, specifically:

> when I disable or enabled scripts it seems that violentmonkey didnt seems to enable or disable them.
I even used the flip button from violentmonkey and disable all scripts with that, and ctrl-F5 the page but it seemed that violentmonkey got stuck in its last stage and the scripts were run again, when they should have not because they were disabled.

The code is trivial with the only nuance that a separate cache is created for preinject data to simplify enumeration of values because the main cache may have thousands of items.