### PR TITLE
fix: set define to undefined even when grant is not none

### DIFF
--- a/src/background/utils/preinject.js
+++ b/src/background/utils/preinject.js
@@ -291,7 +291,7 @@ function prepareScript(script) {
       IS_FIREFOX ? `,${dataKey}){try{` : '){'}${
       grantNone ? '' : 'with(this)with(c)delete c,'
     // hiding module interface from @require'd scripts so they don't mistakenly use it
-    }((${grantNone ? 'define,module,exports' : ''})=>{`,
+    }((define,module,exports)=>{`,
     ...reqsSlices,
     // adding a nested IIFE to support 'use strict' in the code when there are @requires
     hasReqs && wrap && '(()=>{',


### PR DESCRIPTION
Fix a regression introduced by #1532 : UMD requirements are broken in pages using RequireJS when `@grant` is not none.

## Reproduction

- Page: <https://www.skype.com/en/get-skype/>
- Script:

```js
// ==UserScript==
// @name        Test UMD require
// @namespace   Violentmonkey Scripts
// @match       https://www.skype.com/en/get-skype/
// @grant       GM_addStyle
// @version     1.0
// @require     https://cdn.jsdelivr.net/combine/npm/@violentmonkey/dom@^2,npm/@violentmonkey/ui@^0.7
// @author      -
// @description 8/9/2022, 6:17:32 PM
// ==/UserScript==

console.log('ok');
```