### PR TITLE
fix: read active tab's URL for newScript hotkey

### DIFF
--- a/src/background/utils/hotkeys.js
+++ b/src/background/utils/hotkeys.js
@@ -1,15 +1,13 @@
 import { postInitialize } from './init';
 import { commands } from './message';
 
-const ROUTES = {
-  newScript: '#scripts/_new',
-  settings: '#settings',
-};
-
 postInitialize.push(() => {
   browser.commands.onCommand.addListener((cmd) => {
-    commands.TabOpen({
-      url: `${browser.runtime.getManifest().options_ui.page}${ROUTES[cmd] || ''}`,
-    });
+    if (cmd === 'newScript') {
+      commands.OpenEditor();
+    } else {
+      const route = cmd === 'settings' ? `#${cmd}` : '';
+      commands.TabOpen({ url: `/options/index.html${route}` });
+    }
   });
 });

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -295,7 +295,7 @@ export default {
       window.close();
     },
     onEditScript(item) {
-      sendCmd('OpenEditor', item.data.props.id);
+      sendCmd('OpenEditor', { pathId: item.data.props.id });
       window.close();
     },
     onFindSameDomainScripts() {
@@ -330,12 +330,8 @@ export default {
       }
     },
     async onCreateScript() {
-      const { currentTab, domain } = this.store;
-      const id = domain && await sendCmd('CacheNewScript', {
-        url: currentTab.url.split(/[#?]/)[0],
-        name: `- ${domain}`,
-      });
-      sendCmd('OpenEditor', `_new${id ? `/${id}` : ''}`);
+      const { currentTab: { url }, domain } = this.store;
+      sendCmd('OpenEditor', { url, domain });
       window.close();
     },
     async onInjectionFailureFix() {


### PR DESCRIPTION
Pressing a hotkey assigned in `chrome://extensions/shortcuts` to create a new script will use the active tab's url now.