### PR TITLE
feat: options for table view and single-column mode

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -465,6 +465,12 @@ labelTranslator:
 labelUpdateURL:
   description: Label of script @updateURL in custom meta data.
   message: 'Update URL:'
+labelViewSingleColumn:
+  description: Label for option in dashboard script list to show the scripts in single column.
+  message: Single column
+labelViewTable:
+  description: Label for option in dashboard script list to show the scripts as a table.
+  message: Table view
 lastSync:
   description: Label for last sync timestamp.
   message: Last sync at $1

--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -33,6 +33,10 @@ export default {
     searchScope: 'name',
     /** @type 'exec' | 'alpha' | 'update' */
     sort: 'exec',
+    /** @type boolean */
+    viewSingleColumn: false,
+    /** @type boolean */
+    viewTable: true,
   },
   filtersPopup: {
     /** @type 'exec' | 'alpha' */

--- a/src/common/ui/setting-check.vue
+++ b/src/common/ui/setting-check.vue
@@ -1,5 +1,5 @@
 <template>
-  <label>
+  <label class="setting-check">
     <input type="checkbox" v-model="value" :disabled="disabled">
     <slot>
       <span v-text="label" />
@@ -49,3 +49,9 @@ export default {
   },
 };
 </script>
+
+<style>
+.setting-check {
+  display: inline-flex;
+}
+</style>

--- a/src/options/views/script-item.vue
+++ b/src/options/views/script-item.vue
@@ -10,7 +10,8 @@
     @keydownEnter="onEdit">
     <img class="script-icon hidden-xs" :src="script.safeIcon" @click="onEdit">
     <div class="script-info flex ml-1c">
-      <div class="script-name ellipsis flex-auto" v-text="script.$cache.name"></div>
+      <div class="script-name ellipsis flex-auto" v-text="script.$cache.name"
+           @click.exact="nameClickable && onEdit()"/>
       <template v-if="canRender">
         <tooltip v-if="author" :content="i18n('labelAuthor') + script.meta.author"
                  class="script-author ml-1c hidden-sm"
@@ -37,8 +38,8 @@
         </div>
       </template>
     </div>
-    <template v-if="canRender">
-      <div class="script-buttons flex">
+    <div class="script-buttons flex">
+      <template v-if="canRender">
         <div class="flex-auto flex flex-wrap">
           <tooltip :content="i18n('buttonEdit')" align="start">
             <span class="btn-ghost" @click="onEdit">
@@ -88,8 +89,8 @@
             <icon name="trash"></icon>
           </span>
         </tooltip>
-      </div>
-    </template>
+      </template>
+    </div>
   </div>
 </template>
 
@@ -104,6 +105,7 @@ export default {
     'script',
     'draggable',
     'visible',
+    'nameClickable',
   ],
   components: {
     Icon,
@@ -330,9 +332,7 @@ $removedItemHeight: calc(
     .disabled &,
     .removed & {
       filter: grayscale(.8);
-      @media (prefers-color-scheme: dark) {
-        opacity: .5;
-      }
+      opacity: .5;
     }
     .removed & {
       width: $iconSizeSmaller;
@@ -362,32 +362,106 @@ $removedItemHeight: calc(
   }
 }
 
+.scripts {
+  &[data-columns="2"] .script {
+    width: calc(100% / 2 - (2 * $itemMargin));
+  }
+  &[data-columns="3"] .script {
+    width: calc(100% / 3 - (2 * $itemMargin));
+  }
+  &[data-columns="4"] .script {
+    width: calc(100% / 4 - (2 * $itemMargin));
+  }
+  &[data-table] {
+    &[data-columns="1"] .script {
+      margin: 0;
+      border-left: none;
+      border-right: none;
+    }
+    &[data-columns="1"], &[data-columns="3"] {
+      .script:nth-child(even) {
+        background-color: var(--fill-0-5);
+      }
+    }
+    &[data-columns="2"] .script {
+      &:nth-child(4n + 2),
+      &:nth-child(4n + 3) {
+        background-color: var(--fill-0-5);
+      }
+    }
+    &[data-columns="4"] .script {
+      &:nth-child(8n + 2),
+      &:nth-child(8n + 4),
+      &:nth-child(8n + 5),
+      &:nth-child(8n + 7) {
+        background-color: var(--fill-0-5);
+      }
+    }
+    .script {
+      display: flex;
+      align-items: center;
+      height: 2.5rem;
+      margin: 0 $itemMargin;
+      padding: 0 calc(2 * $itemMargin) 0 $itemMargin;
+      border-top: none;
+      border-radius: 0;
+      background: none;
+      &-name {
+        cursor: pointer;
+      }
+      &-icon {
+        width: 2rem;
+        height: 2rem;
+        order: 1;
+        position: static;
+        margin-left: .5rem;
+      }
+      &-info {
+        order: 2;
+        flex: 1;
+        margin-left: .5rem;
+        line-height: 1;
+        > :last-child { /* author + version */
+          align-items: center;
+          display: flex;
+          > * {
+            width: 5rem;
+            text-align: right;
+            color: var(--fill-8);
+          }
+          > :last-child { /* version */
+            width: 3.5rem;
+          }
+        }
+      }
+      &-buttons {
+        margin: 0;
+        min-width: 14rem;
+        > .flex {
+          width: auto;
+          > :first-child { /* edit button */
+            display: none;
+          }
+        }
+      }
+      &-author > .ellipsis {
+        max-width: 15vw;
+      }
+      &-message:not(:empty) {
+        position: absolute;
+        right: 0;
+        font-size: smaller;
+        padding: 1px .5em 2px;
+        border-radius: .5em;
+        border: 1px solid var(--fill-5);
+        background: var(--bg);
+      }
+    }
+  }
+}
 @media (max-width: 319px) {
   .script-icon ~ * {
     margin-left: 0;
-  }
-}
-
-@media (min-width: 1300px) { // for 1366x768
-  .scripts {
-    display: flex;
-    flex-wrap: wrap;
-    align-content: flex-start;
-  }
-  .script {
-    width: calc(100% / 2 - (2 * $itemMargin));
-  }
-}
-
-@media (min-width: 1900px) { // for 1920x1080
-  .script {
-    width: calc(100% / 3 - (2 * $itemMargin));
-  }
-}
-
-@media (min-width: 2500px) { // for 2560x1440
-  .script {
-    width: calc(100% / 4 - (2 * $itemMargin));
   }
 }
 </style>


### PR DESCRIPTION
Addresses #1135 #1210 #1221.

I didn't want to implement it initially because it seemed like a 100% CSS customization but now I kinda do.

* The table layout needs a clickable name because a) this is how such layout usually works and b) the edit button is too far from the script name. Without supporting this event internally the CSS has to stretch the edit button over the name button which is a dirty hack.
*  VM isn't Stylus so it doesn't have a quick way to toggle the style.
* A user might want to switch modes for a quick overview of all the scripts at once, then switch back.

### 1-column table

![image](https://user-images.githubusercontent.com/1310400/110347916-26146600-8042-11eb-9db7-8ec63834cd16.png)

### 2-columns table

![image](https://user-images.githubusercontent.com/1310400/110348040-46dcbb80-8042-11eb-88bf-86add468f011.png)
