### PR TITLE
feat: option to group disabled scripts in popup

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -533,6 +533,9 @@ menuInjectionFailedFix:
 menuMatchedFrameScripts:
   description: Label for menu listing matching scripts in sub-frames.
   message: Sub-frames only scripts
+menuMatchedDisabledScripts:
+  description: Label for menu listing matched disabled scripts when the option to group disabled scripts is selected.
+  message: Matched disabled scripts
 menuMatchedScripts:
   description: Label for menu listing matched scripts.
   message: Matched scripts
@@ -671,9 +674,15 @@ optionEditorWindowSimple:
 optionPopupEnabledFirst:
   description: Option to show enabled scripts first in popup.
   message: Enabled first
+optionPopupGroupDisabled:
+  description: Option to group disabled scripts in popup.
+  message: Group disabled scripts
 optionPopupHideDisabled:
   description: Option to hide disabled scripts in popup.
-  message: Hide disabled
+  message: Hide disabled scripts
+optionPopupShowDisabled:
+  description: Option to show disabled scripts in popup.
+  message: Show disabled scripts
 optionShowEnabledFirst:
   description: Option to show enabled scripts first in alphabetical order.
   message: Show enabled scripts first

--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -29,14 +29,14 @@ export default {
   notifyUpdates: false,
   notifyUpdatesGlobal: false, // `true` ignores script.config.notifyUpdates
   version: null,
-  /** @type 'auto' | 'page' | 'content' */
+  /** @type {'auto' | 'page' | 'content'} */
   defaultInjectInto: INJECT_AUTO,
   filters: {
-    /** @type 'name' | 'code' | 'all' */
+    /** @type {'name' | 'code' | 'all'} */
     searchScope: 'name',
     /** @type boolean */
     showOrder: false,
-    /** @type 'exec' | 'alpha' | 'update' */
+    /** @type {'exec' | 'alpha' | 'update'} */
     sort: 'exec',
     /** @type boolean */
     viewSingleColumn: false,
@@ -44,10 +44,11 @@ export default {
     viewTable: false,
   },
   filtersPopup: {
-    /** @type 'exec' | 'alpha' */
+    /** @type {'exec' | 'alpha'} */
     sort: 'exec',
     enabledFirst: false,
-    hideDisabled: false,
+    /** @type {'' | 'hide' | 'group'} where '' = show */
+    hideDisabled: '',
   },
   editor: {
     lineWrapping: false,

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -157,8 +157,8 @@ const items = {
   'filtersPopup.hideDisabled': {
     enum: {
       '': i18n('optionPopupShowDisabled'),
-      hide: i18n('optionPopupHideDisabled'),
       group: i18n('optionPopupGroupDisabled'),
+      hide: i18n('optionPopupHideDisabled'),
     },
   },
   'filtersPopup.sort': {

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -17,27 +17,32 @@
       <div class="ml-2c">
         <label>
           <locale-group i18n-key="labelPopupSort">
-            <select v-model="settings['filtersPopup.sort']">
-              <option value="exec" v-text="i18n('filterExecutionOrder')" />
-              <option value="alpha" v-text="i18n('filterAlphabeticalOrder')" />
+            <select v-for="opt in ['filtersPopup.sort']" v-model="settings[opt]" :key="opt">
+              <option v-for="(title, value) in items[opt].enum" :key="`${opt}:${value}`"
+                      :value="value" v-text="title" />
             </select>
           </locale-group>
         </label>
+        <label>
+          <select v-for="opt in ['filtersPopup.hideDisabled']" v-model="settings[opt]" :key="opt">
+            <option v-for="(title, value) in items[opt].enum" :key="`${opt}:${value}`"
+                    :value="value" v-text="title" />
+          </select>
+        </label>
         <setting-check name="filtersPopup.enabledFirst" :label="i18n('optionPopupEnabledFirst')" />
-        <setting-check name="filtersPopup.hideDisabled" :label="i18n('optionPopupHideDisabled')" />
       </div>
       <div class="mr-2c">
         <label>
           <span v-text="i18n('labelBadge')"></span>
-          <select v-model="settings.showBadge">
-            <option value="" v-text="i18n('labelBadgeNone')" />
-            <option value="unique" v-text="i18n('labelBadgeUnique')" />
-            <option value="total" v-text="i18n('labelBadgeTotal')" />
+          <select v-for="opt in ['showBadge']" v-model="settings[opt]" :key="opt">
+            <option v-for="(title, value) in items[opt].enum" :key="`${opt}:${value}`"
+                    :value="value" v-text="title" />
           </select>
         </label>
         <label>
           <span v-text="i18n('labelBadgeColors')"/>
-          <tooltip v-for="(title, name) in badgeColors" :key="name" :content="title">
+          <tooltip v-for="(title, name) in items.badgeColor.enum" :key="`bc:${name}`"
+                   :content="title">
             <input type="color" v-model="settings[name]">
           </tooltip>
           <button v-text="i18n('buttonReset')" v-show="isCustomBadgeColor" class="ml-1"
@@ -75,13 +80,9 @@
         <div>
           <label>
             <span v-text="i18n('labelInjectionMode')"></span>
-            <select v-model="settings.defaultInjectInto">
-              <option
-                v-for="option in injectIntoOptions"
-                :key="option"
-                :value="option"
-                v-text="option"
-              />
+            <select v-for="opt in ['defaultInjectInto']" v-model="settings[opt]" :key="opt">
+              <option v-for="(_, mode) in items[opt].enum" :key="`${opt}:${mode}`"
+                      :value="mode" v-text="mode" />
             </select>
             <a class="ml-1" href="https://violentmonkey.github.io/posts/inject-into-context/" target="_blank" rel="noopener noreferrer" v-text="i18n('learnInjectionMode')"></a>
           </label>
@@ -106,14 +107,10 @@
 
 <script>
 import Tooltip from 'vueleton/lib/tooltip/bundle';
-import { debounce, i18n } from '#/common';
-import {
-  INJECT_AUTO,
-  INJECT_PAGE,
-  INJECT_CONTENT,
-} from '#/common/consts';
+import { debounce, hasOwnProperty, i18n } from '#/common';
+import { INJECT_AUTO, INJECT_PAGE, INJECT_CONTENT } from '#/common/consts';
 import SettingCheck from '#/common/ui/setting-check';
-import { forEachKey } from '#/common/object';
+import { forEachEntry, mapEntry } from '#/common/object';
 import options from '#/common/options';
 import optionsDefaults from '#/common/options-defaults';
 import hookSetting from '#/common/hook-setting';
@@ -128,45 +125,64 @@ import VmTemplate from './vm-template';
 import VmBlacklist from './vm-blacklist';
 import VmCss from './vm-css';
 
-const injectIntoOptions = [
-  INJECT_AUTO,
-  INJECT_PAGE,
-  INJECT_CONTENT,
-];
-const badgeColors = {
+const badgeColorEnum = {
   badgeColor: i18n('titleBadgeColor'),
   badgeColorBlocked: i18n('titleBadgeColorBlocked'),
 };
-const items = [
-  {
-    name: 'showBadge',
-    normalize(value) {
-      if (!value) return '';
-      return value === 'total' ? 'total' : 'unique';
-    },
-  },
-  {
-    name: 'autoUpdate',
+const badgeColorNames = Object.keys(badgeColorEnum);
+const badgeColorItem = {
+  enum: badgeColorEnum, // exposing to the template
+  normalize: (value, name) => (
+    /^#[0-9a-f]{6}$/i.test(value) ? value : optionsDefaults[name]
+  ),
+};
+const items = {
+  autoUpdate: {
     normalize: value => Math.max(0, Math.min(365, +value || 0)),
   },
-  {
-    name: 'defaultInjectInto',
-    normalize(value) {
-      return injectIntoOptions.includes(value) ? value : optionsDefaults.defaultInjectInto;
+  defaultInjectInto: {
+    enum: {
+      [INJECT_AUTO]: '',
+      [INJECT_PAGE]: '',
+      [INJECT_CONTENT]: '',
     },
   },
-  {
-    name: 'filtersPopup.sort',
-    normalize: value => value === 'exec' && value || 'alpha',
+  showBadge: {
+    enum: {
+      '': i18n('labelBadgeNone'),
+      unique: i18n('labelBadgeUnique'),
+      total: i18n('labelBadgeTotal'),
+    },
   },
-  ...['badgeColor', 'badgeColorBlocked'].map(name => ({
-    name,
-    normalize: value => (/^#[0-9a-f]{6}$/i.test(value) ? value : optionsDefaults[name]),
-  })),
-];
-const settings = {};
-items.forEach(({ name }) => {
-  settings[name] = null;
+  'filtersPopup.hideDisabled': {
+    enum: {
+      '': i18n('optionPopupShowDisabled'),
+      hide: i18n('optionPopupHideDisabled'),
+      group: i18n('optionPopupGroupDisabled'),
+    },
+  },
+  'filtersPopup.sort': {
+    enum: {
+      exec: i18n('filterExecutionOrder'),
+      alpha: i18n('filterAlphabeticalOrder'),
+    },
+  },
+};
+const normalizeEnum = (value, name) => (
+  items[name].enum::hasOwnProperty(value)
+    ? value
+    : Object.keys(items[name].enum)[0]
+);
+const getItemUpdater = (name, normalize) => (
+  debounce((value, oldValue) => {
+    value = normalize(value, name);
+    oldValue = normalize(oldValue, name);
+    if (value !== oldValue) options.set(name, value);
+  }, 300)
+);
+const settings = items::mapEntry(() => null);
+badgeColorNames.forEach(name => {
+  items[name] = badgeColorItem;
 });
 
 export default {
@@ -187,9 +203,8 @@ export default {
     return {
       showAdvanced: false,
       expose: null,
+      items,
       settings,
-      badgeColors,
-      injectIntoOptions,
     };
   },
   computed: {
@@ -197,29 +212,21 @@ export default {
       return global.chrome.windows?.onBoundsChanged ? null : this.i18n('optionEditorWindowHint');
     },
     isCustomBadgeColor() {
-      return Object.keys(badgeColors).some(name => settings[name] !== optionsDefaults[name]);
+      return badgeColorNames.some(name => settings[name] !== optionsDefaults[name]);
     },
   },
   methods: {
-    getUpdater({ name, normalize }) {
-      return (value, oldValue) => {
-        value = normalize(value);
-        oldValue = normalize(oldValue);
-        if (value !== oldValue) options.set(name, value);
-      };
-    },
     onResetBadgeColors() {
-      badgeColors::forEachKey(name => {
+      badgeColorNames.forEach(name => {
         settings[name] = optionsDefaults[name];
       });
     },
   },
   created() {
     this.revokers = [];
-    items.forEach((item) => {
-      const { name, normalize } = item;
-      this.revokers.push(hookSetting(name, val => { settings[name] = normalize(val); }));
-      this.$watch(() => settings[name], debounce(this.getUpdater(item), 300));
+    items::forEachEntry(([name, { normalize = normalizeEnum }]) => {
+      this.revokers.push(hookSetting(name, val => { settings[name] = normalize(val, name); }));
+      this.$watch(() => settings[name], getItemUpdater(name, normalize));
     });
     this.expose = Object.keys(options.get('expose')).map(k => [k, decodeURIComponent(k)]);
     // Preload zip.js when user visits settings tab

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -29,7 +29,8 @@
                     :value="value" v-text="title" />
           </select>
         </label>
-        <setting-check name="filtersPopup.enabledFirst" :label="i18n('optionPopupEnabledFirst')" />
+        <setting-check name="filtersPopup.enabledFirst" :label="i18n('optionPopupEnabledFirst')"
+                       :disabled="!!settings['filtersPopup.hideDisabled']" />
       </div>
       <div class="mr-2c">
         <label>

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -19,12 +19,15 @@ $topIconSize: 20px;
 $findIconSize: 16px;
 $findIconML: calc($leftPaneWidth - $findIconSize - $iconMR);
 
+$menuTitleBorderBottom: 1px dashed var(--fill-3);
+
 body {
   width: 320px;
   max-width: 100%;
   /* Latest Chrome renders an extra blank for a nonexistent scrollbar */
   overflow: hidden;
   background: var(--fill-0-5);
+  font-weight: normal;
   @media (min-width: 360px) {
     width: 100%;
   }
@@ -116,6 +119,9 @@ footer {
 .menu {
   background: var(--bg);
   border-top: 1px solid var(--fill-4);
+  &:not(.expand) + footer {
+    border-top: $menuTitleBorderBottom;
+  }
   &-item {
     position: relative;
     display: flex;
@@ -130,6 +136,11 @@ footer {
     }
     .icon {
       flex: 0 0 $iconSize;
+      &.icon-collapse {
+        flex: 0 0 $findIconSize;
+        width: $findIconSize;
+        height: $findIconSize;
+      }
     }
     > .icon:first-child {
       margin-right: $iconMR;
@@ -163,15 +174,16 @@ footer {
     }
   }
   &-group {
-    padding-left: $leftPaneWidth;
+    padding-left: $findIconML;
     & [data-totals]::after {
       content: ": " attr(data-totals);
     }
   }
   &.expand {
-    background: var(--fill-0-5);
+    background: var(--fill-1);
     > .submenu {
       display: block;
+      border-color: var(--fill-4);
     }
     .icon-collapse {
       transform: rotateZ(90deg);
@@ -185,7 +197,7 @@ footer {
   max-height: 30rem;
   overflow-y: auto;
   background: var(--bg);
-  border-top: 1px dashed var(--fill-2);
+  border-top: $menuTitleBorderBottom;
   > * {
     position: relative;
     .menu-item {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1310400/130688942-17b98a24-496c-4587-8500-bdd10c352d17.png)

![image](https://user-images.githubusercontent.com/1310400/130689003-17f4a049-ec14-43ef-9bcb-b3bfd8ce9f61.png)

* The iframe scripts aren't affected, they're still listed in one combined menu.
* The `>` icon is moved to the left since all persistent icons are shown there
* The background color of the active menu is one notch stronger
* The last menu has a dashed border in collapsed state to separate it from the footer