### PR TITLE
speedup: GMxhr in FF + use FileReader for internal encoding

### DIFF
--- a/src/background/utils/requests.js
+++ b/src/background/utils/requests.js
@@ -1,4 +1,6 @@
-import { buffer2string, getUniqId, request, i18n, isEmpty, noop, sendTabCmd } from '#/common';
+import {
+  blob2base64, buffer2string, getUniqId, request, i18n, isEmpty, noop, sendTabCmd,
+} from '#/common';
 import { forEachEntry, objectPick } from '#/common/object';
 import ua from '#/common/ua';
 import cache from './cache';
@@ -35,9 +37,9 @@ Object.assign(commands, {
     return id;
   },
   /** @return {void} */
-  HttpRequest(details, src) {
+  HttpRequest(opts, src) {
     const { tab, frameId } = src;
-    httpRequest(details, src, res => (
+    httpRequest(opts, src, res => (
       sendTabCmd(tab.id, 'HttpRequested', res, { frameId })
     ));
   },
@@ -197,34 +199,36 @@ const HeaderInjector = (() => {
   };
 })();
 
+const CHUNK_SIZE = 64e6 / 4;
+
+async function blob2chunk(response, index) {
+  return blob2base64(response, index * CHUNK_SIZE, CHUNK_SIZE);
+}
+
+function blob2objectUrl(response) {
+  const url = URL.createObjectURL(response);
+  cache.put(`xhrBlob:${url}`, setTimeout(commands.RevokeBlob, 60e3, url), 61e3);
+  return url;
+}
+
 function xhrCallbackWrapper(req) {
   let lastPromise = Promise.resolve();
   let contentType;
+  let dataSize;
   let numChunks;
   let response;
   let responseText;
   let responseHeaders;
   let sent = false;
-  const { id, chunkType, xhr } = req;
+  const { id, blobbed, chunked, xhr } = req;
   // Chrome encodes messages to UTF8 so they can grow up to 4x but 64MB is the message size limit
-  const chunkSize = 64e6 / 4;
-  const isBlob = chunkType === 'blob';
-  const getChunk = isBlob
-    ? () => {
-      const url = URL.createObjectURL(response);
-      cache.put(`xhrBlob:${url}`, setTimeout(commands.RevokeBlob, 60e3, url), 61e3);
-      return url;
-    }
-    : index => buffer2string(response, index * chunkSize, chunkSize);
+  const getChunk = blobbed && blob2objectUrl || chunked && blob2chunk;
   const getResponseHeaders = () => {
     const headers = req.responseHeaders || xhr.getAllResponseHeaders();
     if (responseHeaders !== headers) {
       responseHeaders = headers;
       return { responseHeaders };
     }
-  };
-  const chainedCallback = (msg) => {
-    lastPromise = lastPromise.then(() => req.cb(msg));
   };
   return (evt) => {
     const type = evt.type;
@@ -241,17 +245,22 @@ function xhrCallbackWrapper(req) {
       } catch (e) {
         // ignore if responseText is unreachable
       }
-      if (chunkType && response) {
-        numChunks = !isBlob && Math.ceil(response.byteLength / chunkSize) || 1;
+      if ((blobbed || chunked) && response) {
+        dataSize = response.size;
+        numChunks = chunked && Math.ceil(dataSize / CHUNK_SIZE) || 1;
       }
     }
     const shouldNotify = req.eventsToNotify.includes(type);
     // only send response when XHR is complete
     const shouldSendResponse = xhr.readyState === 4 && shouldNotify && !sent;
-    chainedCallback({
+    lastPromise = lastPromise
+    .then(() => shouldSendResponse && numChunks && getChunk(response, 0))
+    .then(chunk => req.cb({
+      blobbed,
+      chunked,
       contentType,
+      dataSize,
       id,
-      chunkType,
       numChunks,
       type,
       data: shouldNotify && {
@@ -259,20 +268,19 @@ function xhrCallbackWrapper(req) {
         ...getResponseHeaders(),
         ...objectPick(xhr, ['readyState', 'status', 'statusText']),
         ...shouldSendResponse && {
-          response: numChunks ? getChunk(0) : response,
+          response: chunk || response,
           responseText,
         },
         ...('loaded' in evt) && objectPick(evt, ['lengthComputable', 'loaded', 'total']),
       },
-    });
+    }));
     if (shouldSendResponse) {
       sent = true;
       for (let i = 1; i < numChunks; i += 1) {
-        chainedCallback({
-          id,
-          chunkIndex: i,
-          chunk: getChunk(i),
-        });
+        const last = i === numChunks - 1;
+        lastPromise = lastPromise
+        .then(() => getChunk(response, i)) // eslint-disable-line no-loop-func
+        .then(data => req.cb({ id, chunk: { data, i, last } }));
       }
     }
   };
@@ -285,14 +293,14 @@ function isSpecialHeader(lowerHeader) {
 }
 
 /**
- * @param {Object} details
+ * @param {Object} opts
  * @param {chrome.runtime.MessageSender | browser.runtime.MessageSender} src
  * @param {function} cb
  */
-async function httpRequest(details, src, cb) {
+async function httpRequest(opts, src, cb) {
   const { tab } = src;
   const { incognito } = tab;
-  const { anonymous, id, chunkType, overrideMimeType, url } = details;
+  const { anonymous, id, overrideMimeType, responseType, url } = opts;
   const req = requests[id];
   if (!req || req.cb) return;
   req.cb = cb;
@@ -300,16 +308,17 @@ async function httpRequest(details, src, cb) {
   const { xhr } = req;
   const vmHeaders = [];
   const FF = ua.isFirefox;
-  // Firefox can send Blob/ArrayBuffer directly...
-  const chunkTypeToUse = chunkType && incognito && !FF ? 'arraybuffer' : chunkType;
-  // ...so it won't need chunking afterwards.
-  if (!FF) req.chunkType = chunkTypeToUse;
+  // Firefox can send Blob/ArrayBuffer directly
+  const chunked = !FF && incognito;
+  // Chrome can't fetch Blob URL in incognito so we use chunks
+  req.blobbed = responseType && !FF && !incognito;
+  req.chunked = chunked;
   // Firefox doesn't send cookies, https://github.com/violentmonkey/violentmonkey/issues/606
   // Both Chrome & FF need explicit routing of cookies in containers or incognito
   let shouldSendCookies = !anonymous && (incognito || FF);
-  xhr.open(details.method || 'GET', url, true, details.user || '', details.password || '');
+  xhr.open(opts.method || 'GET', url, true, opts.user || '', opts.password || '');
   xhr.setRequestHeader(VM_VERIFY, id);
-  details.headers::forEachEntry(([name, value]) => {
+  opts.headers::forEachEntry(([name, value]) => {
     const lowerName = name.toLowerCase();
     if (isSpecialHeader(lowerName)) {
       vmHeaders.push({ name, value });
@@ -321,8 +330,8 @@ async function httpRequest(details, src, cb) {
       shouldSendCookies = false;
     }
   });
-  xhr.responseType = chunkTypeToUse || 'text';
-  xhr.timeout = Math.max(0, Math.min(0x7FFF_FFFF, details.timeout)) || 0;
+  xhr.responseType = chunked && 'blob' || responseType || 'text';
+  xhr.timeout = Math.max(0, Math.min(0x7FFF_FFFF, opts.timeout)) || 0;
   if (overrideMimeType) xhr.overrideMimeType(overrideMimeType);
   if (shouldSendCookies) {
     req.noNativeCookie = true;
@@ -353,7 +362,7 @@ async function httpRequest(details, src, cb) {
   const callback = xhrCallbackWrapper(req);
   req.eventsToNotify.forEach(evt => { xhr[`on${evt}`] = callback; });
   xhr.onloadend = callback; // always send it for the internal cleanup
-  xhr.send(details.data ? decodeBody(details.data) : null);
+  xhr.send(opts.data ? decodeBody(opts.data) : null);
 }
 
 function clearRequest(req) {
@@ -377,9 +386,11 @@ function decodeBody(obj) {
     return result;
   }
   if (['blob', 'file'].includes(cls)) {
+    if (typeof value !== 'string') return value;
+    const str = atob(value);
     const { type, name, lastModified } = obj;
-    const array = new Uint8Array(value.length);
-    for (let i = 0; i < value.length; i += 1) array[i] = value.charCodeAt(i);
+    const array = new Uint8Array(str.length);
+    for (let i = 0; i < str.length; i += 1) array[i] = str.charCodeAt(i);
     const data = [array.buffer];
     if (cls === 'file') return new File(data, name, { type, lastModified });
     return new Blob(data, { type });

--- a/src/background/utils/storage-fetch.js
+++ b/src/background/utils/storage-fetch.js
@@ -4,10 +4,10 @@ import storage from '#/common/storage';
 /** @type { function(url, options, check): Promise<void> } or throws on error */
 storage.cache.fetch = cacheOrFetch({
   init(options) {
-    return { ...options, responseType: 'arraybuffer' };
+    return { ...options, responseType: 'blob' };
   },
   async transform(response, url, options, check) {
-    const [type, body] = storage.cache.makeRaw(response, true);
+    const [type, body] = await storage.cache.makeRaw(response, true);
     await check?.(url, response.data, type);
     return `${type},${body}`;
   },

--- a/src/common/storage.js
+++ b/src/common/storage.js
@@ -1,5 +1,5 @@
 import { browser } from './consts';
-import { buffer2string, ensureArray } from './util';
+import { blob2base64, ensureArray } from './util';
 
 const base = {
   prefix: '',
@@ -59,13 +59,13 @@ export default {
     ...base,
     prefix: 'cac:',
     /**
-     * @param {Response} response
+     * @param {VMRequestResponse} response
      * @param {boolean} [noJoin]
      * @returns {string|string[]}
      */
-    makeRaw(response, noJoin) {
+    async makeRaw(response, noJoin) {
       const type = (response.headers.get('content-type') || '').split(';')[0] || '';
-      const body = btoa(buffer2string(response.data));
+      const body = await blob2base64(response.data);
       return noJoin ? [type, body] : `${type},${body}`;
     },
     /**

--- a/src/confirm/views/app.vue
+++ b/src/confirm/views/app.vue
@@ -258,10 +258,10 @@ export default {
         return cache.get(cacheKey);
       }
       const response = await request(url, {
-        responseType: isBlob ? 'arraybuffer' : null,
+        responseType: isBlob ? 'blob' : null,
       });
       const data = isBlob
-        ? storage.cache.makeRaw(response)
+        ? await storage.cache.makeRaw(response)
         : response.data;
       if (useCache) cache.put(cacheKey, data);
       return data;

--- a/src/injected/content/requests.js
+++ b/src/injected/content/requests.js
@@ -19,12 +19,12 @@ bridge.addHandlers({
 
 bridge.addBackgroundHandlers({
   async HttpRequested(msg) {
-    const { id, numChunks, type } = msg;
+    const { blobbed, id, numChunks, type } = msg;
     const req = requests[id];
     if (!req) return;
     const isLoadEnd = type === 'loadend';
     // only CONTENT realm can read blobs from an extension:// URL
-    const url = msg.chunkType === 'blob'
+    const url = blobbed
       && !req.response
       && req.eventsToNotify::includes(type)
       && msg.data.response;
@@ -37,22 +37,24 @@ bridge.addBackgroundHandlers({
       req.response = await req.response;
     }
     // ...and make sure loadend's bridge.post() runs last
-    if (isLoadEnd) {
+    if (isLoadEnd && blobbed) {
       await 0;
     }
     if (url) {
       msg.data.response = req.response;
     }
     bridge.post('HttpRequested', msg, req.realm);
-    let { allChunks } = req;
+    // If the user in incognito supplied only `onloadend` then it arrives first, followed by chunks
     if (isLoadEnd) {
-      req.ended = true;
-      allChunks = allChunks || !numChunks || numChunks === 1;
-    } else if (msg.isLastChunk) {
-      allChunks = true;
+      req.gotLoadEnd = true;
+      req.gotChunks = req.gotChunks || (numChunks || 0) <= 1;
+    } else if (msg.chunk?.last) {
+      req.gotChunks = true;
     }
-    req.allChunks = allChunks;
-    if (req.ended && allChunks) delete requests[id];
+    // If the user supplied any event before `loadend`, all chunks finish before `loadend` arrives
+    if (req.gotLoadEnd && req.gotChunks) {
+      delete requests[id];
+    }
   },
 });
 

--- a/src/injected/utils/helpers.js
+++ b/src/injected/utils/helpers.js
@@ -15,8 +15,7 @@ export const logging = assign({}, console);
 export const NS_HTML = 'http://www.w3.org/1999/xhtml';
 
 // Firefox defines `isFinite` on `global` not on `window`
-const { Boolean, Uint8Array, isFinite } = global; // eslint-disable-line no-restricted-properties
-const { fromCharCode } = String;
+const { Boolean, isFinite } = global; // eslint-disable-line no-restricted-properties
 const isArray = obj => (
   // ES3 way, not reliable if prototype is modified
   // Object.prototype.toString.call(obj) === '[object Array]'
@@ -68,17 +67,4 @@ export function log(level, tags, ...args) {
   if (tags) tagList::push(...tags);
   const prefix = tagList::map(tag => `[${tag}]`)::join('');
   logging[level](prefix, ...args);
-}
-
-// uses ::safe calls unlike buffer2string in #/common
-export function buffer2stringSafe(buf) {
-  const size = buf.byteLength;
-  // The max number of arguments varies between JS engines but it's >32k so 10k is safe
-  const stepSize = 10e3;
-  const stringChunks = [];
-  for (let from = 0; from < size; from += stepSize) {
-    const sourceChunk = new Uint8Array(buf, from, Math.min(stepSize, size - from));
-    stringChunks::push(fromCharCode(...sourceChunk));
-  }
-  return stringChunks::join('');
 }

--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -5,7 +5,7 @@ import {
 import bridge from './bridge';
 import store from './store';
 import { onTabCreate } from './tabs';
-import { onRequestCreate } from './requests';
+import { atob, onRequestCreate } from './requests';
 import { onNotificationCreate } from './notifications';
 import {
   decodeValue, dumpValue, loadValues, changeHooks,
@@ -16,7 +16,6 @@ import {
 } from '../utils/helpers';
 
 const {
-  atob,
   Blob, Error, TextDecoder, Uint8Array,
   Array: { prototype: { findIndex, indexOf } },
   Document: { prototype: { getElementById } },

--- a/src/injected/web/requests.js
+++ b/src/injected/web/requests.js
@@ -1,18 +1,22 @@
 import { assign, defineProperty, describeProperty, objectPick } from '#/common/object';
 import {
-  filter, includes, map, jsonDump, jsonLoad, join, objectToString, Promise,
-  setAttribute, log, buffer2stringSafe, charCodeAt, slice,
+  filter, forEach, includes, map, jsonDump, jsonLoad, objectToString, Promise,
+  setAttribute, log, charCodeAt, slice,
   createElementNS, NS_HTML,
 } from '../utils/helpers';
 import bridge from './bridge';
 
 const idMap = {};
 
-const { Blob, DOMParser, Error, Uint8Array } = global;
+export const { atob } = global;
+const { Blob, DOMParser, Error, FileReader, Uint8Array } = global;
 const { parseFromString } = DOMParser.prototype;
 const { then } = Promise.prototype;
-const { toLowerCase } = String.prototype;
+const { indexOf, toLowerCase } = String.prototype;
 const { get: getHref } = describeProperty(HTMLAnchorElement.prototype, 'href');
+const { keys, getAll } = FormData.prototype;
+const { readAsDataURL } = FileReader.prototype;
+const promiseAll = Promise.all;
 
 bridge.addHandlers({
   HttpRequested(msg) {
@@ -21,18 +25,18 @@ bridge.addHandlers({
   },
 });
 
-export function onRequestCreate(details, scriptId) {
-  if (!details.url) throw new Error('Required parameter "url" is missing.');
+export function onRequestCreate(opts, scriptId) {
+  if (!opts.url) throw new Error('Required parameter "url" is missing.');
   const req = {
     scriptId,
-    details,
+    opts,
     req: {
       abort() {
         bridge.post('AbortRequest', req.id);
       },
     },
   };
-  details.url = getFullUrl(details.url);
+  opts.url = getFullUrl(opts.url);
   bridge.send('GetRequestId', {
     eventsToNotify: [
       'abort',
@@ -43,15 +47,16 @@ export function onRequestCreate(details, scriptId) {
       'progress',
       'readystatechange',
       'timeout',
-    ]::filter(e => typeof details[`on${e}`] === 'function'),
-    wantsBlob: details.responseType === 'blob',
+    ]::filter(e => typeof opts[`on${e}`] === 'function'),
+    wantsBlob: opts.responseType === 'blob',
   })
   ::then(id => start(req, id));
   return req.req;
 }
 
-function parseData(response, msg, details) {
-  const { responseType } = details;
+function parseData(req, msg, opts) {
+  const response = req.raw;
+  const { responseType } = opts;
   if (responseType === 'json') {
     return jsonLoad(response);
   }
@@ -60,10 +65,15 @@ function parseData(response, msg, details) {
     return new DOMParser()::parseFromString(response, type);
   }
   // arraybuffer/blob in incognito tabs is transferred as ArrayBuffer encoded in string chunks
-  if (msg.chunkType === 'arraybuffer') {
-    const len = response.length;
-    const arr = new Uint8Array(len);
-    for (let i = 0; i < len; i += 1) arr[i] = response::charCodeAt(i);
+  if (msg.chunked) {
+    const arr = new Uint8Array(req.dataSize);
+    let dstIndex = 0;
+    response::forEach((chunk) => {
+      const len = (chunk = atob(chunk)).length;
+      for (let j = 0; j < len; j += 1, dstIndex += 1) {
+        arr[dstIndex] = chunk::charCodeAt(j);
+      }
+    });
     return responseType === 'blob'
       ? new Blob([arr], { type: msg.contentType })
       : arr.buffer;
@@ -74,9 +84,12 @@ function parseData(response, msg, details) {
 
 // request object functions
 async function callback(req, msg) {
-  if (msg.chunk) return receiveChunk(req, msg);
-  const { chunksPromise, details } = req;
-  const cb = details[`on${msg.type}`];
+  if (msg.chunk) {
+    receiveChunk(req, msg.chunk);
+    return;
+  }
+  const { chunksPromise, opts } = req;
+  const cb = opts[`on${msg.type}`];
   if (chunksPromise) {
     await chunksPromise;
   }
@@ -87,10 +100,10 @@ async function callback(req, msg) {
       responseHeaders: headers,
       responseText: text,
     } = data;
-    const isText = ['text']::includes(details.responseType || 'text');
+    const isText = ['text']::includes(opts.responseType || 'text');
     if (!isText && response && !('raw' in req)) {
-      req.raw = msg.numChunks > 1
-        ? receiveAllChunks(req, response, msg.numChunks)
+      req.raw = msg.chunked
+        ? receiveAllChunks(req, response, msg)
         : response;
     }
     if (req.raw?.then) {
@@ -99,14 +112,14 @@ async function callback(req, msg) {
     defineProperty(data, 'response', {
       configurable: true,
       get() {
-        const value = 'raw' in req ? parseData(req.raw, msg, details) : response;
+        const value = 'raw' in req ? parseData(req, msg, opts) : response;
         defineProperty(this, 'response', { value });
         return value;
       },
     });
     if (headers != null) req.headers = headers;
     if (text != null) req.text = text[0] === 'same' ? response : text;
-    data.context = details.context;
+    data.context = opts.context;
     data.responseHeaders = req.headers;
     data.responseText = req.text;
     cb(data);
@@ -114,36 +127,40 @@ async function callback(req, msg) {
   if (msg.type === 'loadend') delete idMap[req.id];
 }
 
-function receiveAllChunks(req, response, numChunks) {
-  req.chunks = [response];
-  req.numChunks = numChunks;
-  req.chunksPromise = new Promise(resolve => {
-    req.resolve = resolve;
-  });
-  return req.chunksPromise;
+function receiveAllChunks(req, response, { dataSize, numChunks }) {
+  let res = [response];
+  req.dataSize = dataSize;
+  if (numChunks > 1) {
+    req.chunks = res;
+    req.chunksPromise = new Promise(resolve => {
+      req.resolve = resolve;
+    });
+    res = req.chunksPromise;
+  }
+  return res;
 }
 
-function receiveChunk(req, { chunk, chunkIndex }) {
-  const { chunks, numChunks } = req;
-  chunks[chunkIndex] = chunk;
-  if (chunkIndex === numChunks - 1) {
+function receiveChunk(req, { data, i, last }) {
+  const { chunks } = req;
+  chunks[i] = data;
+  if (last) {
+    req.resolve(chunks);
     delete req.chunksPromise;
     delete req.chunks;
-    delete req.numChunks;
-    req.resolve(chunks::join(''));
+    delete req.resolve;
   }
 }
 
 async function start(req, id) {
-  const { details, scriptId } = req;
+  const { opts, scriptId } = req;
   // withCredentials is for GM4 compatibility and used only if `anonymous` is not set,
   // it's true by default per the standard/historical behavior of gmxhr
-  const { withCredentials = true, anonymous = !withCredentials } = details;
+  const { withCredentials = true, anonymous = !withCredentials } = opts;
   const payload = assign({
     id,
     scriptId,
     anonymous,
-  }, objectPick(details, [
+  }, objectPick(opts, [
     'headers',
     'method',
     'overrideMimeType',
@@ -154,19 +171,18 @@ async function start(req, id) {
   ]));
   req.id = id;
   idMap[id] = req;
-  const { responseType } = details;
+  const { responseType } = opts;
   if (responseType) {
     if (['arraybuffer', 'blob']::includes(responseType)) {
-      // Firefox can send Blob/ArrayBuffer directly but Chrome can't
-      payload.chunkType = bridge.isFirefox ? responseType : 'blob';
+      payload.responseType = responseType;
     } else if (!['document', 'json', 'text']::includes(responseType)) {
       log('warn', null, `Unknown responseType "${responseType}", see https://violentmonkey.github.io/api/gm/#gm_xmlhttprequest for more detail.`);
     }
   }
   // TM/GM-compatibility: the `binary` option works only with a string `data`
-  payload.data = details.binary
-    ? { value: `${details.data}`, cls: 'blob' }
-    : await encodeBody(details.data);
+  payload.data = opts.binary
+    ? { value: `${opts.data}`, cls: 'blob' }
+    : await encodeBody(opts.data);
   bridge.post('HttpRequest', payload);
 }
 
@@ -176,43 +192,37 @@ function getFullUrl(url) {
   return a::getHref();
 }
 
-const { keys, getAll } = FormData.prototype;
-const { FileReader } = global;
-const { readAsArrayBuffer } = FileReader.prototype;
-
 async function encodeBody(body) {
-  const cls = getType(body);
+  const cls = body::objectToString()::slice(8, -1)::toLowerCase(); // [object TYPENAME]
   switch (cls) {
   case 'formdata': {
     const data = {};
     const resolveKeyValues = async (key) => {
       const values = body::getAll(key)::map(encodeBody);
-      data[key] = await Promise.all(values);
+      data[key] = await promiseAll(values);
     };
-    await Promise.all([...body::keys()]::map(resolveKeyValues));
+    await promiseAll([...body::keys()]::map(resolveKeyValues));
     return { cls, value: data };
   }
   case 'blob':
   case 'file':
-    return new Promise((resolve) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve({
-        cls,
-        value: buffer2stringSafe(reader.result),
-        type: body.type,
-        name: body.name,
-        lastModified: body.lastModified,
-      });
-      reader::readAsArrayBuffer(body);
-    });
+    // TODO: implement BufferSource (ArrayBuffer, DataView, typed arrays)
+    return {
+      cls,
+      type: body.type,
+      name: body.name,
+      lastModified: body.lastModified,
+      // Firefox can send Blob/File/BufferSource directly
+      value: bridge.isFirefox ? body : await new Promise((resolve) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const res = reader.result;
+          resolve(res::slice(res::indexOf(',') + 1));
+        };
+        reader::readAsDataURL(body);
+      }),
+    };
   default:
     if (body != null) return { cls, value: jsonDump(body) };
   }
-}
-
-function getType(obj) {
-  const type = typeof obj;
-  if (type !== 'object') return type;
-  const typeString = obj::objectToString(); // [object TYPENAME]
-  return typeString::slice(8, -1)::toLowerCase();
 }

--- a/src/injected/web/requests.js
+++ b/src/injected/web/requests.js
@@ -14,7 +14,6 @@ const { then } = Promise.prototype;
 const { blob: resBlob } = Response.prototype;
 const { get: getHref } = describeProperty(HTMLAnchorElement.prototype, 'href');
 const { readAsDataURL } = FileReader.prototype;
-const { get: frGetResult } = describeProperty(FileReader.prototype, 'result');
 
 bridge.addHandlers({
   HttpRequested(msg) {
@@ -214,7 +213,7 @@ async function encodeBody(body) {
   const reader = new FileReader();
   return new Promise((resolve) => {
     reader::addEventListener('load', () => resolve([
-      reader::frGetResult(),
+      reader.result,
       wasBlob ? 'blob' : blob.type,
     ]));
     reader::readAsDataURL(blob);

--- a/src/injected/web/requests.js
+++ b/src/injected/web/requests.js
@@ -165,10 +165,11 @@ async function start(req, id) {
     id,
     scriptId,
     anonymous,
-    // `binary` is for TM/GM-compatibility + non-objects = must use a string `data`
-    data: (opts.binary || typeof data !== 'object') && [`${data}`]
+    data: data == null && []
+      // `binary` is for TM/GM-compatibility + non-objects = must use a string `data`
+      || (opts.binary || typeof data !== 'object') && [`${data}`]
       // FF can send any cloneable data directly
-      || (bridge.isFirefox || !data) && [data]
+      || (bridge.isFirefox) && [data]
       // TODO: support huge data by splitting it to multiple messages
       || await encodeBody(data),
     responseType: getResponseType(opts),

--- a/src/injected/web/requests.js
+++ b/src/injected/web/requests.js
@@ -168,8 +168,8 @@ async function start(req, id) {
     data: data == null && []
       // `binary` is for TM/GM-compatibility + non-objects = must use a string `data`
       || (opts.binary || typeof data !== 'object') && [`${data}`]
-      // FF can send any cloneable data directly
-      || (bridge.isFirefox) && [data]
+      // FF56+ can send any cloneable data directly, FF52-55 can't due to https://bugzil.la/1371246
+      || (bridge.isFirefox >= 56) && [data]
       // TODO: support huge data by splitting it to multiple messages
       || await encodeBody(data),
     responseType: getResponseType(opts),

--- a/src/injected/web/requests.js
+++ b/src/injected/web/requests.js
@@ -157,7 +157,8 @@ async function start(req, id) {
   const { responseType } = details;
   if (responseType) {
     if (['arraybuffer', 'blob']::includes(responseType)) {
-      payload.chunkType = 'blob';
+      // Firefox can send Blob/ArrayBuffer directly but Chrome can't
+      payload.chunkType = bridge.isFirefox ? responseType : 'blob';
     } else if (!['document', 'json', 'text']::includes(responseType)) {
       log('warn', null, `Unknown responseType "${responseType}", see https://violentmonkey.github.io/api/gm/#gm_xmlhttprequest for more detail.`);
     }

--- a/test/mock/polyfill.js
+++ b/test/mock/polyfill.js
@@ -27,6 +27,7 @@ for (const k of Object.keys(domProps)) {
 }
 delete domProps.performance;
 Object.defineProperties(global, domProps);
+global.Response = { prototype: {} };
 
 global.URL = {
   _cache: {},


### PR DESCRIPTION
* Firefox can send Blob/File/ArrayBuffer directly via extension messaging, also in incognito tabs. Now, downloading huge files (100MB or more) takes just a couple of seconds. Previously, we used chunks because FF could block fetching of blobs on a page with a strict CSP.
* FileReader is much faster than buffer2string: 2x in Chrome, 10x in Firefox
* Using base64 makes the internal message size 1.5x smaller at least in Chrome because Chrome encodes our buffer2string's result to UTF-8, which increases the size and is slow. Now with base64 Chrome doesn't re-encode.

I've also renamed `details` to `opts` to indicate these are user options of GMxhr's call. I regularly got confused about `details` as it can conceptually refer to a response or a request or anything for that matter.