### PR TITLE
feat: customizable @noframes in editor settings

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -379,6 +379,9 @@ labelMatch:
 labelName:
   description: Label of script name.
   message: 'Name:'
+labelNoFrames:
+  description: Label of script @noframes properties in custom meta data.
+  message: "Run in frames: "
 labelNoName:
   description: Text as the name of a script when no @name is assigned.
   message: No Name

--- a/src/background/utils/db.js
+++ b/src/background/utils/db.js
@@ -266,7 +266,7 @@ export async function getScriptsByURL(url, isTop) {
     ? []
     : store.scripts.filter(script => (
       !script.config.removed
-      && (isTop || !script.meta.noframes)
+      && (isTop || !(script.custom.noframes ?? script.meta.noframes))
       && testScript(url, script)
     ));
   const reqKeys = [];
@@ -624,6 +624,7 @@ export async function vacuum() {
  * @property {string} lastInstallURL
  * @property {string} updateURL
  * @property {'auto' | 'page' | 'content'} injectInto
+ * @property {null | 1 | 0} noframes - null or absence == default (script's value)
  * @property {string[]} exclude
  * @property {string[]} excludeMatch
  * @property {string[]} include

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -218,6 +218,7 @@ export default {
       this.code = code;
     }
     const { custom, config } = this.script;
+    const { noframes } = custom;
     this.settings = {
       config: {
         notifyUpdates: `${config.notifyUpdates ?? ''}`,
@@ -230,6 +231,7 @@ export default {
         ...objectPick(custom, Object.keys(CUSTOM_PROPS)),
         ...objectPick(custom, CUSTOM_LISTS, fromList),
         runAt: custom.runAt || '',
+        noframes: noframes == null ? '' : +noframes, // it was boolean in old VM
       },
     };
     savedSettings = deepCopy(this.settings);
@@ -267,6 +269,7 @@ export default {
       const { settings } = this;
       const { config, custom } = settings;
       const { notifyUpdates } = config;
+      const { noframes } = custom;
       try {
         const codeComponent = this.$refs.code;
         const id = this.script?.props?.id;
@@ -280,6 +283,7 @@ export default {
           custom: {
             ...objectPick(custom, Object.keys(CUSTOM_PROPS)),
             ...objectPick(custom, CUSTOM_LISTS, toList),
+            noframes: noframes ? +noframes : null,
           },
           // User created scripts MUST be marked `isNew` so that
           // the backend is able to check namespace conflicts,

--- a/src/options/views/edit/settings.vue
+++ b/src/options/views/edit/settings.vue
@@ -16,24 +16,30 @@
       </label>
     </div>
     <h4 v-text="i18n('editLabelMeta')"></h4>
-    <div class="form-group">
-      <label v-text="i18n('labelRunAt')"></label>
-      <tooltip content="@run-at" placement="right">
-        <select v-model="custom.runAt">
-          <option value="" v-text="i18n('labelRunAtDefault')"></option>
-          <option value="document-start">document-start</option>
-          <option value="document-body">document-body</option>
-          <option value="document-end">document-end</option>
-          <option value="document-idle">document-idle</option>
-        </select>
-      </tooltip>
-    </div>
-    <div class="form-group" v-for="([ name, label ]) in textInputs" :key="name">
-      <label v-text="label"/>
-      <tooltip :content="`@${name}`" placement="right" class="mr-tooltip">
+    <tooltip content="@run-at" placement="right" class="form-group fit-width">
+      <label v-text="i18n('labelRunAt')"/>
+      <select v-model="custom.runAt">
+        <option value="" v-text="i18n('labelRunAtDefault')"></option>
+        <option value="document-start">document-start</option>
+        <option value="document-body">document-body</option>
+        <option value="document-end">document-end</option>
+        <option value="document-idle">document-idle</option>
+      </select>
+    </tooltip>
+    <tooltip content="@noframes" placement="right" class="form-group fit-width">
+      <label v-text="i18n('labelNoFrames')"/>
+      <select v-model="custom.noframes">
+        <option value="" v-text="i18n('labelRunAtDefault')"/>
+        <option value="0" v-text="i18n('genericOn')"/>
+        <option value="1" v-text="i18n('genericOff')"/>
+      </select>
+    </tooltip>
+    <tooltip v-for="([ name, label ]) in textInputs" :key="name"
+             :content="`@${name}`" placement="right"
+             class="form-group mr-tooltip">
+        <label v-text="label"/>
         <input type="text" v-model="custom[name]" :placeholder="placeholders[name]">
-      </tooltip>
-    </div>
+    </tooltip>
     <div class="form-group" v-for="([ name, orig, label ]) in textAreas" :key="name">
       <div>
         <span v-text="label"/>
@@ -103,6 +109,7 @@ export default {
 </script>
 
 <style>
+$leftColWidth: 11em;
 .edit-settings {
   &.edit-body { // using 2 classes to ensure we override .edit-body in index.vue
     column-width: 50em;
@@ -129,11 +136,19 @@ export default {
     &:not(.condensed) {
       > :nth-child(1) {
         display: flex;
-        flex: 0 0 11em;
+        flex: 0 0 $leftColWidth;
         flex-direction: column;
       }
-      > :nth-child(2) {
+      > :nth-child(2):not(select) {
         flex-grow: 1;
+      }
+    }
+    &.fit-width {
+      display: block;
+      width: fit-content;
+      > :nth-child(1) {
+        display: inline-block;
+        width: $leftColWidth;
       }
     }
   }
@@ -141,9 +156,7 @@ export default {
     text-decoration: underline;
   }
 }
-@media (min-width: 768px) {
-  .mr-tooltip {
-    margin-right: 10em;
-  }
+.mr-tooltip {
+  margin-right: 6em;
 }
 </style>

--- a/src/options/views/tab-settings/vm-import.vue
+++ b/src/options/views/tab-settings/vm-import.vue
@@ -156,8 +156,7 @@ async function importBackup(file) {
       },
       custom: {
         downloadURL: typeof meta.file_url === 'string' ? meta.file_url : undefined,
-        // customizing of @noframes isn't implemented yet
-        noframes: !!ovr.noframes || (ovr.noframes == null ? undefined : false),
+        noframes: ovr.noframes == null ? undefined : +!!ovr.noframes,
         runAt: /^document-(start|body|end|idle)$/.test(opts.run_at) ? opts.run_at : undefined,
         exclude: toStringArray(ovr.use_excludes),
         include: toStringArray(ovr.use_includes),


### PR DESCRIPTION
The label is `Run in frames` which is the opposite of `noframes` because it seems easier to understand than Tampermonkey's "Run only in top frame". People normally say "frame" to refer to an `<iframe>` or `<frame>` element, we don't normally call the main page "top frame", it's an internal term from the extension API or from other low-level internals/specifications.

![image](https://user-images.githubusercontent.com/1310400/130706349-ac5bd48e-ff4a-4879-9110-d5cbc4f78b60.png)