### PR TITLE
ui: align editor settings

### DIFF
--- a/src/options/views/edit/settings.vue
+++ b/src/options/views/edit/settings.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="edit-settings" ref="container">
     <h4 v-text="i18n('editLabelSettings')"></h4>
-    <div class="form-group">
+    <div class="form-group condensed">
       <label>
         <input type="checkbox" v-model="config.shouldUpdate">
         <span v-text="i18n('labelAllowUpdate')"></span>
@@ -16,14 +16,8 @@
       </label>
     </div>
     <h4 v-text="i18n('editLabelMeta')"></h4>
-    <div class="form-group flex">
-      <label class="label" v-text="i18n('labelName')"></label>
-      <tooltip content="@name" placement="right">
-        <input type="text" v-model="custom.name" :placeholder="placeholders.name">
-      </tooltip>
-    </div>
-    <div class="form-group flex">
-      <label class="label" v-text="i18n('labelRunAt')"></label>
+    <div class="form-group">
+      <label v-text="i18n('labelRunAt')"></label>
       <tooltip content="@run-at" placement="right">
         <select v-model="custom.runAt">
           <option value="" v-text="i18n('labelRunAtDefault')"></option>
@@ -34,64 +28,22 @@
         </select>
       </tooltip>
     </div>
-    <div class="form-group flex">
-      <label class="label" v-text="i18n('labelHomepageURL')"></label>
-      <tooltip content="@homepageURL" placement="right">
-        <input type="text" v-model="custom.homepageURL" :placeholder="placeholders.homepageURL">
+    <div class="form-group" v-for="([ name, label ]) in textInputs" :key="name">
+      <label v-text="label"/>
+      <tooltip :content="`@${name}`" placement="right" class="mr-tooltip">
+        <input type="text" v-model="custom[name]" :placeholder="placeholders[name]">
       </tooltip>
     </div>
-    <div class="form-group flex">
-      <label class="label" v-text="i18n('labelUpdateURL')"></label>
-      <tooltip content="@updateURL" placement="right">
-        <input type="text" v-model="custom.updateURL" :placeholder="placeholders.updateURL">
-      </tooltip>
+    <div class="form-group" v-for="([ name, orig, label ]) in textAreas" :key="name">
+      <div>
+        <span v-text="label"/>
+        <label class="ml-2">
+          <input type="checkbox" v-model="custom[orig]">
+          <span v-text="i18n('labelKeepOriginal')"/>
+        </label>
+      </div>
+      <textarea v-model="custom[name]" :rows="countRows(name)" spellcheck="false"/>
     </div>
-    <div class="form-group flex">
-      <label class="label" v-text="i18n('labelDownloadURL')"></label>
-      <tooltip content="@downloadURL" placement="right">
-        <input type="text" v-model="custom.downloadURL" :placeholder="placeholders.downloadURL">
-      </tooltip>
-    </div>
-    <tooltip class="form-group" content="@include" placement="right">
-      <div class="flex">
-        <span class="flex-auto" v-text="i18n('labelInclude')"></span>
-        <label>
-          <input type="checkbox" v-model="custom.origInclude">
-          <span v-text="i18n('labelKeepOriginal')"></span>
-        </label>
-      </div>
-      <textarea v-model="custom.include"></textarea>
-    </tooltip>
-    <tooltip class="form-group" content="@match" placement="right">
-      <div class="flex">
-        <span class="flex-auto" v-text="i18n('labelMatch')"></span>
-        <label>
-          <input type="checkbox" v-model="custom.origMatch">
-          <span v-text="i18n('labelKeepOriginal')"></span>
-        </label>
-      </div>
-      <textarea v-model="custom.match"></textarea>
-    </tooltip>
-    <tooltip class="form-group" content="@exclude" placement="right">
-      <div class="flex">
-        <span class="flex-auto" v-text="i18n('labelExclude')"></span>
-        <label>
-          <input type="checkbox" v-model="custom.origExclude">
-          <span v-text="i18n('labelKeepOriginal')"></span>
-        </label>
-      </div>
-      <textarea v-model="custom.exclude"></textarea>
-    </tooltip>
-    <tooltip class="form-group" content="@exclude-match" placement="right">
-      <div class="flex">
-        <span class="flex-auto" v-text="i18n('labelExcludeMatch')"></span>
-        <label>
-          <input type="checkbox" v-model="custom.origExcludeMatch">
-          <span v-text="i18n('labelKeepOriginal')"></span>
-        </label>
-      </div>
-      <textarea v-model="custom.excludeMatch"></textarea>
-    </tooltip>
   </div>
 </template>
 
@@ -121,6 +73,22 @@ export default {
         downloadURL: objectGet(value, 'meta.downloadURL') || objectGet(value, 'custom.lastInstallURL'),
       };
     },
+    textInputs() {
+      return [
+        ['name', i18n('labelName')],
+        ['homepageURL', i18n('labelHomepageURL')],
+        ['updateURL', i18n('labelUpdateURL')],
+        ['downloadURL', i18n('labelDownloadURL')],
+      ];
+    },
+    textAreas() {
+      return [
+        ['include', 'origInclude', i18n('labelInclude')],
+        ['match', 'origMatch', i18n('labelMatch')],
+        ['exclude', 'origExclude', i18n('labelExclude')],
+        ['exclude-match', 'origExcludeMatch', i18n('labelExcludeMatch')],
+      ];
+    },
   },
   watch: {
     active(val) {
@@ -129,22 +97,31 @@ export default {
       }
     },
   },
+  methods: {
+    countRows(name) {
+      return 2 + (this.settings.custom?.[name]?.match(/\n/g)?.length || 0);
+    },
+  },
 };
 </script>
 
 <style>
 .edit-settings {
+  &.edit-body { // using 2 classes to ensure we override .edit-body in index.vue
+    column-width: 50em;
+    column-gap: 4em;
+    padding-left: 4em;
+    padding-right: 4em;
+  }
   h4 {
     margin: 2em 0 1em;
   }
   .form-group {
-    display: block;
+    display: flex;
     position: relative;
-    max-width: 600px;
     margin-bottom: .5em;
-    &.vl-tooltip {
-      display: block;
-    }
+    break-inside: avoid-column;
+    align-items: center;
     input[type=checkbox] + span {
       user-select: none;
     }
@@ -152,12 +129,24 @@ export default {
       display: block;
       width: 100%;
     }
-    > textarea {
-      min-height: 5em;
+    &:not(.condensed) {
+      > :nth-child(1) {
+        display: flex;
+        flex: 0 0 11em;
+        flex-direction: column;
+      }
+      > :nth-child(2) {
+        flex-grow: 1;
+      }
     }
   }
   label:focus-within span {
     text-decoration: underline;
+  }
+}
+@media (min-width: 768px) {
+  .mr-tooltip {
+    margin-right: 10em;
   }
 }
 </style>

--- a/src/options/views/edit/settings.vue
+++ b/src/options/views/edit/settings.vue
@@ -42,7 +42,7 @@
           <span v-text="i18n('labelKeepOriginal')"/>
         </label>
       </div>
-      <textarea v-model="custom[name]" :rows="countRows(name)" spellcheck="false"/>
+      <textarea v-model="custom[name]" spellcheck="false" ref="area"/>
     </div>
   </div>
 </template>
@@ -51,6 +51,11 @@
 import Tooltip from 'vueleton/lib/tooltip/bundle';
 import { i18n } from '#/common';
 import { objectGet } from '#/common/object';
+
+function fitAreaHeight(el) {
+  el.style.height = 0;
+  el.style.height = `${Math.max(el.scrollHeight, 30) + 16}px`;
+}
 
 export default {
   props: ['active', 'settings', 'value'],
@@ -94,13 +99,14 @@ export default {
     active(val) {
       if (val) {
         this.$refs.container.querySelector('input').focus();
+        this.$refs.area.forEach(fitAreaHeight);
       }
     },
   },
-  methods: {
-    countRows(name) {
-      return 2 + (this.settings.custom?.[name]?.match(/\n/g)?.length || 0);
-    },
+  mounted() {
+    this.$refs.area.forEach((el) => {
+      el.oninput = () => fitAreaHeight(el);
+    });
   },
 };
 </script>


### PR DESCRIPTION
+ align editor settings
+ split into multiple columns on wide displays
+ auto-fit textarea height
+ remove tooltips on textareas because their labels already indicate `@key`

![chrome_2021-01-27_01-07-06](https://user-images.githubusercontent.com/1310400/105912721-ee76cf00-603c-11eb-8141-87a2944c6689.png)