### PR TITLE
fix: HttpRequest msg.data context

### DIFF
--- a/src/injected/content/requests.js
+++ b/src/injected/content/requests.js
@@ -2,7 +2,6 @@ import bridge from './bridge';
 import { getFullUrl, makeElem, sendCmd } from './util';
 
 const {
-  cloneInto,
   fetch: safeFetch,
   FileReader: SafeFileReader,
   FormData: SafeFormData,
@@ -34,9 +33,11 @@ bridge.addHandlers({
       'fileName',
     ]);
     msg.url = getFullUrl(msg.url);
-    if (msg.data[1]) {
+    let { data } = msg;
+    if (data[1]) {
       // TODO: support huge data by splitting it to multiple messages
-      msg.data = cloneInto(await encodeBody(msg.data[0], msg.data[1]), msg.data);
+      data = await encodeBody(data[0], data[1]);
+      msg.data = cloneInto ? cloneInto(data, msg) : data;
     }
     sendCmd('HttpRequest', msg);
   },

--- a/src/injected/content/requests.js
+++ b/src/injected/content/requests.js
@@ -2,6 +2,7 @@ import bridge from './bridge';
 import { getFullUrl, makeElem, sendCmd } from './util';
 
 const {
+  cloneInto,
   fetch: safeFetch,
   FileReader: SafeFileReader,
   FormData: SafeFormData,
@@ -35,7 +36,7 @@ bridge.addHandlers({
     msg.url = getFullUrl(msg.url);
     if (msg.data[1]) {
       // TODO: support huge data by splitting it to multiple messages
-      msg.data = await encodeBody(msg.data[0], msg.data[1]);
+      msg.data = cloneInto(await encodeBody(msg.data[0], msg.data[1]), msg.data);
     }
     sendCmd('HttpRequest', msg);
   },


### PR DESCRIPTION
_Disclaimer: I am not well versed in webexts, so I am not sure if this is the proper fix._

After update to `v2.13.1`, I noticed that some functionality with `GM_xmlhttpRequest` was broken.
(I did test latest master commit and latest beta release, both had the issue as well.)

In particular, this simplified excerpt stopped working:

```js
var url = "...";
var formData = new FormData();

formData.append("..", var1);
formData.append("..", var2);
formData.append("..", var3);
formData.append("..", var4);

GM_xmlhttpRequest({
    method: "POST",
    url: url,
    data: formData,
    onload: function(r) {
        ...
    }
});
```

leading to the following error in the browser console:

```
Error: Not allowed to define cross-origin object as property on [Object] or [Array] XrayWrapper
```
at the following line of code https://github.com/violentmonkey/violentmonkey/blob/7f2a6dff07c45fccc27bb4b0ad51f983781d0b80/src/injected/content/requests.js#L38

https://github.com/violentmonkey/violentmonkey/commit/86887363ae5cdc4e27769984d01640f556f2e6d1 is the first bad commit (in which the example stopped working), if we are to trust git bisect 

---

I am using Firefox 105.0.1 (64-bit), have not tested this under any other browser or version, but this change fixes my scripts. 

P.S I really like the newest version :)
