### PR TITLE
fix: accept only JS to disable prefetch and CSP errors

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -260,11 +260,10 @@ export async function request(url, options = {}) {
     method,
     body: isBodyObj ? JSON.stringify(body) : body,
     headers: isBodyObj || accept
-      ? {
-        ...headers,
-        ...isBodyObj && { 'Content-Type': 'application/json' },
-        ...accept && { accept },
-      }
+      ? Object.assign({},
+        headers,
+        isBodyObj && { 'Content-Type': 'application/json' },
+        accept && { accept })
       : headers,
   };
   const result = { url, status: -1 };


### PR DESCRIPTION
How to test: click the install button in https://greasyfork.org/scripts/430515 and when VM's installer shows up, open devtools console.

@JasonBarnabe, do you think this solution (sending an `Accept` header only with JS types) is universal? Otherwise maybe you could return empty content with 404 status if we add some special header to the request?

@gera2ld, I'm not sure this PR is even necessary because the only bad thing is the spam in console, and it happens only when a dependency on greasyfork was deleted so it responds with a `404` html page.

P.S. I have another solution: 50 dense lines of stripping the header via webRequest API, but it's probably an overkill.