### PR TITLE
feat: faster wrapper prop resolution

### DIFF
--- a/src/background/utils/preinject.js
+++ b/src/background/utils/preinject.js
@@ -38,10 +38,12 @@ const KEY_XHR_INJECT = 'xhrInject';
 const BAD_URL_CHAR = IS_FIREFOX
   ? /[#&',/:;?=+]/g // FF shows `@` fine as ASCII but mangles it as full-width
   : /[#&',/:;?=+@]/g;
+const BIGINT = 'BigInt';
 /** Userscript globals that are likely to be used hundreds of times per second */
 const INLINED_GLOBALS = [
-  'Date',
+  BIGINT in global && BIGINT,
   'Boolean',
+  'Date',
   'Math',
   'Node',
   'Number',
@@ -49,7 +51,7 @@ const INLINED_GLOBALS = [
   'parseFloat',
   'parseInt',
   'performance',
-].join(',');
+]::trueJoin(',');
 const expose = {};
 let isApplied;
 let injectInto;

--- a/src/background/utils/preinject.js
+++ b/src/background/utils/preinject.js
@@ -286,7 +286,8 @@ function prepareScript(script) {
   const hasReqs = reqsSlices.length;
   const wrap = !meta.unwrap;
   const { grant } = meta;
-  const grantNone = grant.length === 1 && grant[0] === 'none';
+  const numGrants = grant.length;
+  const grantNone = !numGrants || numGrants === 1 && grant[0] === 'none';
   const injectedCode = [
     wrap && `window.${dataKey}=function(${
       // using a shadowed name to avoid scope pollution

--- a/src/background/utils/preinject.js
+++ b/src/background/utils/preinject.js
@@ -40,22 +40,15 @@ const BAD_URL_CHAR = IS_FIREFOX
   : /[#&',/:;?=+@]/g;
 /** Userscript globals that are likely to be used hundreds of times per second */
 const INLINED_GLOBALS = [
-  'Array',
   'Date',
   'Boolean',
   'Math',
   'Node',
   'Number',
   'Object',
-  'Promise',
-  'clearTimeout',
-  'document',
   'parseFloat',
   'parseInt',
   'performance',
-  'queueMicrotask',
-  'requestAnimationFrame',
-  'setTimeout',
 ].join(',');
 const expose = {};
 let isApplied;

--- a/src/injected/web/gm-api-wrapper.js
+++ b/src/injected/web/gm-api-wrapper.js
@@ -27,7 +27,7 @@ let componentUtils;
 export function makeGmApiWrapper(script) {
   // Add GM functions
   // Reference: http://wiki.greasespot.net/Greasemonkey_Manual:API
-  const { dataKey, meta } = script;
+  const { meta } = script;
   const grant = meta.grant;
   let wrapper;
   let numGrants = grant.length;
@@ -42,7 +42,7 @@ export function makeGmApiWrapper(script) {
     id,
     script,
     resources,
-    dataKey,
+    dataKey: script.dataKey,
     resCache: createNullObj(),
   };
   const gmInfo = makeGmInfo(script, resources);
@@ -79,7 +79,9 @@ export function makeGmApiWrapper(script) {
   });
   if (numGrants) {
     wrapper = makeGlobalWrapper(gm);
-    gm[dataKey] = gm;
+    /* Exposing the fast cache of resolved properties,
+     * using a name that'll never be added to the web platform */
+    gm.c = gm;
   }
   return { gm, wrapper };
 }

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -118,7 +118,7 @@ async function onCodeSet(item, fn) {
   const run = () => {
     bridge.post('Run', item.props.id, item);
     const { gm, wrapper } = makeGmApiWrapper(item);
-    (wrapper || global)::fn(wrapper || gm, logging.error);
+    (wrapper || global)::fn(gm, logging.error);
   };
   const el = document::getCurrentScript();
   const wait = waiters?.[stage];

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -117,9 +117,8 @@ async function onCodeSet(item, fn) {
   }
   const run = () => {
     bridge.post('Run', item.props.id, item);
-    const wrapper = makeGmApiWrapper(item);
-    const thisArg = item.meta.grant.length ? wrapper : global;
-    thisArg::fn(wrapper, logging.error);
+    const { gm, wrapper } = makeGmApiWrapper(item);
+    (wrapper || global)::fn(wrapper || gm, logging.error);
   };
   const el = document::getCurrentScript();
   const wait = waiters?.[stage];


### PR DESCRIPTION
Fixes #1531.

* Uses a second `with` to let JS engine resolve the globals we already resolved instead of calling our Proxy's `get` trap that replicated the same behavior but much slower.
* ~Uses local variables for 16 frequently used globals like `Array` or `Math`. The only possible problem is that a userscript cannot alter the value of these globals via the standard approach like `window.Math = polyfill` as this will not change the variable.~
* Removes `with` from grant-none scripts to avoid the drop in performance