### PR TITLE
feat: update isRemote

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -252,8 +252,19 @@ const FORCED_ACCEPT = {
   'greasyfork.org': 'application/javascript, text/plain, text/css',
 };
 
-export const isRemote = url => url
-  && !(/^(file:|data:|https?:\/\/(localhost|127\.0\.0\.1[:/]))/.test(url));
+export const isRemote = url => {
+  try {
+    const { protocol, hostname } = new URL(url);
+    return !['file:', 'data:'].includes(protocol)
+      && !['localhost', '127.0.0.1', '[::1]', ''].includes(hostname)
+      && !hostname.startsWith('192.168.') && !hostname.startsWith('172.16.') && !hostname.startsWith('10.0.')
+      && !hostname.startsWith('[fe80::') && !hostname.startsWith('[fc00::')
+      && !hostname.endsWith('.test') && !hostname.endsWith('.example')
+      && !hostname.endsWith('.invalid') && !hostname.endsWith('.localhost');
+  } catch (_) {
+    return false;
+  }
+};
 
 /** @typedef {{
   url: string,

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -252,19 +252,8 @@ const FORCED_ACCEPT = {
   'greasyfork.org': 'application/javascript, text/plain, text/css',
 };
 
-export const isRemote = url => {
-  try {
-    const { protocol, hostname } = new URL(url);
-    return !['file:', 'data:'].includes(protocol)
-      && !['localhost', '127.0.0.1', '[::1]', ''].includes(hostname)
-      && !hostname.startsWith('192.168.') && !hostname.startsWith('172.16.') && !hostname.startsWith('10.0.')
-      && !hostname.startsWith('[fe80::') && !hostname.startsWith('[fc00::')
-      && !hostname.endsWith('.test') && !hostname.endsWith('.example')
-      && !hostname.endsWith('.invalid') && !hostname.endsWith('.localhost');
-  } catch (_) {
-    return false;
-  }
-};
+export const isRemote = url => url
+  && !(/^(file:\/\/|data:|https?:\/\/(localhost|127\.0\.0\.1|(192\.168|172\.16|10\.0)\.[0-9]+\.[0-9]+|\[(::1|(fe80|fc00)::[.:0-9a-f]+)\]|.+\.(test|example|invalid|localhost))(:[0-9]+|\/|$))/i.test(url));
 
 /** @typedef {{
   url: string,

--- a/test/common/index.test.js
+++ b/test/common/index.test.js
@@ -13,6 +13,17 @@ test('isRemote', (t) => {
   t.notOk(isRemote('http://localhost/a.user.js'));
   t.notOk(isRemote('https://localhost/a.user.js'));
   t.notOk(isRemote('http://127.0.0.1/a.user.js'));
+  t.notOk(isRemote('http://127.0.0.1:5555/a.user.js'));
+  t.notOk(isRemote('http://192.168.1.32/a.user.js'));
+  t.notOk(isRemote('http://172.16.0.1/a.user.js'));
+  t.notOk(isRemote('http://10.0.0.1/a.user.js'));
+  t.notOk(isRemote('http://[::1]/a.user.js'));
+  t.notOk(isRemote('http://[fe80::6996:2ba9:37e6:8762]/a.user.js'));
+  t.notOk(isRemote('http://[fc00::90:90]/a.user.js'));
+  t.notOk(isRemote('http://example.test/a.user.js'));
+  t.notOk(isRemote('https://example.example/a.user.js'));
+  t.notOk(isRemote('http://example.invalid/a.user.js'));
+  t.notOk(isRemote('https://example.localhost/a.user.js'));
   t.end();
 });
 


### PR DESCRIPTION
Add a simple test for private address ([RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918), [RFC 4193](https://datatracker.ietf.org/doc/html/rfc4193)) and reserved domains ([RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606)).