### PR TITLE
refactor: use Proxy for `browser`, embed it as module

### DIFF
--- a/scripts/plaid.conf.js
+++ b/scripts/plaid.conf.js
@@ -6,37 +6,21 @@ const { isProd } = require('@gera2ld/plaid/util');
  * - value.html: options object passed to HtmlWebpackPlugin.
  * - value.html.inlineSource: if true, JS and CSS files will be inlined in HTML.
  */
-const injectTo = item => {
-  if (!(item.attributes.src || '').endsWith('/index.js')) return 'head';
-};
-const htmlFactory = extra => options => ({
-  ...options,
-  title: 'Violentmonkey',
-  ...extra,
-  chunks: ['browser', ...options.chunks],
-  injectTo,
-});
-exports.pages = {
-  'browser': {
-    entry: './src/common/browser',
+exports.pages = [
+  'background',
+  'confirm',
+  'options',
+  'popup',
+].reduce((res, name) => Object.assign(res, {
+  [`${name}/index`]: {
+    entry: `./src/${name}`,
+    html: options => ({
+      ...options,
+      title: 'Violentmonkey',
+      injectTo: item => (item.attributes.src || '').endsWith('/index.js') ? 'body' : 'head',
+    }),
   },
-  'background/index': {
-    entry: './src/background',
-    html: htmlFactory(),
-  },
-  'options/index': {
-    entry: './src/options',
-    html: htmlFactory(),
-  },
-  'confirm/index': {
-    entry: './src/confirm',
-    html: htmlFactory(),
-  },
-  'popup/index': {
-    entry: './src/popup',
-    html: htmlFactory(),
-  },
-};
+}), {});
 
 const splitVendor = prefix => ({
   [prefix]: {
@@ -57,7 +41,7 @@ exports.optimization = {
         name: 'common',
         minChunks: 2,
         enforce: true,
-        chunks: chunk => chunk.name !== 'browser',
+        chunks: 'all',
       },
       ...splitVendor('codemirror'),
       ...splitVendor('tldjs'),

--- a/scripts/webpack.conf.js
+++ b/scripts/webpack.conf.js
@@ -13,7 +13,6 @@ const VM_VER = require('../package.json').version.replace(/-[^.]*/, '');
 const definitions = new webpack.DefinePlugin({
   'process.env.INIT_FUNC_NAME': JSON.stringify(INIT_FUNC_NAME),
   'process.env.DEBUG': JSON.stringify(process.env.DEBUG || false),
-  'process.env.DEV': JSON.stringify(!isProd),
   'process.env.VM_VER': JSON.stringify(VM_VER),
 });
 const minimizerOptions = {

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,3 +1,4 @@
+import '#/common/browser';
 import { getActiveTab, makePause, sendCmd } from '#/common';
 import { TIMEOUT_24HOURS, TIMEOUT_MAX } from '#/common/consts';
 import { deepCopy, forEachEntry, objectSet } from '#/common/object';

--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -1,9 +1,7 @@
-/*
- Since this also runs in a content script we'll guard against implicit global variables
- for DOM elements with 'id' attribute which is a standard feature, more info:
- https://github.com/mozilla/webextension-polyfill/pull/153
- https://html.spec.whatwg.org/multipage/window-object.html#named-access-on-the-window-object
-*/
+// Since this also runs in a content script we'll guard against implicit global variables
+// for DOM elements with 'id' attribute which is a standard feature, more info:
+// https://github.com/mozilla/webextension-polyfill/pull/153
+// https://html.spec.whatwg.org/multipage/window-object.html#named-access-on-the-window-object
 if (!global.browser?.runtime?.sendMessage) {
   // region Chrome
   const { chrome, Error, Promise, Proxy } = global;

--- a/src/common/browser.js
+++ b/src/common/browser.js
@@ -24,14 +24,15 @@ if (!global.browser?.runtime?.sendMessage) {
       });
       // Make the error messages actually useful by capturing a real stack
       const stackInfo = new Error();
-      thisArg::func(...args, (response) => {
+      // Using (...results) for API methods (not used currently) that return several results
+      thisArg::func(...args, (...results) => {
         let err = chrome.runtime.lastError;
         if (err) {
           err = err.message;
         } else if (preprocessorFunc) {
-          err = preprocessorFunc(resolve, response);
+          err = preprocessorFunc(resolve, ...results);
         } else {
-          resolve(response);
+          resolve(results[0]);
         }
         // Prefer `reject` over `throw` which stops debugger in 'pause on exceptions' mode
         if (err) reject(new Error(`${err}\n${stackInfo.stack}`));
@@ -104,7 +105,7 @@ if (!global.browser?.runtime?.sendMessage) {
    * 0 = non-async method or the entire group
    * function = preprocessor,
    *   for onXXX methods: (listener, ...originalArgs): void
-   *   for async methods: (resolve, data): any - a truthy return value goes into reject()
+   *   for async methods: (resolve, ...originalArgs): any - a truthy return value goes into reject()
    */
   global.browser = proxifyGroup('', chrome, {
     extension: 0, // we don't use its async methods

--- a/src/common/handlers.js
+++ b/src/common/handlers.js
@@ -1,4 +1,3 @@
-import { browser } from '#/common/consts';
 import options from './options';
 
 const handlers = {

--- a/src/common/storage.js
+++ b/src/common/storage.js
@@ -1,4 +1,3 @@
-import { browser } from './consts';
 import { blob2base64, ensureArray } from './util';
 
 const base = {

--- a/src/common/ua.js
+++ b/src/common/ua.js
@@ -1,5 +1,3 @@
-import { browser } from './consts';
-
 // UA can be overridden by about:config in FF or devtools in Chrome
 // so we'll test for window.chrome.app which is only defined in Chrome
 // and for browser.runtime.getBrowserInfo in Firefox 51+

--- a/src/confirm/index.js
+++ b/src/confirm/index.js
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import '#/common/browser';
 import { i18n } from '#/common';
 import '#/common/handlers';
 import options from '#/common/options';

--- a/src/injected/index.js
+++ b/src/injected/index.js
@@ -1,3 +1,4 @@
+import '#/common/browser';
 import { sendCmd } from '#/common';
 import './content';
 

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -26,7 +26,6 @@ options_ui:
   open_in_tab: true
 content_scripts:
   - js:
-      - browser.js
       - injected-web.js
       - injected.js
     matches:

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import '#/common/browser';
 import { sendCmdDirectly, i18n, getLocaleString } from '#/common';
 import handlers from '#/common/handlers';
 import { loadScriptIcon } from '#/common/load-script-icon';

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import '#/common/browser';
 import { i18n, sendCmdDirectly } from '#/common';
 import { INJECT_PAGE } from '#/common/consts';
 import handlers from '#/common/handlers';


### PR DESCRIPTION
1. The startup time is faster for ~5ms because Proxy works on demand.

   The overall time spent inside the module has marginally decreased (from 7ms to 5ms) judging by performance profiler while opening VM's dashboard page.

   Now there's no need to manually add new methods because the meta object lists just the special cases - non-asynchronous and overridden methods.

2. browser.js is embedded as a module because executing each separate content script has internal overhead. The overall file size decreased a little because the actual contents of browser.js is just 0.9k, the rest 1.2k was webpack's bootstrap. Now browser.js is embedded into two files: injected.js and common.js.

   Embedding it allowed some deduplicating of webpack/plaid configs.