### PR TITLE
feat: show structured info in install confirm ui

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -583,6 +583,9 @@ msgSavedScriptTemplate:
 msgScriptUpdated:
   description: Notification message for script updates.
   message: 'Script [$1] is updated!'
+msgShowHide:
+  description: Tooltip or text shown on a toggle that shows/hides stuff
+  message: Show/hide
 msgSyncError:
   description: Message shown when sync failed.
   message: Sync error!

--- a/src/background/utils/script.js
+++ b/src/background/utils/script.js
@@ -56,6 +56,11 @@ const metaTypes = {
     transform: () => true,
   },
 };
+const metaOptionalTypes = {
+  antifeature: arrayType,
+  compatible: arrayType,
+  connect: arrayType,
+};
 export function parseMeta(code) {
   // initialize meta
   const meta = metaTypes::mapEntry(([, value]) => value.default());
@@ -65,7 +70,7 @@ export function parseMeta(code) {
     const camelKey = keyName.replace(/[-_](\w)/g, (m, g) => g.toUpperCase());
     const key = locale ? `${camelKey}:${locale.toLowerCase()}` : camelKey;
     const val = rawValue.trim();
-    const metaType = metaTypes[key] || defaultType;
+    const metaType = metaTypes[key] || metaOptionalTypes[key] || defaultType;
     let oldValue = meta[key];
     if (typeof oldValue === 'undefined') oldValue = metaType.default();
     meta[key] = metaType.transform(oldValue, val);

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -103,6 +103,10 @@ export const cmOptions = {
 export default {
   props: {
     active: Boolean,
+    focus: {
+      type: Boolean,
+      default: true,
+    },
     readonly: {
       type: Boolean,
       default: false,
@@ -159,7 +163,7 @@ export default {
       });
       cm.clearHistory();
       cm.markClean();
-      cm.focus();
+      if (this.focus) cm.focus();
       cm.on('changes', this.onChanges);
       cm.on('beforeChange', this.onBeforeChange);
     },
@@ -301,7 +305,7 @@ export default {
       this.cm[onOff]('blur', this.onKeyDownToggler);
       this.cm[onOff]('focus', this.onKeyDownToggler);
       if (state) {
-        this.cm?.focus();
+        if (this.focus) this.cm?.focus();
       } else {
         window.removeEventListener('keydown', this.onKeyDown);
       }

--- a/src/confirm/views/app.vue
+++ b/src/confirm/views/app.vue
@@ -2,53 +2,77 @@
   <div class="page-confirm frame flex flex-col h-100">
     <div class="frame-block">
       <div class="flex">
-        <h1 class="mt-0 hidden-sm">
-          <span v-text="i18n('labelInstall')"></span> - <span v-text="i18n('extName')"></span>
-        </h1>
-        <div class="flex-auto"></div>
-        <div class="text-right">
-          <dropdown class="confirm-options" align="right">
-            <button slot="toggle" v-text="i18n('buttonInstallOptions')"></button>
-            <label>
-              <setting-check name="closeAfterInstall" @change="checkClose" />
-              <span class="ml-1" v-text="i18n('installOptionClose')"></span>
-            </label>
-            <label>
-              <setting-check name="trackLocalFile"
-                             :disabled="closeAfterInstall || !isLocal"
-                             @change="trackLocalFile"/>
-              <tooltip :content="trackTooltip" :disabled="!trackTooltip">
-                <span class="ml-1" v-text="i18n('installOptionTrack')"/>
-              </tooltip>
-            </label>
-          </dropdown>
-          <button v-text="i18n('buttonConfirmInstallation')"
-          :disabled="!installable" @click="installScript"></button>
-          <button v-text="i18n('buttonClose')" @click="close"></button>
-          <div class="incognito" v-if="info.incognito" v-text="i18n('msgIncognitoChanges')"/>
+        <div class="image">
+          <img src="/public/images/icon128.png">
+        </div>
+        <div class="info">
+          <h1>
+            <div v-text="heading"/>
+            <div class="ellipsis" v-text="name"/>
+          </h1>
+          <a class="url ellipsis" v-text="decodedUrl"
+             :title="info.url" :href="info.url" @click.prevent />
+          <p class="descr" v-text="descr"/>
+          <div class="lists flex flex-wrap" :data-collapsed="!listsShown">
+            <tooltip :content="i18n('msgShowHide')" placement="top" v-if="lists">
+              <div class="toggle" @click="listsShown = !listsShown">
+                <icon name="info"/>
+              </div>
+            </tooltip>
+            <dl v-for="(list, name) in lists" :key="name" :hidden="!list.length" tabindex="0">
+              <dt v-text="`@${name}`"/>
+              <dd v-if="Array.isArray(list)" class="flex flex-col">
+                <a v-for="(url, i) in list" :key="name + i" :href="url" v-text="url"
+                   rel="noopener noreferrer" target="_blank"/>
+              </dd>
+              <dd v-else v-text="list" class="ellipsis"/>
+            </dl>
+          </div>
+          <div v-text="message" :title="error"/>
         </div>
       </div>
       <div class="flex">
-        <div class="ellipsis flex-auto mr-2" :title="info.url" v-text="info.url"></div>
-        <div v-text="message"></div>
+        <div class="image flex">
+          <img :src="safeIcon">
+        </div>
+        <div class="actions flex flex-wrap">
+          <button v-text="i18n('buttonConfirmInstallation')" @click="installScript"
+                  :disabled="!installable"/>
+          <button v-text="i18n('buttonClose')" @click="close"/>
+          <label>
+            <setting-check name="closeAfterInstall" @change="checkClose" />
+            <span class="ml-1" v-text="i18n('installOptionClose')"/>
+          </label>
+          <label>
+            <setting-check name="trackLocalFile" @change="trackLocalFile"
+                           :disabled="closeAfterInstall || !isLocal"/>
+            <tooltip :content="trackTooltip" :disabled="!trackTooltip">
+              <span class="ml-1" v-text="i18n('installOptionTrack')"/>
+            </tooltip>
+          </label>
+        </div>
       </div>
+      <div class="incognito" v-if="info.incognito" v-text="i18n('msgIncognitoChanges')"/>
     </div>
     <div class="frame-block flex-auto pos-rel">
-      <vm-code class="abs-full" readonly :value="code" :commands="commands" />
+      <vm-code class="abs-full" readonly :value="code" :commands="commands" :focus="false" />
     </div>
   </div>
 </template>
 
 <script>
-import Dropdown from 'vueleton/lib/dropdown/bundle';
 import Tooltip from 'vueleton/lib/tooltip/bundle';
+import Icon from '#/common/ui/icon';
 import {
   sendCmd, leftpad, request, buffer2string, isRemote, getFullUrl, makePause,
+  getLocaleString, trueJoin,
 } from '#/common';
 import options from '#/common/options';
 import initCache from '#/common/cache';
 import VmCode from '#/common/ui/code';
 import SettingCheck from '#/common/ui/setting-check';
+import { loadScriptIcon } from '#/common/load-script-icon';
+import { objectPick } from '#/common/object';
 import { route } from '#/common/router';
 import ua from '#/common/ua';
 
@@ -62,7 +86,7 @@ let filePortNeeded;
 
 export default {
   components: {
-    Dropdown,
+    Icon,
     VmCode,
     SettingCheck,
     Tooltip,
@@ -79,6 +103,14 @@ export default {
         close: this.close,
       },
       info: {},
+      decodedUrl: '...',
+      descr: '',
+      error: null,
+      heading: this.i18n('msgLoadingData'),
+      lists: null,
+      listsShown: true,
+      name: '...',
+      safeIcon: null,
     };
   },
   computed: {
@@ -90,7 +122,6 @@ export default {
     },
   },
   async mounted() {
-    this.message = this.i18n('msgLoadingData');
     const id = route.paths[0];
     const key = `confirm-${id}`;
     this.info = await sendCmd('CacheLoad', key);
@@ -98,10 +129,13 @@ export default {
       this.close();
       return;
     }
-    filePortNeeded = ua.isFirefox >= 68 && this.info?.url.startsWith('file:');
+    const { url } = this.info;
+    this.decodedUrl = decodeURIComponent(url);
+    filePortNeeded = ua.isFirefox >= 68 && url.startsWith('file:');
     this.guard = setInterval(sendCmd, 5000, 'CacheHit', { key });
     await this.loadData();
     await this.parseMeta();
+    this.heading = this.i18n('labelInstall');
   },
   beforeDestroy() {
     if (this.guard) {
@@ -118,52 +152,67 @@ export default {
       if (code == null || changedOnly && this.code === code) throw 0;
       this.code = code;
     },
-    parseMeta() {
-      return sendCmd('ParseMeta', this.code)
-      .then((script) => {
-        const urls = Object.keys(script.resources)
-        .map(key => script.resources[key]);
+    async parseMeta() {
+      try {
+        /** @type {VMScriptMeta} */
+        const script = await sendCmd('ParseMeta', this.code);
+        const urls = Object.values(script.resources);
         const length = script.require.length + urls.length;
-        if (!length) return;
+        this.name = [getLocaleString(script, 'name'), script.version]::trueJoin(', ');
+        this.descr = getLocaleString(script, 'description');
+        this.lists = objectPick(script, [
+          'antifeature',
+          'grant',
+          'match',
+          'include',
+          'exclude',
+          'excludeMatch',
+          'compatible',
+          'connect',
+        ], list => (
+          list
+          ?.map(s => [s.replace(/^\W+/, '') || s, s])
+          .sort(([a], [b]) => (a < b ? -1 : a > b))
+          .map(([, s]) => s)
+          .join('\n')
+          || ''
+        ));
+        this.lists.require = [...new Set(script.require)];
+        this.lists.resource = [...new Set(urls)];
+        this.meta = script;
+        loadScriptIcon(this);
+        this.require = {};
+        this.resources = {};
         let finished = 0;
-        const error = [];
         const updateStatus = () => {
           this.message = this.i18n('msgLoadingDependency', [finished, length]);
         };
+        /** @returns {string|undefined} URL in case of error or `undefined` on success */
+        const download = async (url, target, isBlob) => {
+          const fullUrl = getFullUrl(url, this.info.url);
+          try {
+            target[fullUrl] = await this.getFile(fullUrl, { isBlob, useCache: true });
+            finished += 1;
+            updateStatus();
+          } catch (e) {
+            return url;
+          }
+        };
         updateStatus();
-        this.require = {};
-        this.resources = {};
-        const promises = script.require.map((url) => {
-          const fullUrl = getFullUrl(url, this.info.url);
-          return this.getFile(fullUrl, { useCache: true }).then((res) => {
-            this.require[fullUrl] = res;
-          });
-        })
-        .concat(urls.map((url) => {
-          const fullUrl = getFullUrl(url, this.info.url);
-          return this.getFile(fullUrl, { isBlob: true, useCache: true })
-          .then((res) => {
-            this.resources[fullUrl] = res;
-          });
-        }))
-        .map(promise => promise.then(() => {
-          finished += 1;
-          updateStatus();
-        }, (url) => {
-          error.push(url);
-        }));
-        return Promise.all(promises).then(() => {
-          if (error.length) return Promise.reject(error.join('\n'));
-          this.dependencyOK = true;
-        });
-      })
-      .then(() => {
-        this.message = this.i18n('msgLoadedData');
+        const promises = [
+          ...script.require.map(url => download(url, this.require, false)),
+          ...urls.map(url => download(url, this.resources, true)),
+        ];
+        const error = (await Promise.all(promises))::trueJoin('\n');
+        if (error) throw error;
+        this.error = null;
+        this.dependencyOK = true;
         this.installable = true;
-      }, (err) => {
-        this.message = this.i18n('msgErrorLoadingDependency', [err]);
-        return Promise.reject();
-      });
+        this.message = null;
+      } catch (err) {
+        this.message = this.i18n('msgErrorLoadingDependency');
+        this.error = err.message || err;
+      }
     },
     close() {
       sendCmd('TabClose');
@@ -250,7 +299,97 @@ export default {
 </script>
 
 <style>
+$imgSize: 48px;
+$imgGapR: 14px;
+$infoIconSize: 18px;
+
 .page-confirm {
+  h1 {
+    line-height: 1.3;
+    margin: .25rem 0;
+  }
+  a:not(:hover) {
+    color: unset;
+    text-decoration: none;
+  }
+  p {
+    margin-top: 1rem;
+  }
+  .image {
+    flex: 0 0 $imgSize;
+    align-items: center;
+    justify-content: center;
+    min-height: $imgSize; // reserve the height so it doesn't shift when the icon loads
+    padding: 0 $imgGapR 0 .25rem;
+    box-sizing: content-box;
+    img {
+      max-width: 100%;
+    }
+  }
+  .info {
+    overflow: hidden;
+    .descr {
+      max-height: 4rem;
+      overflow-y: auto;
+    }
+    .toggle {
+      position: absolute;
+      margin-left: calc(-1 * $imgSize / 2 - $infoIconSize / 2 - $imgGapR);
+      cursor: pointer;
+      [data-collapsed] & {
+      }
+      .icon {
+        width: $infoIconSize;
+        height: $infoIconSize;
+      }
+    }
+  }
+  .lists {
+    margin-top: 1rem;
+    dl {
+      margin: 0 1rem 1rem 0;
+    }
+    dt {
+      font-weight: bold;
+    }
+    dd {
+      white-space: pre;
+      min-width: 5rem;
+      max-height: 10vh;
+      min-height: 1.5rem;
+      overflow-y: auto;
+    }
+  }
+  [data-collapsed] {
+    dd {
+      display: none;
+    }
+    dl:focus dd {
+      display: flex;
+      position: absolute;
+      max-height: 50vh;
+      z-index: 100;
+      background: var(--fill-0-5);
+      box-shadow: 1px 3px 9px rgba(128, 128, 128, .5);
+      padding: .5rem;
+    }
+    dt {
+      cursor: pointer;
+    }
+    .toggle {
+      opacity: .3;
+    }
+  }
+  .actions {
+    align-items: center;
+    margin: .5rem 0;
+    > * {
+      margin-right: 1rem;
+    }
+    > button:first-of-type:not(:disabled) {
+      font-weight: bold;
+    }
+  }
   .incognito {
     padding: .25em 0;
     color: red;


### PR DESCRIPTION
Fixes #1121

Narrow window | Wide window
-|-
![image](https://user-images.githubusercontent.com/1310400/107669157-806c1200-6ca2-11eb-9657-cad2249f8877.png) | ![image](https://user-images.githubusercontent.com/1310400/107669287-a2659480-6ca2-11eb-9053-532a5f1a68ed.png)

Clicking the `(i)` icon collapses the lists and makes their titles clickable to display only the clicked list:

![image](https://user-images.githubusercontent.com/1310400/107669613-fa9c9680-6ca2-11eb-8148-c649acac11e6.png)

I don't want to store this state persistently via `setting-check` because the entire point of showing the lists in the installer is to make them obvious at a glance, especially important if the script has the metablock somewhere down the code or it adds spaces to "hide" the urls.