### PR TITLE
feat: add empty row to editor>settings>textarea

### DIFF
--- a/src/common/ui/index.js
+++ b/src/common/ui/index.js
@@ -60,5 +60,9 @@ export function autofitElementsHeight(elems) {
 /** @this {HTMLTextAreaElement} */
 function autofitSingleElementHeight() {
   this.style.height = 0;
-  this.style.height = `${Math.max(this.scrollHeight, 30) + 16}px`;
+  this.style.height = `${
+    Math.max(this.scrollHeight, 30)
+    + (this.offsetHeight - this.clientHeight) // borders
+    + 2 // some air for the cursor
+  }px`;
 }

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -90,7 +90,12 @@ const CUSTOM_LISTS = [
   'exclude',
   'excludeMatch',
 ];
-const fromList = list => list?.join('\n') || '';
+const fromList = list => (
+  list
+    // Adding a new row so the user can click it and type, just like in an empty textarea.
+    ? `${list.join('\n')}\n`
+    : ''
+);
 const toList = text => (
   text.split('\n')
   .map(line => line.trim())


### PR DESCRIPTION
Adding a new row so the user can click it and type, just like in an empty textarea:

![image](https://user-images.githubusercontent.com/1310400/126078244-383ee3df-7cfa-4ac5-84de-a1269badec8a.png)
