### PR TITLE
fix: use webRequest to intercept tokens

### DIFF
--- a/src/background/sync/dropbox.js
+++ b/src/background/sync/dropbox.js
@@ -1,6 +1,7 @@
 import { loadQuery, dumpQuery } from '../utils';
 import {
   getURI, getItemFilename, BaseService, isScriptFile, register,
+  openAuthPage,
 } from './base';
 
 const config = {
@@ -100,7 +101,7 @@ const Dropbox = BaseService.extend({
       redirect_uri: config.redirect_uri,
     };
     const url = `https://www.dropbox.com/oauth2/authorize?${dumpQuery(params)}`;
-    browser.tabs.create({ url });
+    openAuthPage(url, config.redirect_uri);
   },
   authorized(raw) {
     const data = loadQuery(raw);

--- a/src/background/sync/googledrive.js
+++ b/src/background/sync/googledrive.js
@@ -6,6 +6,7 @@ import { objectGet } from '#/common/object';
 import { dumpQuery, notify } from '../utils';
 import {
   getURI, getItemFilename, BaseService, register, isScriptFile,
+  openAuthPage,
 } from './base';
 
 const SECRET_KEY = JSON.parse(window.atob('eyJjbGllbnRfc2VjcmV0IjoiTjBEbTZJOEV3bkJaeE1xMUpuMHN3UER0In0='));
@@ -118,7 +119,7 @@ const GoogleDrive = BaseService.extend({
     };
     if (!this.config.get('refresh_token')) params.prompt = 'consent';
     const url = `https://accounts.google.com/o/oauth2/v2/auth?${dumpQuery(params)}`;
-    browser.tabs.create({ url });
+    openAuthPage(url, config.redirect_uri);
   },
   checkAuth(url) {
     const redirectUri = `${config.redirect_uri}?code=`;

--- a/src/background/sync/index.js
+++ b/src/background/sync/index.js
@@ -1,5 +1,4 @@
 import {
-  checkAuthUrl,
   initialize,
   sync,
   getStates,
@@ -18,10 +17,6 @@ Object.assign(commands, {
   SyncRevoke: revoke,
   SyncStart: sync,
   SyncSetConfig: setConfig,
-});
-
-browser.tabs.onUpdated.addListener((tabId, changes) => {
-  if (changes.url && checkAuthUrl(changes.url)) browser.tabs.remove(tabId);
 });
 
 export {

--- a/src/background/sync/onedrive.js
+++ b/src/background/sync/onedrive.js
@@ -4,6 +4,7 @@ import { objectGet } from '#/common/object';
 import { dumpQuery } from '../utils';
 import {
   getURI, getItemFilename, BaseService, isScriptFile, register,
+  openAuthPage,
 } from './base';
 
 const SECRET_KEY = JSON.parse(window.atob('eyJjbGllbnRfc2VjcmV0Ijoiajl4M09WRXRIdmhpSEtEV09HcXV5TWZaS2s5NjA0MEgifQ=='));
@@ -106,7 +107,7 @@ const OneDrive = BaseService.extend({
       redirect_uri: config.redirect_uri,
     };
     const url = `https://login.live.com/oauth20_authorize.srf?${dumpQuery(params)}`;
-    browser.tabs.create({ url });
+    openAuthPage(url, config.redirect_uri);
   },
   checkAuth(url) {
     const redirectUri = `${config.redirect_uri}?code=`;


### PR DESCRIPTION
Also, the request to redirect_uri will be blocked sooner so it won't see the token.

This fix may resolve https://github.com/kiwibrowser/src.next/issues/278.
@KaKi87, you can try the attached development build of the extension: [dev.zip](https://github.com/violentmonkey/violentmonkey/files/6996650/dev.zip) (v2, reuploaded).
