### PR TITLE
refactor: declare own VM types via jsconfig

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -5,5 +5,8 @@
       "@/*": ["./src/*"]
     }
   },
+  "typeAcquisition": {
+    "include": ["./types.d.ts"]
+  },
   "exclude": ["node_modules", "dist"]
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@gera2ld/plaid-webpack": "~1.5.5",
     "@types/chrome": "^0.0.191",
     "@types/firefox-webext-browser": "94.0.1",
+    "@violentmonkey/types": "0.1.4",
     "amo-upload": "^0.2.0",
     "babel-plugin-transform-modern-regexp": "^0.0.6",
     "cross-env": "^7.0.3",

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -27,7 +27,7 @@ hookOptions((changes) => {
 });
 
 Object.assign(commands, {
-  /** @return {Promise<{ scripts: VMScript[], cache: Object, sync: Object }>} */
+  /** @return {Promise<{ scripts: VM.Script[], cache: Object, sync: Object }>} */
   async GetData(ids) {
     const data = await getData(ids);
     data.sync = sync.getStates();

--- a/src/background/plugin/index.js
+++ b/src/background/plugin/index.js
@@ -10,7 +10,7 @@ export const script = {
   update: commands.ParseScript,
   /**
    * List all available scripts, without script code
-   * @return {Promise<VMScript[]>}
+   * @return {Promise<VM.Script[]>}
    */
   list: async () => getScripts(),
   /**

--- a/src/background/utils/icon.js
+++ b/src/background/utils/icon.js
@@ -49,17 +49,17 @@ const KEY_IS_APPLIED = 'isApplied';
 const KEY_SHOW_BADGE = 'showBadge';
 const KEY_BADGE_COLOR = 'badgeColor';
 const KEY_BADGE_COLOR_BLOCKED = 'badgeColorBlocked';
-/** @type boolean */
+/** @type {boolean} */
 let isApplied;
-/** @type VMBadgeMode */
+/** @type {VM.BadgeMode} */
 let showBadge;
-/** @type string */
+/** @type {string} */
 let badgeColor;
-/** @type string */
+/** @type {string} */
 let badgeColorBlocked;
-/** @type string */
+/** @type {string} */
 let titleBlacklisted;
-/** @type string */
+/** @type {string} */
 let titleNoninjectable;
 
 hookOptions((changes) => {

--- a/src/background/utils/preinject.js
+++ b/src/background/utils/preinject.js
@@ -52,7 +52,7 @@ let injectInto;
 let xhrInject;
 
 Object.assign(commands, {
-  /** @return {Promise<VMGetInjectedData>} */
+  /** @return {Promise<VM.Injection.Sent>} */
   async GetInjected({ url, forceContent }, src) {
     const { frameId, tab } = src;
     const tabId = tab.id;
@@ -60,9 +60,9 @@ Object.assign(commands, {
     clearFrameData(tabId, frameId);
     const key = getKey(url, !frameId);
     const cacheVal = cache.pop(key) || prepare(key, url, tabId, frameId, forceContent);
-    const data = cacheVal[INJECT] ? cacheVal : await cacheVal;
-    const inject = data[INJECT];
-    const feedback = data[FEEDBACK];
+    const bag = cacheVal[INJECT] ? cacheVal : await cacheVal;
+    const inject = bag[INJECT];
+    const feedback = bag[FEEDBACK];
     if (feedback?.length) {
       // Injecting known content scripts without waiting for InjectionFeedback message.
       // Running in a separate task because it may take a long time to serialize data.
@@ -126,13 +126,13 @@ onStorageChanged(async ({ keys: dbKeys }) => {
   const raw = cache.getValues();
   const resolved = !raw.some(val => val?.then);
   const cacheValues = resolved ? raw : await Promise.all(raw);
-  const dirty = cacheValues.some(data => data[INJECT]
+  const dirty = cacheValues.some(bag => bag[INJECT]
     && dbKeys.some((key) => {
       const prefix = key.slice(0, key.indexOf(':') + 1);
       const prop = propsToClear[prefix];
       key = key.slice(prefix.length);
       return prop === true
-        || data[prop]?.includes(prefix === storage.value.prefix ? +key : key);
+        || bag[prop]?.includes(prefix === storage.value.prefix ? +key : key);
     }));
   if (dirty) {
     cache.destroy();
@@ -171,8 +171,6 @@ function onOptionChanged(changes) {
     }
   });
 }
-
-/** @typedef {Promise<VMGetInjectedDataContainer>|VMGetInjectedDataContainer} VMGetInjected */
 
 function getKey(url, isTop) {
   return isTop ? url : `-${url}`;
@@ -223,35 +221,34 @@ function onSendHeaders({ url, tabId, frameId }) {
 /** @param {chrome.webRequest.WebResponseHeadersDetails} info */
 function onHeadersReceived(info) {
   const key = getKey(info.url, !info.frameId);
-  const data = xhrInject && cache.get(key);
+  const bag = xhrInject && cache.get(key);
   // Proceeding only if prepareScripts has replaced promise in cache with the actual data
-  return data?.[INJECT] && prepareXhrBlob(info, data);
+  return bag?.[INJECT] && prepareXhrBlob(info, bag);
 }
 
 /**
  * @param {chrome.webRequest.WebResponseHeadersDetails} info
- * @param {VMGetInjectedDataContainer} data
+ * @param {VM.Injection.Bag} bag
  */
-function prepareXhrBlob({ url, responseHeaders }, data) {
+function prepareXhrBlob({ url, responseHeaders }, bag) {
   if (url.startsWith('https:') && detectStrictCsp(responseHeaders)) {
-    forceContentInjection(data);
+    forceContentInjection(bag);
   }
   const blobUrl = URL.createObjectURL(new Blob([
-    JSON.stringify(data[INJECT]),
+    JSON.stringify(bag[INJECT]),
   ]));
   responseHeaders.push({
     name: 'Set-Cookie',
     value: `"${process.env.INIT_FUNC_NAME}"=${blobUrl.split('/').pop()}; SameSite=Lax`,
   });
   setTimeout(URL.revokeObjectURL, TIME_KEEP_DATA, blobUrl);
-  data[HEADERS] = true;
+  bag[HEADERS] = true;
   return { responseHeaders };
 }
 
 function prepare(key, url, tabId, frameId, forceContent) {
-  /** @namespace VMGetInjectedDataContainer */
+  /** @type {VM.Injection.Bag} */
   const res = {
-    /** @namespace VMGetInjectedData */
     [INJECT]: {
       expose: !frameId
         && url.startsWith('https://')
@@ -263,30 +260,39 @@ function prepare(key, url, tabId, frameId, forceContent) {
     : res;
 }
 
+/**
+ * @param {VM.Injection.Bag} res
+ * @param cacheKey
+ * @param url
+ * @param tabId
+ * @param frameId
+ * @param forceContent
+ * @return {Promise<any>}
+ */
 async function prepareScripts(res, cacheKey, url, tabId, frameId, forceContent) {
-  const data = getScriptsByURL(url, !frameId);
-  const { envDelayed, [ENV_SCRIPTS]: scripts } = Object.assign(data, await data.promise);
+  const bag = getScriptsByURL(url, !frameId);
+  const { envDelayed, [ENV_SCRIPTS]: scripts } = Object.assign(bag, await bag.promise);
   const isLate = forceContent != null;
-  data[FORCE_CONTENT] = forceContent; // used in prepareScript and isPageRealm
-  const feedback = scripts.map(prepareScript, data).filter(Boolean);
+  bag[FORCE_CONTENT] = forceContent; // used in prepareScript and isPageRealm
+  const feedback = scripts.map(prepareScript, bag).filter(Boolean);
   const more = envDelayed.promise;
   const envKey = getUniqId(`${tabId}:${frameId}:`);
+  /** @type {VM.Injection.Sent} */
   const inject = res[INJECT];
-  /** @namespace VMGetInjectedData */
   Object.assign(inject, {
     [ENV_SCRIPTS]: scripts,
     [INJECT_INTO]: injectInto,
     [INJECT_PAGE]: !forceContent && (
-      scripts.some(isPageRealm, data)
-      || envDelayed[ENV_SCRIPTS].some(isPageRealm, data)
+      scripts.some(isPageRealm, bag)
+      || envDelayed[ENV_SCRIPTS].some(isPageRealm, bag)
     ),
-    cache: data.cache,
+    cache: bag.cache,
     feedId: {
       cacheKey, // InjectionFeedback cache key for cleanup when getDataFF outruns GetInjected
       envKey, // InjectionFeedback cache key for envDelayed
     },
     hasMore: !!more, // tells content bridge to expect envDelayed
-    ids: data.disabledIds, // content bridge adds the actually running ids and sends via SetPopup
+    ids: bag.disabledIds, // content bridge adds the actually running ids and sends via SetPopup
     info: {
       ua,
     },
@@ -301,7 +307,7 @@ async function prepareScripts(res, cacheKey, url, tabId, frameId, forceContent) 
   return res;
 }
 
-/** @this {VMScriptByUrlData} */
+/** @this {VM.Injection.Env} */
 function prepareScript(script) {
   const { custom, meta, props } = script;
   const { id } = props;
@@ -343,7 +349,7 @@ function prepareScript(script) {
     `\n//# sourceURL=${extensionRoot}${IS_FIREFOX ? '%20' : ''}${name}.user.js#${id}`,
   ]::trueJoin('');
   cache.put(dataKey, injectedCode, TIME_KEEP_DATA);
-  /** @namespace VMInjectedScript */
+  /** @type {VM.Injection.Script} */
   Object.assign(script, {
     dataKey,
     displayName,
@@ -401,15 +407,14 @@ function detectStrictCsp(responseHeaders) {
   ));
 }
 
-/** @param {VMGetInjectedDataContainer} data */
-function forceContentInjection(data) {
-  /** @type VMGetInjectedData */
-  const inject = data[INJECT];
+/** @param {VM.Injection.Bag} bag */
+function forceContentInjection(bag) {
+  const inject = bag[INJECT];
   inject[FORCE_CONTENT] = true;
   inject[ENV_SCRIPTS].forEach(scr => {
     // When script wants `page`, the result below will be `true` so the script goes into `failedIds`
     scr.code = !isContentRealm(scr, true) || '';
-    data[FEEDBACK].push([scr.dataKey, true]);
+    bag[FEEDBACK].push([scr.dataKey, true]);
   });
 }
 
@@ -420,7 +425,7 @@ function isContentRealm(scr, forceContent) {
   return realm === INJECT_CONTENT || forceContent && realm === INJECT_AUTO;
 }
 
-/** @this {VMScriptByUrlData} */
+/** @this {VM.Injection.Env} */
 function isPageRealm(scr) {
   return !isContentRealm(scr, this[FORCE_CONTENT]);
 }

--- a/src/background/utils/requests-core.js
+++ b/src/background/utils/requests-core.js
@@ -6,22 +6,7 @@ import { extensionOrigin } from './init';
 let encoder;
 
 export const VM_VERIFY = getUniqId('VM-Verify');
-/** @typedef {{
-  anonymous: boolean,
-  blobbed: boolean,
-  cb: function(Object),
-  chunked: boolean,
-  coreId: number,
-  eventsToNotify: string[],
-  id: number,
-  noNativeCookie: boolean,
-  responseHeaders: string,
-  storeId: string,
-  tabId: number,
-  url: string,
-  xhr: XMLHttpRequest,
-}} VMHttpRequest */
-/** @type {Object<string,VMHttpRequest>} */
+/** @type {Object<string,VM.Xhr.BG>} */
 export const requests = { __proto__: null };
 export const verify = { __proto__: null };
 export const FORBIDDEN_HEADER_RE = re`/
@@ -52,7 +37,7 @@ export const FORBIDDEN_HEADER_RE = re`/
   upgrade|
   via
 )$/ix`;
-/** @type chrome.webRequest.RequestFilter */
+/** @type {chrome.webRequest.RequestFilter} */
 const API_FILTER = {
   urls: ['<all_urls>'],
   types: ['xmlhttprequest'],
@@ -120,7 +105,7 @@ function onBeforeSendHeaders({ requestHeaders: headers, requestId, url }) {
 
 /**
  * @param {string} headerValue
- * @param {VMHttpRequest} req
+ * @param {VM.Xhr.BG} req
  * @param {string} url
  */
 function setCookieInStore(headerValue, req, url) {

--- a/src/background/utils/requests.js
+++ b/src/background/utils/requests.js
@@ -8,10 +8,15 @@ import {
 } from './requests-core';
 
 Object.assign(commands, {
-  /** @return {void} */
+  /**
+   * @param {VM.Xhr.Message.Web} opts
+   * @param {MessageSender} src
+   * @return {Promise<void>}
+   */
   HttpRequest(opts, src) {
     const { tab: { id: tabId }, frameId } = src;
     const { id, eventsToNotify } = opts;
+    /** @type {VM.Xhr.BG} */
     requests[id] = {
       id,
       tabId,
@@ -55,7 +60,7 @@ function blob2objectUrl(response) {
   return url;
 }
 
-/** @param {VMHttpRequest} req */
+/** @param {VM.Xhr.BG} req */
 function xhrCallbackWrapper(req) {
   let lastPromise = Promise.resolve();
   let contentType;
@@ -109,6 +114,7 @@ function xhrCallbackWrapper(req) {
         id,
         numChunks,
         type,
+        /** @type {VMScriptResponseObject} */
         data: shouldNotify && {
           finalUrl: req.url || xhr.responseURL,
           ...getResponseHeaders(),
@@ -142,8 +148,8 @@ function xhrCallbackWrapper(req) {
 }
 
 /**
- * @param {Object} opts
- * @param {chrome.runtime.MessageSender | browser.runtime.MessageSender} src
+ * @param {VM.Xhr.Message.Web} opts
+ * @param {MessageSender} src
  * @param {function} cb
  */
 async function httpRequest(opts, src, cb) {
@@ -215,7 +221,7 @@ async function httpRequest(opts, src, cb) {
   xhr.send(body);
 }
 
-/** @param {VMHttpRequest} req */
+/** @param {VM.Xhr.BG} req */
 function clearRequest({ id, coreId }) {
   delete verify[coreId];
   delete requests[id];

--- a/src/background/utils/script.js
+++ b/src/background/utils/script.js
@@ -12,7 +12,7 @@ Object.assign(commands, {
     cache.put(`new-${id}`, newScript(data));
     return id;
   },
-  /** @return {VMScript} */
+  /** @return {VM.Script} */
   NewScript(id) {
     return id && cache.get(`new-${id}`) || newScript();
   },

--- a/src/background/utils/tab-redirector.js
+++ b/src/background/utils/tab-redirector.js
@@ -25,7 +25,7 @@ Object.assign(commands, {
       url === from
       || cache.has(`autoclose:${tabId}`)
       || /^(chrome:\/\/(newtab|startpage)\/|about:(home|newtab))$/.test(from));
-    /** @namespace VMConfirmCache */
+    /** @namespace VM.ConfirmCache */
     cache.put(`confirm-${confirmKey}`, { incognito, url, from, tabId, ff: ua.firefox });
     const confirmUrl = CONFIRM_URL_BASE + confirmKey;
     const { windowId } = canReplaceCurTab

--- a/src/background/utils/values.js
+++ b/src/background/utils/values.js
@@ -64,7 +64,7 @@ export function clearValueOpener(tabId, frameId) {
 /**
  * @param {number} tabId
  * @param {number} frameId
- * @param {VMInjectedScript[]} injectedScripts
+ * @param {VM.Injection.Script[]}
  */
 export function addValueOpener(tabId, frameId, injectedScripts) {
   injectedScripts.forEach(script => {

--- a/src/common/cache.js
+++ b/src/common/cache.js
@@ -15,7 +15,6 @@ export default function initCache({
   let batchStartTime;
   // eslint-disable-next-line no-return-assign
   const getNow = () => batchStarted && batchStartTime || (batchStartTime = performance.now());
-  /** @namespace VMCache */
   const exports = {
     batch, get, getValues, pop, put, del, has, hit, destroy,
   };

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -159,7 +159,7 @@ export function getScriptName(script) {
 }
 
 /**
- * @param {VMScript} script
+ * @param {VM.Script} script
  * @param {boolean} [all] - to return all two urls (1: check, 2: download)
  * @return {Array<string>|string|void}
  */
@@ -244,7 +244,7 @@ export function makeDataUri(raw, url) {
 }
 
 /**
- * @param {VMRequestResponse} response
+ * @param {VM.Req.Response} response
  * @param {boolean} [noJoin]
  * @returns {string|string[]}
  */

--- a/src/common/load-script-icon.js
+++ b/src/common/load-script-icon.js
@@ -6,7 +6,7 @@ const KEY = 'safeIcon';
 
 /**
  * Sets script's safeIcon property after the image is successfully loaded
- * @param {VMScript} script
+ * @param {VM.Script} script
  * @param {Object} [cache]
  * @param {number} [defSize] - show default icon of this size, -1 = auto, falsy = no
  */

--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -6,8 +6,7 @@ export default {
   // ignoreGrant: false,
   lastUpdate: 0,
   lastModified: 0,
-  /** @typedef {'unique' | 'total' | ''} VMBadgeMode */
-  /** @type VMBadgeMode */
+  /** @type {VM.BadgeMode} */
   showBadge: 'unique',
   badgeColor: '#880088',
   badgeColorBlocked: '#888888',
@@ -30,19 +29,19 @@ export default {
   notifyUpdates: false,
   notifyUpdatesGlobal: false, // `true` ignores script.config.notifyUpdates
   version: null,
-  /** @type {'auto' | 'page' | 'content'} */
+  /** @type {VMScriptInjectInto} */
   defaultInjectInto: INJECT_AUTO,
   xhrInject: false,
   filters: {
     /** @type {'name' | 'code' | 'all'} */
     searchScope: 'name',
-    /** @type boolean */
+    /** @type {boolean} */
     showOrder: false,
     /** @type {'exec' | 'alpha' | 'update'} */
     sort: 'exec',
-    /** @type boolean */
+    /** @type {boolean} */
     viewSingleColumn: false,
-    /** @type boolean */
+    /** @type {boolean} */
     viewTable: false,
   },
   filtersPopup: {
@@ -76,7 +75,6 @@ export default {
 // ==/UserScript==
 `,
   showAdvanced: true,
-  /** @typedef {'' | 'dark' | 'light'} VMUiTheme */
-  /** @type VMUiTheme */
+  /** @type {'' | 'dark' | 'light'} */
   uiTheme: '',
 };

--- a/src/common/ua.js
+++ b/src/common/ua.js
@@ -2,18 +2,7 @@
 // so we'll test for window.chrome.app which is only defined in Chrome
 // and for browser.runtime.getBrowserInfo in Firefox 51+
 
-/** @typedef UAExtras
- * @property {number|NaN} chrome - Chrome/ium version number
- * @property {number|NaN} firefox - derived from UA string initially, a real number when `ready`
- * @property {Promise<void>} ready - resolves when `browser` API returns real versions
- */
-/** @typedef UAInjected
- * @property {chrome.runtime.PlatformInfo.arch} arch
- * @property {chrome.runtime.PlatformInfo.os} os
- * @property {string} browserName
- * @property {string} browserVersion
- */
-/** @type {UAInjected & UAExtras} */
+/** @type {VM.UA} */
 const ua = {};
 export default ua;
 

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -354,20 +354,13 @@ export default {
         search.show = true;
       }
     },
-    /** @param {VMSearchOptions} opts */
+    /** @param {VM.SearchOptions} opts */
     doSearch(opts) {
       const { search } = this;
       search.hasResult = !search.query || !!this.doSearchInternal({ ...opts, wrapAround: true });
     },
     /**
-     * @typedef {Object} VMSearchOptions
-     * @property {boolean} [reversed]
-     * @property {boolean} [wrapAround]
-     * @property {boolean} [reuseCursor]
-     * @property {{line:number,ch:number}} [pos]
-     */
-    /**
-     * @param {VMSearchOptions} opts
+     * @param {VM.SearchOptions} opts
      * @returns {?true}
      */
     doSearchInternal({ reversed, wrapAround, pos, reuseCursor } = {}) {

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -221,12 +221,19 @@ const binaryTypes = [
   'blob',
   'arraybuffer',
 ];
+
+/**
+ * @param {string} url
+ * @param {VM.Req.Options} options
+ * @return {Promise<VM.Req.Response>}
+ */
 export async function requestLocalFile(url, options = {}) {
   // only GET method is allowed for local files
   // headers is meaningless
   return new Promise((resolve, reject) => {
-    const result = {};
     const xhr = new XMLHttpRequest();
+    /** @type {VM.Req.Response} */
+    const result = {};
     const { responseType } = options;
     xhr.open('GET', url, true);
     if (binaryTypes.includes(responseType)) xhr.responseType = responseType;
@@ -280,17 +287,11 @@ const isLocalUrlRe = re`/^(
 export const isDataUri = url => /^data:/i.test(url);
 export const isRemote = url => url && !isLocalUrlRe.test(decodeURI(url));
 
-/** @typedef {{
-  url: string,
-  status: number,
-  headers: Headers,
-  data: string|ArrayBuffer|Blob|Object
-}} VMRequestResponse */
 /**
  * Make a request.
  * @param {string} url
- * @param {RequestInit} options
- * @return Promise<VMRequestResponse>
+ * @param {VM.Req.Options} options
+ * @return {Promise<VM.Req.Response>}
  */
 export async function request(url, options = {}) {
   // fetch does not support local file

--- a/src/confirm/views/app.vue
+++ b/src/confirm/views/app.vue
@@ -136,7 +136,7 @@ export default {
         close: this.close,
       },
       confirmHotkey: CONFIRM_HOTKEY,
-      /** @type VMConfirmCache */
+      /** @type {VM.ConfirmCache} */
       info: {},
       deps: {}, // combines `this.require` and `this.resources` = all actually loaded deps
       descr: '',
@@ -238,7 +238,7 @@ export default {
       }
     },
     async parseMeta() {
-      /** @type {VMScriptMeta} */
+      /** @type {VM.Script.meta} */
       const meta = await sendCmdDirectly('ParseMeta', this.code);
       const name = getLocaleString(meta, 'name');
       document.title = `${name.slice(0, MAX_TITLE_NAME_LEN)}${name.length > MAX_TITLE_NAME_LEN ? '...' : ''} - ${

--- a/src/injected/content/bridge.js
+++ b/src/injected/content/bridge.js
@@ -50,7 +50,7 @@ const bridge = {
   ids: [], // all ids including the disabled ones for SetPopup
   runningIds: [],
   // userscripts running in the content script context are messaged via invokeGuest
-  /** @type Number[] */
+  /** @type {Number[]} */
   invokableIds: [],
   failedIds: [],
   cache: createNullObj(),
@@ -71,7 +71,7 @@ const bridge = {
     assignHandlers(bgHandlers, obj, force);
   },
   /**
-   * @param {VMInjectedScript | VMScript} script
+   * @param {VM.Injection.Script} script
    */
   allowScript({ dataKey, meta }) {
     allowCmd('Run', dataKey);

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -14,12 +14,12 @@ const VAULT_WRITER = `${IS_FIREFOX ? VM_UUID : INIT_FUNC_NAME}VW`;
 const VAULT_WRITER_ACK = `${VAULT_WRITER}+`;
 let contLists;
 let pgLists;
-/** @type {Object<string,VMInjectionRealm>} */
+/** @type {Object<string,VM.Injected.RealmData>} */
 let realms;
 /** @type {?boolean} */
 let pageInjectable;
 let frameEventWnd;
-/** @type ShadowRoot */
+/** @type {ShadowRoot} */
 let injectedRoot;
 
 // https://bugzil.la/1408996
@@ -121,16 +121,14 @@ export function injectPageSandbox(contentId, webId) {
 /**
  * @param {string} contentId
  * @param {string} webId
- * @param {VMGetInjectedData} data
+ * @param {VM.Injection.Sent} data
  * @param {boolean} isXml
  */
 export async function injectScripts(contentId, webId, data, isXml) {
   const { hasMore, info } = data;
   realms = {
     __proto__: null,
-    /** @namespace VMInjectionRealm */
     [INJECT_CONTENT]: {
-      /** @namespace VMRunAtLists */
       lists: contLists = { start: [], body: [], end: [], idle: [] },
       is: 0,
       info,

--- a/src/injected/web/bridge.js
+++ b/src/injected/web/bridge.js
@@ -1,7 +1,7 @@
 const handlers = createNullObj();
 const callbacks = createNullObj();
 /**
- * @property {UAInjected} ua
+ * @property {VMScriptGMInfoPlatform} ua
  */
 const bridge = {
   __proto__: null,

--- a/src/injected/web/gm-api-wrapper.js
+++ b/src/injected/web/gm-api-wrapper.js
@@ -21,7 +21,7 @@ let gmApi;
 let componentUtils;
 
 /**
- * @param {VMScript & VMInjectedScript} script
+ * @param {VM.Injection.Script} script
  * @returns {Object}
  */
 export function makeGmApiWrapper(script) {
@@ -37,7 +37,6 @@ export function makeGmApiWrapper(script) {
   }
   const { id } = script.props;
   const resources = createNullObj(meta.resources);
-  /** @namespace VMInjectedScript.Context */
   const context = {
     id,
     script,
@@ -148,9 +147,6 @@ function makeGmInfo(script, resources) {
 function makeGmMethodCaller(gmMethod, context, isAsync) {
   // keeping the native console.log intact
   if (gmMethod === gmApi.GM_log) return gmMethod;
-  if (isAsync) {
-    /** @namespace VMInjectedScript.Context */
-    context = assign({ __proto__: null, async: true }, context);
-  }
+  if (isAsync) context = assign({ __proto__: null, async: true }, context);
   return vmOwnFunc(gmMethod::bind(context));
 }

--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -99,6 +99,7 @@ export function makeGmApi() {
     },
     GM_download(arg1, name) {
       // not using ... as it calls Babel's polyfill that calls unsafe Object.xxx
+      /** @type {VMScriptGMDownloadOptions} */
       const opts = createNullObj();
       let onload;
       if (isString(arg1)) {
@@ -205,6 +206,12 @@ function webAddElement(parent, tag, attrs, context) {
   ));
 }
 
+/**
+ * @param {VM.Injected.Context} context
+ * @param name
+ * @param isBlob
+ * @param isBlobAuto
+ */
 function getResource(context, name, isBlob, isBlobAuto) {
   let res;
   const { id, resCache, resources } = context;

--- a/src/injected/web/gm-values.js
+++ b/src/injected/web/gm-values.js
@@ -35,7 +35,7 @@ export function loadValues(id) {
  * @param {?} val
  * @param {?string} raw
  * @param {?string} oldRaw
- * @param {VMInjectedScript.Context} context
+ * @param {VM.Injected.Context} context
  * @return {void|Promise<void>}
  */
 export function dumpValue(id, key, val, raw, oldRaw, context) {

--- a/src/injected/web/requests.js
+++ b/src/injected/web/requests.js
@@ -1,15 +1,22 @@
 import bridge from './bridge';
 
+/** @type {Object<string,VM.Xhr.Web>} */
 const idMap = createNullObj();
 
 bridge.addHandlers({
+  /** @param {VM.Xhr.Message.BG} msg */
   HttpRequested(msg) {
     const req = idMap[msg.id];
     if (req) callback(req, msg);
   },
 });
 
-/** `opts` must already have a null proto */
+/**
+ * @param {VM.Xhr.UserOpts} opts - must already have a null proto
+ * @param {VM.Injected.Context} context
+ * @param {string} fileName
+ * @return {VMScriptXHRControl}
+ */
 export function onRequestCreate(opts, context, fileName) {
   if (process.env.DEBUG) throwIfProtoPresent(opts);
   let { url } = opts;
@@ -29,6 +36,7 @@ export function onRequestCreate(opts, context, fileName) {
   }
   const scriptId = context.id;
   const id = safeGetUniqId('VMxhr');
+  /** @type {VM.Xhr.Web} */
   const req = {
     __proto__: null,
     id,
@@ -43,6 +51,11 @@ export function onRequestCreate(opts, context, fileName) {
   };
 }
 
+/**
+ * @param {VM.Xhr.Web} req
+ * @param {VM.Xhr.Message.BG} msg
+ * @returns {string|number|boolean|Array|Object|Document|Blob|ArrayBuffer}
+ */
 function parseData(req, msg) {
   let res = req.raw;
   switch (req.opts.responseType) {
@@ -64,6 +77,7 @@ function parseData(req, msg) {
 /**
  * Not using RegExp because it internally depends on proto stuff that can be easily broken,
  * and safe-guarding all of it is ridiculously disproportional.
+ * @param {VM.Xhr.Message.BG} msg
  */
 function getContentType(msg) {
   const type = msg.contentType || '';
@@ -77,7 +91,11 @@ function getContentType(msg) {
   return type::slice(0, i);
 }
 
-// request object functions
+/**
+ * @param {VM.Xhr.Web} req
+ * @param {VM.Xhr.Message.BG} msg
+ * @returns {*}
+ */
 function callback(req, msg) {
   const { opts } = req;
   const cb = opts[`on${msg.type}`];
@@ -109,12 +127,18 @@ function callback(req, msg) {
   if (msg.type === 'loadend') delete idMap[req.id];
 }
 
+/**
+ * @param {VM.Xhr.Web} req
+ * @param {VM.Injected.Context} context
+ * @param {string} fileName
+ */
 function start(req, context, fileName) {
   const { id, opts, scriptId } = req;
   // withCredentials is for GM4 compatibility and used only if `anonymous` is not set,
   // it's true by default per the standard/historical behavior of gmxhr
   const { data, withCredentials = true, anonymous = !withCredentials } = opts;
   idMap[id] = req;
+  /** @type {VM.Xhr.Message.Web} */
   bridge.post('HttpRequest', createNullObj({
     id,
     scriptId,

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -33,7 +33,7 @@ function initialize() {
 }
 
 /**
- * @param {VMScript} script
+ * @param {VM.Script} script
  */
 async function initScript(script) {
   const meta = script.meta || {};
@@ -54,7 +54,7 @@ async function initScript(script) {
 
 /**
  * @param {number[]} sz
- * @param {VMScript} script
+ * @param {VM.Script} script
  */
 function initSize(sz, { $cache }) {
   let total = 0;
@@ -70,7 +70,7 @@ function initSize(sz, { $cache }) {
 }
 
 /**
- * @param {VMScript} script
+ * @param {VM.Script} script
  */
 async function initScriptAndSize(script) {
   const res = initScript(script);

--- a/src/options/views/tab-settings/vm-editor.vue
+++ b/src/options/views/tab-settings/vm-editor.vue
@@ -105,7 +105,7 @@ export default {
       showMessage({ text: this.$refs.editor.error || this.i18n('msgSavedEditorOptions') });
     },
     toggleBoolean(event) {
-      const el = /** @type HTMLTextAreaElement */ event.target;
+      const el = /** @type {HTMLTextAreaElement} */ event.target;
       const { selectionStart: start, selectionEnd: end, value } = el;
       const toggled = { false: 'true', true: 'false' }[value.slice(start, end)];
       // FF can't run execCommand on textarea, https://bugzil.la/1220696#c24

--- a/src/options/views/tab-settings/vm-import.vue
+++ b/src/options/views/tab-settings/vm-import.vue
@@ -147,7 +147,7 @@ async function importBackup(file) {
     if (!meta || !opts) return;
     const ovr = opts.override || {};
     reports[0].text = 'Tampermonkey';
-    /** @type VMScript */
+    /** @type {VM.Script} */
     vm.scripts[name] = {
       config: {
         enabled: settings.enabled !== false ? 1 : 0,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,277 @@
+declare namespace VM {
+
+  declare type BadgeMode = 'unique' | 'total' | ''
+  declare type NumBool = 0 | 1
+  /** null means "default" or "inherit from global" */
+  declare type NumBoolNull = 0 | 1 | null
+  declare type StringMap = Object<string,string>
+
+  declare interface Script {
+    config: Script.Config
+    custom: Script.Custom
+    meta: Script.Meta
+    props: Script.Props
+  }
+
+  declare namespace Script {
+    declare type Config = {
+      enabled: NumBool
+      removed: NumBool
+      shouldUpdate: NumBool
+      notifyUpdates?: NumBoolNull
+    }
+    declare type Custom = {
+      name?: string
+      downloadURL:? string
+      homepageURL?: string
+      lastInstallURL?: string
+      updateURL?: string
+      injectInto?: VMScriptInjectInto
+      noframes?: NumBoolNull
+      exclude?: string[]
+      excludeMatch?: string[]
+      include?: string[]
+      match?: string[]
+      origExclude: boolean
+      origExcludeMatch: boolean
+      origInclude: boolean
+      origMatch: boolean
+      pathMap?: StringMap
+      runAt?: VMScriptRunAt
+    }
+    declare type Meta = {
+      description?: string
+      downloadURL?: string
+      exclude: string[]
+      excludeMatch: string[]
+      grant: string[]
+      homepageURL?: string
+      icon?: string
+      include: string[]
+      injectInto?: VMScriptInjectInto
+      match: string[]
+      namespace?: string
+      name: string
+      noframes?: boolean
+      require: string[]
+      resources: StringMap
+      runAt?: VMScriptRunAt
+      supportURL?: string
+      unwrap?: boolean
+      version?: string
+    }
+    declare type Props = {
+      id: number
+      lastModified: number
+      lastUpdated: number
+      position: number
+      uri: string
+      uuid: string
+    }
+  }
+
+  /**
+   * Related to injection itself in the background script
+   */
+  declare namespace Injection {
+    declare interface Env {
+      cache: StringMap
+      cacheKeys: string[]
+      code: StringMap
+      depsMap: Object<string,number[]>
+      /** Only present in envStart */
+      disabledIds?: number[]
+      /** Only present in envStart */
+      envDelayed?: Env
+      ids: number[]
+      promise: Promise<Env>
+      reqKeys: string[]
+      require: StringMap
+      scripts: VM.Script[]
+      sizing?: boolean
+      value: Object<string,StringMap>
+      valueIds: number[]
+    }
+    /**
+     * Contains the injected data and non-injected auxiliaries
+     */
+    declare interface Bag {
+      inject: Sent
+      feedback: (string|number)[] | false
+      csar: Promise<browser.contentScripts.RegisteredContentScript>
+    }
+    declare interface Info {
+      ua: VMScriptGMInfoPlatform
+    }
+    /**
+     * The injected data
+     */
+    declare interface Sent {
+      expose: string | false
+      scripts: Script[]
+      injectInto: VMScriptInjectInto
+      injectPage: boolean
+      cache: StringMap
+      feedId: {
+        /** InjectionFeedback cache key for cleanup when getDataFF outruns GetInjected */
+        cacheKey: string
+        /** InjectionFeedback cache key for envDelayed */
+        envKey: string
+      }
+      /** tells content bridge to expect envDelayed */
+      hasMore: boolean
+      /** content bridge adds the actually running ids and sends via SetPopup */
+      ids: number[]
+      info: Info
+      isPopupShown?: boolean
+    }
+    /**
+     * Script prepared for injection
+     */
+    declare interface Script extends VM.Script {
+      dataKey: string
+      displayName: string
+      code: string
+      metaStr: string
+      runAt?: 'start' | 'body' | 'end' | 'idle'
+      values?: StringMap
+    }
+  }
+
+  /**
+   * Injected::Content and Injected::Web
+   */
+  declare namespace Injected {
+    declare interface RealmData {
+      lists: {
+        start: Script[]
+        body: Script[]
+        end: Script[]
+        idle: Script[]
+      }
+      is: boolean
+      info: Sent
+    }
+    /**
+     * Script context object used by GM### API
+     */
+    declare interface Context {
+      async?: boolean
+      dataKey: string
+      id: number
+      resCache: StringMap
+      resources: StringMap
+      script: VM.Script
+    }
+  }
+
+  /**
+   * Own function request()
+   */
+  declare namespace Req {
+    interface Options extends RequestInit {
+      /** @implements XMLHttpRequestResponseType */
+      responseType: '' | 'arraybuffer' | 'blob' | 'json' | 'text'
+    }
+    declare interface Response {
+      url: string,
+      status: number,
+      headers: Headers,
+      data: string | ArrayBuffer | Blob | Object
+    }
+  }
+
+  /**
+   * GM_xmlhttpRequest paraphernalia
+   */
+  declare namespace Xhr {
+    type EventType = keyof XMLHttpRequestEventMap;
+    type UserOpts = VMScriptGMDownloadOptions | VMScriptGMXHRDetails;
+    declare interface BG {
+      anonymous: boolean
+      blobbed: boolean
+      cb: function(Object)
+      chunked: boolean
+      coreId: number
+      eventsToNotify: string[]
+      frameId: number
+      id: string
+      noNativeCookie: boolean
+      responseHeaders: string
+      storeId: string
+      tabId: number
+      url: string
+      xhr: XMLHttpRequest
+    }
+    declare interface Content {
+      realm: VMScriptInjectInto
+      wantsBlob: boolean
+      eventsToNotify: EventType[]
+      fileName: string
+      arr?: Uint8Array
+      resolve?: function
+      dataSize?: number
+      contentType?: string
+      gotChunks?: boolean
+    }
+    declare interface Web {
+      id: string
+      scriptId: number
+      opts: UserOpts
+      raw: string | Blob | ArrayBuffer
+      response: string | Blob | ArrayBuffer
+      headers: string
+      text?: string
+    }
+    declare namespace Message {
+      type Chunk = {
+        pos: number
+        data: string
+        last: boolean
+      }
+      declare interface BG {
+        blobbed: boolean
+        chunked: boolean
+        contentType: string
+        data: VMScriptResponseObject
+        dataSize: number
+        id: string
+        numChunks?: number
+        type: EventType
+        chunk?: Chunk
+      }
+      declare interface Web {
+        id: string
+        scriptId: number
+        anonymous: boolean
+        fileName: string
+        data: Array
+        eventsToNotify: EventType[]
+        headers?: StringMap
+        method?: string
+        overrideMimeType?: string
+        password?: string
+        timeout?: number
+        url: string
+        user?: string
+        xhrType: XMLHttpRequestResponseType
+      }
+    }
+  }
+
+  declare type SearchOptions = {
+    reversed?: boolean
+    wrapAround?: chrome.tabs.Tab
+    reuseCursor?: boolean
+    pos?: { line: number, ch: number }
+  }
+
+  declare interface UA extends VMScriptGMInfoPlatform {
+    /** Chrome/ium version number */
+    chrome: number | NaN
+    /** derived from UA string initially, a real number when `ready` */
+    firefox: number | NaN
+    /** resolves when `browser` API returns real versions */
+    ready: Promise<void>
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,6 +1588,11 @@
   dependencies:
     "@babel/runtime" "^7.16.7"
 
+"@violentmonkey/types@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@violentmonkey/types/-/types-0.1.4.tgz#90411ed402e5ed16ee76cd2cb47c884db59eb348"
+  integrity sha512-ckaN0UbxRYNyJH+UuyeRgTpkwAZWtR5g1VXnd8ufWtQQmJkrlOFPGazIp3F+CuJx/6VhLH4Nn+3GdjyE6WrsUA==
+
 "@vue/compiler-sfc@2.7.8":
   version "2.7.8"
   resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-2.7.8.tgz#731aadd6beafdb9c72fd8614ce189ac6cee87612"


### PR DESCRIPTION
It's actually working in VSCode, unlike the jsdoc `@namespace` comments. I don't know typescript though, so maybe everything is done wrong :-) PTAL!