### PR TITLE
fix: ensure content script to be unregistered

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -73,7 +73,6 @@ Object.assign(commands, {
       // FF bug: the badge is reset because sometimes tabs get their real/internal url later
       if (ua.isFirefox) cache.put(`badge:${tab.id}${url}`, badgeData);
       Object.assign(res, data.inject);
-      data.registration?.then(r => r.unregister());
       // Injecting known content mode scripts without waiting for InjectionFeedback
       const inContent = res.scripts.map(s => !s.code && [s.dataKey, true]).filter(Boolean);
       if (inContent.length) {


### PR DESCRIPTION
In Firefox, when a content script registration is removed from our cache because of expiration, it won't be unregistered, leading to multiple registrations for a URL and script updates cannot take effect any more.
This PR adds an `onDispose` callback to explicitly dispose every cached registration when it is removed from cache.