### PR TITLE
feat: reuse an existing editor when editing a script

### DIFF
--- a/src/background/utils/tabs.js
+++ b/src/background/utils/tabs.js
@@ -1,4 +1,5 @@
 import { getActiveTab, noop, sendTabCmd, getFullUrl } from '#/common';
+import { deepCopy } from '#/common/object';
 import ua from '#/common/ua';
 import { extensionRoot } from './init';
 import { commands } from './message';
@@ -25,7 +26,8 @@ Object.assign(commands, {
     // Firefox until v56 doesn't support moz-extension:// pattern in browser.tabs.query()
     for (const view of browser.extension.getViews()) {
       if (view.location.href === url) {
-        const tab = await view.browser.tabs.getCurrent();
+        // deep-copying to avoid dead objects
+        const tab = deepCopy(await view.browser.tabs.getCurrent());
         browser.tabs.update(tab.id, { active: true });
         browser.windows.update(tab.windowId, { focused: true });
         return tab;

--- a/src/background/utils/tabs.js
+++ b/src/background/utils/tabs.js
@@ -62,7 +62,12 @@ Object.assign(commands, {
     }
     const canOpenIncognito = !incognito || ua.isFirefox || !/^(chrome[-\w]*):/.test(url);
     let newTab;
-    if (maybeInWindow && browser.windows && getOption('editorWindow')) {
+    if (maybeInWindow
+        && browser.windows
+        && getOption('editorWindow')
+        /* cookieStoreId in windows.create() is supported since FF64 https://bugzil.la/1393570
+         * and a workaround is too convoluted to add it for such an ancient version */
+        && (!storeId || ua.isFirefox >= 64)) {
       const wndOpts = {
         url,
         incognito: canOpenIncognito && incognito,

--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -103,6 +103,7 @@ if (!global.browser?.runtime?.sendMessage) {
       onReplaced: true,
       create: wrapAsync,
       get: wrapAsync,
+      getCurrent: wrapAsync,
       query: wrapAsync,
       reload: wrapAsync,
       remove: wrapAsync,


### PR DESCRIPTION
* **feat: reuse an existing editor when editing a script** - a couple of times I accidentally opened a second editor after forgetting I had unsaved changes in the first one
* **fix: disable windowed editor in FF before v64** - cookieStoreId in windows.create() is supported since FF64 and a workaround is too convoluted to add it for such an ancient version