### PR TITLE
ui: combine import/export in "Backup" section

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -271,6 +271,9 @@ labelAutoReloadCurrentTabDisabled:
 labelAutoUpdate:
   description: Option to allow automatically checking scripts for updates
   message: 'Check for script updates every $1 day(s), use 0 to disable'
+labelBackup:
+  description: Label of the import/export section in settings.
+  message: Backup
 labelBadge:
   description: Label for option to show number on badge.
   message: 'Display on badge: '

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -67,8 +67,11 @@
                        class="ml-2" />
       </div>
     </section>
-    <vm-import></vm-import>
-    <vm-export></vm-export>
+    <section class="mb-2c">
+      <h3 v-text="i18n('labelBackup')" />
+      <vm-import></vm-import>
+      <vm-export></vm-export>
+    </section>
     <vm-sync></vm-sync>
     <div class="show-advanced">
       <button @click="showAdvanced = !showAdvanced">

--- a/src/options/views/tab-settings/vm-export.vue
+++ b/src/options/views/tab-settings/vm-export.vue
@@ -1,6 +1,5 @@
 <template>
-  <section>
-    <h3 v-text="i18n('labelDataExport')"></h3>
+  <div>
     <button v-text="i18n('buttonExportData')" @click="handleExport" :disabled="exporting"></button>
     <div class="mt-1">
       <setting-check name="exportValues" :label="i18n('labelExportScriptData')" />
@@ -17,7 +16,7 @@
         </a>
       </div>
     </modal>
-  </section>
+  </div>
 </template>
 
 <script>

--- a/src/options/views/tab-settings/vm-import.vue
+++ b/src/options/views/tab-settings/vm-import.vue
@@ -1,14 +1,10 @@
 <template>
-  <section>
-    <h3 v-text="i18n('labelDataImport')" />
+  <div>
     <button v-text="i18n('buttonImportData')" @click="pickBackup" ref="buttonImport"/>
-    <button
-      :title="i18n('hintVacuum')"
-      @click="vacuum"
-      :disabled="vacuuming"
-      v-text="labelVacuum"
-    />
-    <div class="mt-1 ml-2c">
+    <tooltip :content="i18n('hintVacuum')">
+      <button @click="vacuum" :disabled="vacuuming" v-text="labelVacuum" />
+    </tooltip>
+    <div class="mt-1 flex flex-col">
       <setting-check name="importScriptData" :label="i18n('labelImportScriptData')" />
       <setting-check name="importSettings" :label="i18n('labelImportSettings')" />
     </div>
@@ -18,10 +14,11 @@
         <td v-text="text" :colspan="name ? null : 2"/>
       </tr>
     </table>
-  </section>
+  </div>
 </template>
 
 <script>
+import Tooltip from 'vueleton/lib/tooltip/bundle';
 import { ensureArray, i18n, sendCmd } from '#/common';
 import options from '#/common/options';
 import SettingCheck from '#/common/ui/setting-check';
@@ -33,6 +30,7 @@ const reports = [];
 export default {
   components: {
     SettingCheck,
+    Tooltip,
   },
   data() {
     return {


### PR DESCRIPTION
I think this is an improvement because it removes the repetition of `import` and `export` words in the title/buttons and combines the closely related activities in one section.

![image](https://user-images.githubusercontent.com/1310400/131327262-308cb729-d963-4232-9b3f-945056fa367a.png)
