### PR TITLE
fix: use the db storage cache for icons in popup

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -52,7 +52,7 @@ hookOptions((changes) => {
 });
 
 Object.assign(commands, {
-  /** @return {Promise<Object>} */
+  /** @return {Promise<{ scripts: VMScript[], cache: Object, sync: Object }>} */
   async GetData(ids) {
     const data = await getData(ids);
     data.sync = sync.getStates();

--- a/src/background/utils/db.js
+++ b/src/background/utils/db.js
@@ -46,10 +46,6 @@ Object.assign(commands, {
   GetScriptCode(id) {
     return storage.code.getOne(id);
   },
-  /** @return {VMScript[]} */
-  GetMetas(ids) {
-    return ids.map(getScriptById).filter(Boolean);
-  },
   /** @return {Promise<void>} */
   MarkRemoved({ id, removed }) {
     return updateScriptInfo(id, {
@@ -323,14 +319,11 @@ function pushUnique(arr, elem) {
 }
 
 /** @return {string[]} */
-function getIconUrls() {
-  return store.scripts.reduce((res, script) => {
-    const { icon } = script.meta;
-    if (isRemote(icon)) {
-      res.push(script.custom.pathMap?.[icon] || icon);
-    }
-    return res;
-  }, []);
+function getIconUrls(ids) {
+  return store.scripts.map((script) => {
+    const icon = (!ids || ids.includes(script.props.id)) && script.meta.icon;
+    return isRemote(icon) && (script.custom.pathMap?.[icon] || icon);
+  }).filter(Boolean);
 }
 
 /**
@@ -341,7 +334,7 @@ export async function getData(ids) {
   const { scripts } = store;
   return {
     scripts: ids ? ids.map(getScriptById) : scripts,
-    cache: await storage.cache.getMulti(getIconUrls()),
+    cache: await storage.cache.getMulti(getIconUrls(ids)),
   };
 }
 

--- a/src/background/utils/popup-tracker.js
+++ b/src/background/utils/popup-tracker.js
@@ -1,5 +1,6 @@
 import { getActiveTab, sendTabCmd } from '#/common';
 import cache from './cache';
+import { getData } from './db';
 import { postInitialize } from './init';
 import { commands } from './message';
 
@@ -30,7 +31,7 @@ async function prefetchSetPopup() {
   const tabId = (await getActiveTab()).id;
   sendTabCmd(tabId, 'PopupShown', true);
   commands.SetPopup = async (data, src) => {
-    data.metas = commands.GetMetas(data.ids);
+    Object.assign(data, await getData(data.ids));
     cache.put('SetPopup', Object.assign({ [src.frameId]: [data, src] }, cache.get('SetPopup')));
   };
 }

--- a/src/popup/utils/index.js
+++ b/src/popup/utils/index.js
@@ -1,5 +1,4 @@
 export const store = {
-  cache: {},
   scripts: [],
   frameScripts: [],
   commands: [],

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -82,7 +82,7 @@
           <div
             class="menu-item menu-area"
             @click="onToggleScript(item)">
-            <img class="script-icon" :src="item.data.safeIcon" @error="scriptIconError">
+            <img class="script-icon" :src="item.data.safeIcon">
             <icon :name="getSymbolCheck(item.data.config.enabled)"></icon>
             <div class="script-name flex-auto ellipsis" v-text="item.name"
                  @click.ctrl.exact.stop="onEditScript(item)"
@@ -252,9 +252,6 @@ export default {
     },
     getSymbolCheck(bool) {
       return `toggle-${bool ? 'on' : 'off'}`;
-    },
-    scriptIconError(event) {
-      event.target.removeAttribute('src');
     },
     onToggle() {
       options.set('isApplied', optionsData.isApplied = !optionsData.isApplied);


### PR DESCRIPTION
When I added icons in popup I thought reusing db cache would be complicated but turns out it's simple so here it is.