### PR TITLE
ui: show "Not configured yet" instead of sync error

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -653,6 +653,9 @@ msgSyncInit:
 msgSyncInitError:
   description: Message shown when sync fails in initialization.
   message: Initializing error!
+msgSyncNotConfigured:
+  description: Message shown when the selected sync provider hasn't been configured yet.
+  message: Not configured yet.
 msgSyncReady:
   description: Message shown when sync will start soon.
   message: Sync will start soon...

--- a/src/background/sync/base.js
+++ b/src/background/sync/base.js
@@ -210,6 +210,7 @@ export const BaseService = serviceFactory({
     this.config = serviceConfig(this.name);
     this.authState = serviceState([
       'idle',
+      'not-configured',
       'initializing',
       'authorizing', // in case some services require asynchronous requests to get access_tokens
       'authorized',
@@ -269,13 +270,13 @@ export const BaseService = serviceFactory({
   prepare() {
     this.authState.set('initializing');
     return (this.initToken() ? Promise.resolve(this.user()) : Promise.reject({
-      type: 'unauthorized',
+      type: 'not-configured',
     }))
     .then(() => {
       this.authState.set('authorized');
     }, (err) => {
-      if (err && err.type === 'unauthorized') {
-        this.authState.set('unauthorized');
+      if (['not-configured', 'unauthorized'].includes(err?.type)) {
+        this.authState.set(err.type);
       } else {
         console.error(err);
         this.authState.set('error');


### PR DESCRIPTION
* show "Not configured yet" instead of sync error
* show the status in the same row to make it more noticeable

   ![image](https://user-images.githubusercontent.com/1310400/131860142-bc165991-5be7-4b09-b545-149caa4e8b7f.png)

* hide "[x] Sync script status" when `None` is selected 

   ![image](https://user-images.githubusercontent.com/1310400/131860229-485e9d13-ffdb-41a8-b1e4-4485f17019ef.png)
