### PR TITLE
fix: close popup on command click

### DIFF
--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -306,6 +306,7 @@ export default {
     },
     onCommand(id, cap) {
       sendTabCmd(store.currentTab.id, 'Command', `${id}:${cap}`);
+      window.close();
     },
     onToggleScript(item) {
       const { data } = item;


### PR DESCRIPTION
I guess the popup should be closed when a command is clicked, which is the default behavior of most menus.