### PR TITLE
feat: show more examples of injection failures

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -185,7 +185,7 @@ failureReasonNoninjectable:
     failureBlacklistedUrl)
   message: |-
     Violentmonkey cannot run userscripts in this page
-    (common examples: browser UI or an extension)
+    (common examples: browser UI, an extension, blocked via policies, a search engine site in Opera)
 filterAlphabeticalOrder:
   description: Label for option to sort scripts in alphabetical order.
   message: alphabetical order


### PR DESCRIPTION
Tests the actual injectability via executeScript and displays two additional examples of non-injectable sites in popup:
* search engine site in Opera
* blocked via policies, specifically `runtime_blocked_hosts` in Chrome

![image](https://user-images.githubusercontent.com/1310400/127194765-60c48fa8-c283-4f01-b852-5279edb95386.png)

Should help #1322.

I went with this simplified universal solution since we can't even reliably detect if the current site is actually the default search engine in Opera, and we don't want to add a browser-specific kludge for such an edge case anyway.