### PR TITLE
feat: pass DOM event to GM_registerMenuCommand function

### DIFF
--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -51,7 +51,8 @@ const { split } = '';
 
 bridge.addBackgroundHandlers({
   Command(data) {
-    const id = +data::split(':', 1)[0];
+    const [cmd] = data;
+    const id = +cmd::split(':', 1)[0];
     const realm = bridge.invokableIds::includes(id) && INJECT_CONTENT;
     bridge.post('Command', data, realm);
   },

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -12,6 +12,7 @@ import './tabs';
 
 // Make sure to call safe::methods() in code that may run after userscripts
 
+const { KeyboardEvent, MouseEvent } = global;
 const { get: getCurrentScript } = describeProperty(Document.prototype, 'currentScript');
 
 const sendSetTimeout = () => bridge.send('SetTimeout', 0);
@@ -46,8 +47,9 @@ export default function initialize(
 }
 
 bridge.addHandlers({
-  Command(data) {
-    store.commands[data]?.();
+  Command([cmd, evt]) {
+    const constructor = evt.key ? KeyboardEvent : MouseEvent;
+    store.commands[cmd]?.(new constructor(evt.type, evt));
   },
   Callback({ callbackId, payload }) {
     bridge.callbacks[callbackId]?.(payload);

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -229,8 +229,6 @@ export default {
       activeMenu: 'scripts',
       activeExtras: null,
       message: null,
-      /** @type HTMLElement */
-      mousedown: null,
       focusedId: null,
     };
   },


### PR DESCRIPTION
https://github.com/Tampermonkey/tampermonkey/issues/1307

The menu command can be executed by clicking any mouse button or pressing <kbd>Space</kbd> or <kbd>Enter</kbd>, with any modifiers. All this info is passed to GM_registerMenuCommand's function as KeyboardEvent or MouseEvent accordingly.

Test script:
```js
// ==UserScript==
// @name        test GM_registerMenuCommand event
// @match       *://*/*
// @grant       GM_registerMenuCommand
// ==/UserScript==

GM_registerMenuCommand('test', (e = {}) => {
  const isMouse = e.button != null;
  alert([
    e.shiftKey && 'Shift-',
    e.ctrlKey && 'Ctrl-',
    e.altKey && 'Alt-',
    e.metaKey && 'Meta-',
    isMouse
      ? `btn${e.button}`
      : `${e.key === ' ' ? '" "' : e.key} / ${e.keyCode}`,
    !isMouse && e.code !== e.key && ` / ${e.code}`,
  ].filter(Boolean).join(''));
});
```