### PR TITLE
feat: load icons from storage cache

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -52,7 +52,7 @@ hookOptions((changes) => {
 });
 
 Object.assign(commands, {
-  /** @return {Promise<Object>} */
+  /** @return {Promise<{ scripts: VMScript[], cache: Object, sync: Object }>} */
   async GetData(ids) {
     const data = await getData(ids);
     data.sync = sync.getStates();

--- a/src/background/utils/icon.js
+++ b/src/background/utils/icon.js
@@ -4,9 +4,20 @@ import { INJECTABLE_TAB_URL_RE } from '#/common/consts';
 import { objectPick } from '#/common/object';
 import cache from './cache';
 import { postInitialize } from './init';
-import { forEachTab } from './message';
+import { commands, forEachTab } from './message';
 import { getOption, hookOptions } from './options';
 import { testBlacklist } from './tester';
+
+// storing in `cache` only for the duration of page load in case there are 2+ identical urls
+const CACHE_DURATION = 1000;
+
+Object.assign(commands, {
+  async GetImageData(url) {
+    const key = `GetImageData:${url}`;
+    return cache.get(key)
+      || cache.put(key, loadImageData(url, { base64: true }).catch(noop), CACHE_DURATION);
+  },
+});
 
 // Firefox Android does not support such APIs, use noop
 
@@ -152,19 +163,23 @@ async function setIcon(tab = {}, data = {}) {
   });
 }
 
-function loadImageData(path) {
-  return new Promise(resolve => {
+function loadImageData(path, { base64 } = {}) {
+  return new Promise((resolve, reject) => {
     const img = new Image();
     img.src = path;
     img.onload = () => {
       const { width, height } = img;
+      if (!width) { // FF reports 0 for SVG
+        resolve(path);
+        return;
+      }
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
       canvas.width = width;
       canvas.height = height;
-      ctx.clearRect(0, 0, width, height);
       ctx.drawImage(img, 0, 0, width, height);
-      resolve(ctx.getImageData(0, 0, width, height));
+      resolve(base64 ? canvas.toDataURL() : ctx.getImageData(0, 0, width, height));
     };
+    img.onerror = reject;
   });
 }

--- a/src/background/utils/popup-tracker.js
+++ b/src/background/utils/popup-tracker.js
@@ -1,5 +1,6 @@
 import { getActiveTab, sendTabCmd } from '#/common';
 import cache from './cache';
+import { getData } from './db';
 import { postInitialize } from './init';
 import { commands } from './message';
 
@@ -30,7 +31,7 @@ async function prefetchSetPopup() {
   const tabId = (await getActiveTab()).id;
   sendTabCmd(tabId, 'PopupShown', true);
   commands.SetPopup = async (data, src) => {
-    data.metas = commands.GetMetas(data.ids);
+    Object.assign(data, await getData(data.ids));
     cache.put('SetPopup', Object.assign({ [src.frameId]: [data, src] }, cache.get('SetPopup')));
   };
 }

--- a/src/common/load-script-icon.js
+++ b/src/common/load-script-icon.js
@@ -1,52 +1,24 @@
-const images = {};
+import { sendCmdDirectly } from '#/common/index';
+
+const KEY = 'safeIcon';
 
 /**
  * Sets script's safeIcon property after the image is successfully loaded
  * @param {VMScript} script
- * @param {Object} [_]
- * @param {?string} [_.default]
- * @param {string} [_.key]
- * @param {Object} [_.cache]
- * @returns {Promise<boolean>}
+ * @param {Object} [cache]
  */
-export function loadScriptIcon(script, {
-  default: defaultIcon = null,
-  key = 'safeIcon',
-  cache = {},
-} = {}) {
+export async function loadScriptIcon(script, cache = {}) {
   const { icon } = script.meta;
   const url = script.custom?.pathMap?.[icon] || icon;
-  const isNewUrl = url !== script[key];
-  let promise = isNewUrl && url ? images[url] : Promise.resolve(false);
-  if (!promise) {
-    promise = Promise.resolve(cache?.[url] || fetchImage(url));
-    images[url] = promise;
+  if (!url || url !== script[KEY]) {
+    // creates an observable property so Vue will see the change after `await`
+    script[KEY] = null;
+    if (url) {
+      script[KEY] = cache[url]
+        || url.startsWith('data:') && url
+        || await sendCmdDirectly('GetImageData', url)
+        || null;
+    }
   }
-  if (isNewUrl || !url) {
-    // creates an observable property so Vue will see the change in then()
-    script[key] = defaultIcon;
-    promise.then(ok => {
-      script[key] = ok ? url : defaultIcon;
-    });
-  }
-  return promise;
-}
-
-async function fetchImage(url) {
-  /* The benefit of fetch+createImageBitmap is that it doesn't delay the popup in Chrome,
-     but it doesn't work with SVG so we're using DOM Image in case the modern method fails
-     or when the URL obviously contains an SVG */
-  if (!/^data:image\/svg|\.svgz?([#?].*)?$/.test(url)) {
-    try {
-      const blob = await (await fetch(url)).blob();
-      await createImageBitmap(blob);
-      return true;
-    } catch (e) { /* NOP */ }
-  }
-  return new Promise((resolve) => {
-    const img = new Image();
-    img.src = url;
-    img.onload = () => resolve(true);
-    img.onerror = () => resolve(false);
-  });
+  return script[KEY];
 }

--- a/src/common/storage.js
+++ b/src/common/storage.js
@@ -10,10 +10,17 @@ const base = {
     const key = this.getKey(id);
     return browser.storage.local.get(key).then(data => data[key]);
   },
-  async getMulti(ids, def) {
+  /**
+   * @param {string[]} ids
+   * @param {?} def
+   * @param {function(id:string, val:?):?} transform
+   * @returns {Promise<Object>}
+   */
+  async getMulti(ids, def, transform) {
     const data = await browser.storage.local.get(ids.map(this.getKey, this));
     return ids.reduce((res, id) => {
-      res[id] = data[this.getKey(id)] || def;
+      const val = data[this.getKey(id)];
+      res[id] = transform ? transform(id, val) : (val || def);
       return res;
     }, {});
   },

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { sendCmdDirectly, i18n, getLocaleString } from '#/common';
-import { forEachEntry } from '#/common/object';
 import handlers from '#/common/handlers';
+import { loadScriptIcon } from '#/common/load-script-icon';
 import options from '#/common/options';
 import loadZip from '#/common/zip';
 import '#/common/ui/style';
@@ -12,7 +12,6 @@ Vue.prototype.i18n = i18n;
 
 Object.assign(store, {
   loading: false,
-  cache: {},
   scripts: [],
   sync: [],
   title: null,
@@ -33,7 +32,7 @@ function initialize() {
   });
 }
 
-function initScript(script) {
+async function initScript(script) {
   const meta = script.meta || {};
   const localeName = getLocaleString(meta, 'name');
   const search = [
@@ -47,6 +46,11 @@ function initScript(script) {
   const name = script.custom.name || localeName;
   const lowerName = name.toLowerCase();
   script.$cache = { search, name, lowerName };
+  if (!await loadScriptIcon(script, store.cache)) {
+    script.safeIcon = `/public/images/icon${
+      store.HiDPI ? 128 : script.config.removed && 32 || 38
+    }.png`;
+  }
 }
 
 export async function loadData() {
@@ -56,16 +60,9 @@ export async function loadData() {
     sendCmdDirectly('GetData', params, { retry: true }),
     options.ready,
   ]);
-  if (cache) {
-    const oldCache = store.cache || {};
-    cache::forEachEntry(([url, raw]) => {
-      const res = oldCache[url] || raw && `data:image/png;base64,${raw.split(',').pop()}`;
-      if (res) cache[url] = res;
-    });
-  }
+  store.cache = cache;
   scripts?.forEach(initScript);
   store.scripts = scripts;
-  store.cache = cache;
   store.sync = sync;
   store.loading = false;
 }

--- a/src/options/views/script-item.vue
+++ b/src/options/views/script-item.vue
@@ -8,7 +8,7 @@
     }"
     :draggable="draggable"
     @keydownEnter="onEdit">
-    <img class="script-icon hidden-xs" :src="safeIcon" @click="onEdit">
+    <img class="script-icon hidden-xs" :src="script.safeIcon" @click="onEdit">
     <div class="script-info flex">
       <div class="script-name ellipsis flex-auto" v-text="script.$cache.name"></div>
       <template v-if="canRender">
@@ -98,9 +98,7 @@
 <script>
 import Tooltip from 'vueleton/lib/tooltip/bundle';
 import { sendCmd, getLocaleString, formatTime } from '#/common';
-import { loadScriptIcon } from '#/common/load-script-icon';
 import Icon from '#/common/ui/icon';
-import { store } from '../utils';
 import enableDragging from '../utils/dragging';
 
 export default {
@@ -115,7 +113,6 @@ export default {
   },
   data() {
     return {
-      safeIcon: null,
       canRender: this.visible,
     };
   },
@@ -178,10 +175,6 @@ export default {
     },
   },
   mounted() {
-    loadScriptIcon(this.script, { cache: store.cache }).then(() => {
-      this.safeIcon = this.script.safeIcon
-        || `/public/images/icon${store.HiDPI ? 128 : this.script.config.removed && 32 || 38}.png`;
-    });
     enableDragging(this.$el, {
       onDrop: (from, to) => this.$emit('move', { from, to }),
     });

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -42,9 +42,9 @@ Object.assign(handlers, {
     if (ids.length) {
       // frameScripts may be appended multiple times if iframes have unique scripts
       const scope = store[isTop ? 'scripts' : 'frameScripts'];
-      const metas = data.metas?.filter(({ props: { id } }) => ids.includes(id))
-        || await sendCmdDirectly('GetMetas', ids);
-      metas.forEach(script => loadScriptIcon(script, { cache: store.cache }));
+      const metas = data.scripts?.filter(({ props: { id } }) => ids.includes(id))
+        || (Object.assign(data, await sendCmdDirectly('GetData', ids))).scripts;
+      metas.forEach(script => loadScriptIcon(script, data.cache));
       scope.push(...metas);
       data.failedIds.forEach(id => {
         scope.forEach((script) => {

--- a/src/popup/utils/index.js
+++ b/src/popup/utils/index.js
@@ -1,5 +1,4 @@
 export const store = {
-  cache: {},
   scripts: [],
   frameScripts: [],
   commands: [],

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -82,7 +82,7 @@
           <div
             class="menu-item menu-area"
             @click="onToggleScript(item)">
-            <img class="script-icon" :src="item.data.safeIcon" @error="scriptIconError">
+            <img class="script-icon" :src="item.data.safeIcon">
             <icon :name="getSymbolCheck(item.data.config.enabled)"></icon>
             <div class="script-name flex-auto ellipsis" v-text="item.name"
                  @click.ctrl.exact.stop="onEditScript(item)"
@@ -252,9 +252,6 @@ export default {
     },
     getSymbolCheck(bool) {
       return `toggle-${bool ? 'on' : 'off'}`;
-    },
-    scriptIconError(event) {
-      event.target.removeAttribute('src');
     },
     onToggle() {
       options.set('isApplied', optionsData.isApplied = !optionsData.isApplied);


### PR DESCRIPTION
Icons now load instantly (in Chrome at least).

* icons will be loaded from db `cache` and used in dashboard/popup as `data:` to avoid network requests
* if an icon isn't in cache for whatever weird reason, a new command is added: `GetImageData`
* `data:` icons will be used directly without verification because I don't think I ever saw a broken one
* `transform` parameter added to `getMulti` method in `storage`