### PR TITLE
fix: keep empty strings as params in requests

### DIFF
--- a/src/injected/web/requests.js
+++ b/src/injected/web/requests.js
@@ -205,7 +205,7 @@ async function encodeBody(body) {
       reader::readAsArrayBuffer(body);
     });
   default:
-    if (body) return { cls, value: jsonDump(body) };
+    if (body != null) return { cls, value: jsonDump(body) };
   }
 }
 


### PR DESCRIPTION
fix #1240

Otherwise empty string data `[{ cls: 'string', value: '""' }]` becomes `[null]` and `decodeBody` throws.