### PR TITLE
Separate "Update" into two strings + rename "buttonUpdate" to "buttonCheckForUpdates"

### DIFF
--- a/src/_locales/cs/messages.yml
+++ b/src/_locales/cs/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Cancel
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Zkontrolovat aktualizace
 buttonClose:
   description: Button to close window.
   message: Zavřít
@@ -90,8 +93,8 @@ buttonUndo:
   message: ''
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Zkontrolovat aktualizace
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Zkontrolovat aktualizace
@@ -723,6 +726,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: ''
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Update
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: ''
@@ -744,9 +752,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: ''
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Update
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: ''

--- a/src/_locales/de/messages.yml
+++ b/src/_locales/de/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Abbrechen
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Auf Aktualisierungen prüfen
 buttonClose:
   description: Button to close window.
   message: Schließen
@@ -90,8 +93,8 @@ buttonUndo:
   message: Rückgängig machen
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Auf Aktualisierungen prüfen
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Alle auf Aktualisierungen prüfen
@@ -772,6 +775,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: Hell
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Aktualisierung
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Groß- und Kleinschreibung beachtend
@@ -795,9 +803,6 @@ titleBadgeColorBlocked:
   message: >-
     Badge-Farbe, wenn die Seite uninjizierbar ist (geblacklistet oder nicht
     unterstützt)
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Aktualisierung
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/el/messages.yml
+++ b/src/_locales/el/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Ακύρωση
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Έλεγχος για αναβαθμίσεις
 buttonClose:
   description: Button to close window.
   message: Κλείσιμο
@@ -90,8 +93,8 @@ buttonUndo:
   message: Αναίρεση
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Έλεγχος για αναβαθμίσεις
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Έλεγχος όλων για αναβαθμίσεις
@@ -745,6 +748,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: ''
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Ενημέρωση
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Διάκριση πεζών-κεφαλαίων
@@ -766,9 +774,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: ''
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Ενημέρωση
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: ''

--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Cancel
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Check for updates
 buttonClose:
   description: Button to close window.
   message: Close
@@ -90,8 +93,8 @@ buttonUndo:
   message: Undo
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Check for updates
+  description: Button to update a script.
+  message: Update
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Check all for updates
@@ -753,6 +756,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: light
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Update
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Case sensitive
@@ -774,9 +782,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: Badge color when the site is non-injectable (blacklisted or unsupported)
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Update
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/es/messages.yml
+++ b/src/_locales/es/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: ''
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: ''
 buttonClose:
   description: Button to close window.
   message: ''
@@ -90,7 +93,7 @@ buttonUndo:
   message: ''
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
+  description: Button to update a script.
   message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
@@ -719,6 +722,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: ''
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: ''
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: ''
@@ -739,9 +747,6 @@ titleBadgeColor:
   message: ''
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
-  message: ''
-titleScriptUpdated:
-  description: Notification title for script updates.
   message: ''
 titleSearchHint:
   description: Hover title for search icon in dashboard.

--- a/src/_locales/es_419/messages.yml
+++ b/src/_locales/es_419/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Cancelar
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Buscar actualizaciones
 buttonClose:
   description: Button to close window.
   message: Cerrar
@@ -92,8 +95,8 @@ buttonUndo:
   message: Deshacer
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Buscar actualizaciones
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Buscar todas las actualizaciones
@@ -780,6 +783,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: claro
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Actualización
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Distinguir mayúsculas y minúsculas
@@ -803,9 +811,6 @@ titleBadgeColorBlocked:
   message: >-
     Color del icono cuando el sitio no es inyectable (en lista negra o sin
     soporte)
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Actualización
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/fi/messages.yml
+++ b/src/_locales/fi/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Peruuta
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Tarkista päivitykset
 buttonClose:
   description: Button to close window.
   message: Sulje
@@ -90,8 +93,8 @@ buttonUndo:
   message: Peruuta
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Tarkista päivitykset
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Tarkista kaikki päivitykset
@@ -725,6 +728,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: ''
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Päivitys
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Merkkikokoriippuvainen
@@ -746,9 +754,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: ''
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Päivitys
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: ''

--- a/src/_locales/fr/messages.yml
+++ b/src/_locales/fr/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Annuler
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Vérifier les mises à jour
 buttonClose:
   description: Button to close window.
   message: Fermer
@@ -92,8 +95,8 @@ buttonUndo:
   message: Annuler
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Vérifier les mises à jour
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Vérifier toutes les mises à jour
@@ -756,6 +759,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: ''
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Mise à jour
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Sensible à la casse
@@ -777,9 +785,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: ''
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Mise à jour
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: "* La touche <Enter> ajoute le texte à l'historique d'autocomplétion\n* La syntaxe pour les expressions régulières est supportée\_: /re/ et /re/flags"

--- a/src/_locales/hr/messages.yml
+++ b/src/_locales/hr/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Otkaži
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Provjeri za obnove
 buttonClose:
   description: Button to close window.
   message: Zatvori
@@ -90,8 +93,8 @@ buttonUndo:
   message: ''
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Provjeri za obnove
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Provjeri obnove za sve skripte
@@ -723,6 +726,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: ''
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Obnovi
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: ''
@@ -744,9 +752,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: ''
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Obnovi
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: ''

--- a/src/_locales/hu/messages.yml
+++ b/src/_locales/hu/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Mégse
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Frissítések keresése
 buttonClose:
   description: Button to close window.
   message: Bezár
@@ -92,8 +95,8 @@ buttonUndo:
   message: ''
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Frissítések keresése
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Frissítések keresése (mindenhez)
@@ -764,6 +767,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: light
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Update
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Case sensitive
@@ -785,9 +793,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: Badge color when the site is non-injectable (blacklisted or unsupported)
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Update
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/id/messages.yml
+++ b/src/_locales/id/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Batal
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Periksa pembaruan
 buttonClose:
   description: Button to close window.
   message: Tutup
@@ -90,8 +93,8 @@ buttonUndo:
   message: ''
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Periksa pembaruan
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Periksa semua pembaruan
@@ -754,6 +757,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: terang
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Perbarui
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Sesuai besar kecil huruf
@@ -775,9 +783,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: ''
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Perbarui
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/it/messages.yml
+++ b/src/_locales/it/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Annulla
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Controlla aggiornamenti
 buttonClose:
   description: Button to close window.
   message: Chiudi
@@ -92,8 +95,8 @@ buttonUndo:
   message: Annulla
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Controlla aggiornamenti
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Controlla tutti gli aggiornamenti
@@ -772,6 +775,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: chiaro
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Aggiornamento
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Maiuscole/minuscole
@@ -795,9 +803,6 @@ titleBadgeColorBlocked:
   message: >-
     Colore del badge quando il sito non è iniettabile (nella lista nera o non
     supportato)
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Aggiornamento
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/ja/messages.yml
+++ b/src/_locales/ja/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: キャンセル
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: 更新を確認
 buttonClose:
   description: Button to close window.
   message: 閉じる
@@ -90,8 +93,8 @@ buttonUndo:
   message: 元に戻す
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: 更新を確認
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: すべての更新を確認
@@ -734,6 +737,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: ''
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: 更新
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: 大文字と小文字を区別する
@@ -755,9 +763,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: ブラックリストに登録されている、サポートされていない等の理由でサイトにインジェクションできない場合のバッジの色
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: 更新
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/ko/messages.yml
+++ b/src/_locales/ko/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: 취소
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: 업데이트 확인
 buttonClose:
   description: Button to close window.
   message: 닫기
@@ -90,8 +93,8 @@ buttonUndo:
   message: 되돌리기
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: 업데이트 확인
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: 모두 업데이트 확인
@@ -739,6 +742,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: 라이트
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: 업데이트
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: 대소문자 확인하기
@@ -760,9 +768,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: 주입할 수 없는 사이트의 배지 색상(블랙리스트 또는 지원되지 않음)
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: 업데이트
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/nl/messages.yml
+++ b/src/_locales/nl/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Annuleren
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Controleren op updates
 buttonClose:
   description: Button to close window.
   message: Sluiten
@@ -90,8 +93,8 @@ buttonUndo:
   message: ''
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Controleren op updates
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Alle scripts controleren op updates
@@ -760,6 +763,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: Licht
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Bijwerken
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Hoofdlettergevoelig
@@ -783,9 +791,6 @@ titleBadgeColorBlocked:
   message: >-
     De kleur die wordt gebruikt als de code niet kan worden toegevoegd aan de
     site (zwarte lijst of niet-ondersteund)
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Bijwerken
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/pl/messages.yml
+++ b/src/_locales/pl/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Anuluj
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Sprawdź dostępność aktualizacji
 buttonClose:
   description: Button to close window.
   message: Zamknij
@@ -92,8 +95,8 @@ buttonUndo:
   message: Cofnij
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Sprawdź dostępność aktualizacji
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Sprawdź aktualizacje dla wszystkich skryptów
@@ -773,6 +776,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: jasny
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Aktualizacja
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Rozróżnianie wielkości liter
@@ -796,9 +804,6 @@ titleBadgeColorBlocked:
   message: >-
     Kolor plakietki, kiedy witryna nie nadaje się do wstrzykiwania (jest na
     czarnej liście lub nie jest obsługiwana)
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Aktualizacja
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/pt_BR/messages.yml
+++ b/src/_locales/pt_BR/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Cancelar
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Verificar se há atualizações
 buttonClose:
   description: Button to close window.
   message: Fechar
@@ -92,8 +95,8 @@ buttonUndo:
   message: Desfazer
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Verificar se há atualizações
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Verificar atualizações para todos
@@ -769,6 +772,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: Claro
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Atualização
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Respeitar maiúsculas/minúsculas
@@ -790,9 +798,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: Cor do emblema quando o site não é injetável (lista negra ou sem suporte)
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Atualização
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/pt_PT/messages.yml
+++ b/src/_locales/pt_PT/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Cancelar
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Procurar atualizações
 buttonClose:
   description: Button to close window.
   message: Fechar
@@ -90,8 +93,8 @@ buttonUndo:
   message: Anular
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Procurar atualizações
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Procurar atualizações para todos
@@ -735,6 +738,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: ''
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Atualização
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Respeitar maiúsculas/minúsculas
@@ -756,9 +764,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: ''
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Atualização
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: ''

--- a/src/_locales/ro/messages.yml
+++ b/src/_locales/ro/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Anulează
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Caută actualizări
 buttonClose:
   description: Button to close window.
   message: Închide
@@ -92,8 +95,8 @@ buttonUndo:
   message: Revocă
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Caută actualizări
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Caută actualizări pentru toate
@@ -774,6 +777,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: deschisă
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Actualizare
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Sensibil la scrierea cu litere mari și mici
@@ -797,9 +805,6 @@ titleBadgeColorBlocked:
   message: >-
     Culoarea insignei atunci când site-ul este neinjectabil (în lista neagră sau
     nesuportat)
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Actualizare
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/ru/messages.yml
+++ b/src/_locales/ru/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Отмена
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Проверить обновления
 buttonClose:
   description: Button to close window.
   message: Закрыть
@@ -90,8 +93,8 @@ buttonUndo:
   message: Отменить
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Проверить обновления
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Проверить обновления скриптов
@@ -754,6 +757,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: светлый
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Обновление
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: С учетом регистра
@@ -777,9 +785,6 @@ titleBadgeColorBlocked:
   message: |-
     Цвет значка, если скрипты не запустились
     (страница в черном списке или вообще не скриптуемая)
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Обновление
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/sk/messages.yml
+++ b/src/_locales/sk/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Zrušiť
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Skontrolovať aktualizácie
 buttonClose:
   description: Button to close window.
   message: Zavrieť
@@ -92,8 +95,8 @@ buttonUndo:
   message: Späť
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Skontrolovať aktualizácie
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Skontrolovať aktualizácie
@@ -763,6 +766,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: svetlý
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Aktualizácia
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Rozlišovať veľké a malé písmená
@@ -786,9 +794,6 @@ titleBadgeColorBlocked:
   message: >-
     Farba odznaku, keď je web neinjektovateľný (na čiernej listine alebo
     nepodporovaný)
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Aktualizácia
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/sr/messages.yml
+++ b/src/_locales/sr/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Откажи
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Провери ажурирања
 buttonClose:
   description: Button to close window.
   message: Затвори
@@ -90,8 +93,8 @@ buttonUndo:
   message: ''
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Провери ажурирања
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Провери ажурирања за све
@@ -725,6 +728,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: ''
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Ажурирај
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: ''
@@ -746,9 +754,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: ''
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Ажурирај
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: ''

--- a/src/_locales/tr/messages.yml
+++ b/src/_locales/tr/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: İptal
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Güncellemeleri denetle
 buttonClose:
   description: Button to close window.
   message: Kapat
@@ -92,8 +95,8 @@ buttonUndo:
   message: Geri Al
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Güncellemeleri denetle
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Yeni güncellemeleri kontrol et
@@ -764,6 +767,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: aydınlık
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Güncelleme
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Büyük/küçük harfe duyarlı
@@ -787,9 +795,6 @@ titleBadgeColorBlocked:
   message: >-
     Site enjekte etmeye kapalı iken rozet rengi (kara listede veya
     desteklenmiyor iken)
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Güncelleme
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/uk/messages.yml
+++ b/src/_locales/uk/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Скасувати
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Перевірити оновлення
 buttonClose:
   description: Button to close window.
   message: Закрити
@@ -90,8 +93,8 @@ buttonUndo:
   message: Скасувати
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Перевірити оновлення
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Перевірити оновлення скриптів
@@ -727,6 +730,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: ''
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Оновлення
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: ''
@@ -748,9 +756,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: ''
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Оновлення
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: ''

--- a/src/_locales/vi/messages.yml
+++ b/src/_locales/vi/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: Hủy
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: Kiểm tra cập nhật
 buttonClose:
   description: Button to close window.
   message: Đóng
@@ -90,8 +93,8 @@ buttonUndo:
   message: Hoàn tác
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: Kiểm tra cập nhật
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: Kiểm tra cập nhật tất cả
@@ -758,6 +761,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: Sáng
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: Cập nhật
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Phân biệt hoa thường
@@ -781,9 +789,6 @@ titleBadgeColorBlocked:
   message: >-
     Màu huy hiệu khi trang web không thể đưa vào (danh sách đen hoặc không được
     hỗ trợ)
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: Cập nhật
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: Nhập chính xác hoặc gần giống nội dung cần tìm

--- a/src/_locales/zh_CN/messages.yml
+++ b/src/_locales/zh_CN/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: 取消
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: 查找更新
 buttonClose:
   description: Button to close window.
   message: 关闭
@@ -90,8 +93,8 @@ buttonUndo:
   message: 撤销
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: 查找更新
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: 全部更新
@@ -736,6 +739,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: 浅色
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: 更新
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: 区分大小写
@@ -757,9 +765,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: 页面无法注入脚本（列入黑名单或不支持）时的徽标颜色
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: 更新
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/_locales/zh_TW/messages.yml
+++ b/src/_locales/zh_TW/messages.yml
@@ -1,6 +1,9 @@
 buttonCancel:
   description: Cancel button on dialog.
   message: 取消
+buttonCheckForUpdates:
+  description: Button to check a script for updates.
+  message: 檢查更新
 buttonClose:
   description: Button to close window.
   message: 關閉
@@ -90,8 +93,8 @@ buttonUndo:
   message: 復原
   touched: false
 buttonUpdate:
-  description: Check a script for updates.
-  message: 檢查更新
+  description: Button to update a script.
+  message: ''
 buttonUpdateAll:
   description: Check all scripts for updates.
   message: 全部檢查更新
@@ -726,6 +729,11 @@ optionUiThemeDark:
 optionUiThemeLight:
   description: Name of a theme selector value in settings.
   message: ''
+optionUpdate:
+  description: >-
+    Label of the update section in settings and notification title for script
+    updates.
+  message: 更新
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: 區分大小寫
@@ -747,9 +755,6 @@ titleBadgeColor:
 titleBadgeColorBlocked:
   description: Tooltip for option to set badge color of non-injectable tabs.
   message: ''
-titleScriptUpdated:
-  description: Notification title for script updates.
-  message: 更新
 titleSearchHint:
   description: Hover title for search icon in dashboard.
   message: |-

--- a/src/background/utils/update.js
+++ b/src/background/utils/update.js
@@ -137,7 +137,7 @@ function notify({
   commands.Notification({
     text,
     // FF doesn't show the name of the extension in the title of the notification
-    title: IS_FIREFOX ? i18n('titleScriptUpdated') : '',
+    title: IS_FIREFOX ? i18n('optionUpdate') : '',
   }, undefined, {
     onClick,
   });

--- a/src/options/views/script-item.vue
+++ b/src/options/views/script-item.vue
@@ -72,7 +72,7 @@
           </tooltip>
           <tooltip
             :disabled="!canUpdate || script.checking"
-            :content="i18n('buttonUpdate')"
+            :content="i18n('buttonCheckForUpdates')"
             align="start">
             <a
               class="btn-ghost"

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -56,7 +56,7 @@
       </div>
     </section>
     <section class="mb-1c">
-      <h3 v-text="i18n('titleScriptUpdated')"/>
+      <h3 v-text="i18n('optionUpdate')"/>
       <div>
         <label>
           <locale-group i18n-key="labelAutoUpdate">

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -180,7 +180,7 @@
            tabindex="0"
            @click="onRemoveScript"/>
       <div v-if="!activeExtras.data.config.removed && canUpdate(activeExtras.data)"
-           v-text="i18n('titleScriptUpdated')"
+           v-text="i18n('buttonUpdate')"
            tabindex="0"
            @click="onUpdateScript"/>
     </div>


### PR DESCRIPTION
`Update` is used in two cases:
- As label of the update section in settings
- As command in popup "..." menu for a script (first introduced in BETA v2.13.1.2)

In Romanian it would be as a noun and a verb, so we need two different translations.
And I'm pretty sure other languages might need this as well, for instance, French.

Hope everything's okay with this PR. 😊