### PR TITLE
fix: wrap long text in confirm page

### DIFF
--- a/src/confirm/views/app.vue
+++ b/src/confirm/views/app.vue
@@ -398,7 +398,7 @@ $infoIconSize: 18px;
       font-weight: bold;
     }
     dd {
-      white-space: pre;
+      white-space: pre-wrap;
       min-width: 5rem;
       max-height: 10vh;
       min-height: 1.5rem;


### PR DESCRIPTION
When `@antifeature` is too long, it will be cut at the right of the page.

Before:
<img width="687" alt="image" src="https://user-images.githubusercontent.com/3139113/127139545-df8fc246-6d91-4171-887b-be07a91138ef.png">

After:
<img width="687" alt="image" src="https://user-images.githubusercontent.com/3139113/127139627-98e293ec-4eb5-494d-85f5-4c98611e6e43.png">
