### PR TITLE
fix: safe-guard window.vmXXX initializers + speedup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,9 +11,12 @@ const FILES_WEB = [`src/injected/web/**/*.js`];
 const FILES_SHARED = [
   'src/common/browser.js',
   'src/common/consts.js',
+  'src/common/safe-globals-shared.js',
 ];
 
+const GLOBALS_SHARED = getGlobals('*');
 const GLOBALS_COMMON = {
+  ...GLOBALS_SHARED,
   ...getGlobals('common'),
   re: false, // transform-modern-regexp with useRe option
 };
@@ -24,10 +27,12 @@ const GLOBALS_INJECTED = {
 };
 const GLOBALS_CONTENT = {
   INIT_FUNC_NAME: false,
+  ...GLOBALS_SHARED,
   ...getGlobals('injected/content'),
   ...GLOBALS_INJECTED,
 };
 const GLOBALS_WEB = {
+  ...GLOBALS_SHARED,
   ...getGlobals('injected/web'),
   ...GLOBALS_INJECTED,
   IS_FIREFOX: false, // passed as a parameter to VMInitInjection in webpack.conf.js

--- a/src/background/utils/script.js
+++ b/src/background/utils/script.js
@@ -69,7 +69,7 @@ const metaOptionalTypes = {
 export function parseMeta(code) {
   // initialize meta
   const meta = metaTypes::mapEntry(value => value.default());
-  const metaBody = code.match(METABLOCK_RE)[1] || '';
+  const metaBody = code.match(METABLOCK_RE)[2] || '';
   metaBody.replace(/(?:^|\n)\s*\/\/\x20(@\S+)(.*)/g, (_match, rawKey, rawValue) => {
     const [keyName, locale] = rawKey.slice(1).split(':');
     const camelKey = keyName.replace(/[-_](\w)/g, (m, g) => g.toUpperCase());

--- a/src/background/utils/values.js
+++ b/src/background/utils/values.js
@@ -76,7 +76,7 @@ export function clearValueOpener(tabId, frameId) {
  */
 export function addValueOpener(tabId, frameId, injectedScripts) {
   injectedScripts?.forEach(script => {
-    const { values, props: { id } } = script;
+    const { id, values } = script;
     if (values) objectSet(openers, [id, tabId, frameId], values);
     else delete openers[id];
   });

--- a/src/common/cache.js
+++ b/src/common/cache.js
@@ -17,7 +17,7 @@ export default function initCache({
   const getNow = () => batchStarted && batchStartTime || (batchStartTime = performance.now());
   const OVERRUN = 1000; // in ms, to reduce frequency of calling setTimeout
   const exports = {
-    batch, get, forEach, pop, put, del, has, hit, destroy,
+    batch, get, some, pop, put, del, has, hit, destroy,
   };
   if (process.env.DEV) Object.defineProperty(exports, 'data', { get: () => cache });
   return exports;
@@ -36,11 +36,13 @@ export default function initCache({
    * @param {(val:?, key:string) => void} fn
    * @param {Object} [thisObj]
    */
-  function forEach(fn, thisObj) {
+  function some(fn, thisObj) {
     for (const key in cache) {
       const item = cache[key];
-      if (item) fn.call(thisObj, item.value, key);
       // Might be already deleted by fn
+      if (item && fn.call(thisObj, item.value, key)) {
+        return true;
+      }
     }
   }
   function pop(key, def) {

--- a/src/common/consts.js
+++ b/src/common/consts.js
@@ -4,34 +4,16 @@ export const INFERRED = 'inferred';
 export const HOMEPAGE_URL = 'homepageURL';
 export const SUPPORT_URL = 'supportURL';
 
-export const INJECT_AUTO = 'auto';
-export const INJECT_PAGE = 'page';
-export const INJECT_CONTENT = 'content';
-export const INJECT_INTO = 'injectInto';
-export const INJECT_MAPPING = {
-  __proto__: null,
-  // `auto` tries to provide `window` from the real page as `unsafeWindow`
-  [INJECT_AUTO]: [INJECT_PAGE, INJECT_CONTENT],
-  // inject into page context
-  [INJECT_PAGE]: [INJECT_PAGE],
-  // inject into content context only
-  [INJECT_CONTENT]: [INJECT_CONTENT],
-};
-export const ID_BAD_REALM = -1;
-export const ID_INJECTING = 2;
-
 // Allow metadata lines to start with WHITESPACE? '//' SPACE
 // Allow anything to follow the predefined text of the metaStart/End
 // The SPACE must be on the same line and specifically \x20 as \s would also match \r\n\t
 // Note: when there's no valid metablock, an empty string is matched for convenience
 export const USERSCRIPT_META_INTRO = '// ==UserScript==';
-export const METABLOCK_RE = /(?:^|\n)\s*\/\/\x20==UserScript==([\s\S]*?\n)\s*\/\/\x20==\/UserScript==|$/;
+export const METABLOCK_RE = /((?:^|\n)\s*\/\/\x20==UserScript==)([\s\S]*?\n)\s*\/\/\x20==\/UserScript==|$/;
+export const META_STR = 'metaStr';
 export const NEWLINE_END_RE = /\n((?!\n)\s)*$/;
 export const INJECTABLE_TAB_URL_RE = /^(https?|file|ftps?):/;
 export const WATCH_STORAGE = 'watchStorage';
-export const FEEDBACK = 'feedback';
-export const FORCE_CONTENT = 'forceContent';
-export const MORE = 'more';
 // `browser` is a local variable since we remove the global `chrome` and `browser` in injected*
 // to prevent exposing them to userscripts with `@inject-into content`
 export const browser = process.env.IS_INJECTED !== 'injected-web' && global.browser;

--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -1,5 +1,3 @@
-import { INJECT_AUTO } from './consts';
-
 export default {
   isApplied: true,
   autoUpdate: 1, // days, 0 = disable

--- a/src/common/safe-globals-shared.js
+++ b/src/common/safe-globals-shared.js
@@ -1,0 +1,28 @@
+/* eslint-disable no-unused-vars */
+
+/**
+ * This file is used first by the entire `src` including `injected`.
+ * `global` is used instead of WebPack's polyfill which we disable in webpack.conf.js.
+ * Not exporting NodeJS built-in globals as this file is imported in the test scripts.
+ */
+
+const global = (function _() {
+  return this || globalThis; // eslint-disable-line no-undef
+}());
+/** These two are unforgeable so we extract them primarily to improve minification.
+ * The document's value can change only in about:blank but we don't inject there. */
+const { document, window } = global;
+export const VIOLENTMONKEY = 'Violentmonkey';
+export const INJECT_AUTO = 'auto';
+export const INJECT_PAGE = 'page';
+export const INJECT_CONTENT = 'content';
+export const INJECT_CONTENT_FORCE = 'forceContent';
+export const INJECT_INTO = 'injectInto';
+export const INJECT_MORE = 'more';
+export const ID_BAD_REALM = -1;
+export const ID_INJECTING = 2;
+export const kResponseHeaders = 'responseHeaders';
+export const kResponseText = 'responseText';
+export const kResponseType = 'responseType';
+export const isFunction = val => typeof val === 'function';
+export const isObject = val => val != null && typeof val === 'object';

--- a/src/common/safe-globals.js
+++ b/src/common/safe-globals.js
@@ -2,22 +2,16 @@
 
 /**
  * This file is used by entire `src` except `injected`.
- * `global` is used instead of WebPack's polyfill which we disable in webpack.conf.js.
  * `safeCall` is used by our modified babel-plugin-safe-bind.js.
  * Standard globals are extracted for better minification and marginally improved lookup speed.
  * Not exporting NodeJS built-in globals as this file is imported in the test scripts.
  */
 
-const global = (function _() {
-  return this || globalThis; // eslint-disable-line no-undef
-}());
 const {
   Boolean,
   Error,
   Object,
   Promise,
-  document,
-  window,
   performance,
 } = global;
 export const SafePromise = Promise; // alias used by browser.js
@@ -25,9 +19,3 @@ export const SafeError = Error; // alias used by browser.js
 export const { apply: safeApply, has: hasOwnProperty } = Reflect;
 export const safeCall = Object.call.bind(Object.call);
 export const IS_FIREFOX = !global.chrome.app;
-export const isFunction = val => typeof val === 'function';
-export const isObject = val => val != null && typeof val === 'object';
-export const VIOLENTMONKEY = 'Violentmonkey';
-export const kResponseHeaders = 'responseHeaders';
-export const kResponseText = 'responseText';
-export const kResponseType = 'responseType';

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -72,11 +72,9 @@ export function throttle(func, time) {
 export function noop() {}
 
 export function getUniqId(prefix = 'VM') {
-  const now = performance.now();
-  // `rnd + 1` to make sure the number is large enough and the string is long enough
-  return prefix
-    + Math.floor((now - Math.floor(now) + 1) * 1e12).toString(36)
-    + Math.floor((Math.random() + 1) * 1e12).toString(36);
+  for (let rnd = ''; (rnd += Math.random().toString(36).slice(2));) {
+    if (rnd.length > 9) return prefix + rnd;
+  }
 }
 
 /**

--- a/src/injected/content/bridge.js
+++ b/src/injected/content/bridge.js
@@ -1,4 +1,4 @@
-import { INJECT_PAGE, browser } from '../util';
+import { browser } from '../util';
 import { sendCmd } from './util';
 
 const handlers = createNullObj();

--- a/src/injected/content/cmd-run.js
+++ b/src/injected/content/cmd-run.js
@@ -1,6 +1,5 @@
 import bridge from './bridge';
 import { sendCmd } from './util';
-import { INJECT_PAGE } from '../util';
 
 const { ids } = bridge;
 const runningIds = [];

--- a/src/injected/content/gm-api-content.js
+++ b/src/injected/content/gm-api-content.js
@@ -1,6 +1,5 @@
 import bridge, { addBackgroundHandlers, addHandlers } from './bridge';
 import { decodeResource, elemByTag, makeElem, nextTask, sendCmd } from './util';
-import { INJECT_INTO } from '../util';
 
 const menus = createNullObj();
 let setPopupThrottle;

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -137,7 +137,7 @@ export async function injectScripts(data, isXml) {
     injectPageSandbox();
   }
   const toContent = data.scripts
-    .filter(scr => triageScript(scr, scr[INJECT_INTO]) === INJECT_CONTENT)
+    .filter(scr => triageScript(scr) === INJECT_CONTENT)
     .map(scr => [scr.id, scr.key.data]);
   const moreData = (more || toContent.length)
     && sendCmd('InjectionFeedback', {
@@ -177,7 +177,8 @@ export async function injectScripts(data, isXml) {
   bridgeInfo = contLists = pageLists = VMInitInjection = null;
 }
 
-function triageScript(script, realm) {
+function triageScript(script) {
+  let realm = script[INJECT_INTO];
   realm = (realm === INJECT_AUTO && !pageInjectable) || realm === INJECT_CONTENT
     ? INJECT_CONTENT
     : pageInjectable && INJECT_PAGE;

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -1,10 +1,6 @@
 import bridge, { addHandlers } from './bridge';
 import { elemByTag, makeElem, nextTask, onElement, sendCmd } from './util';
-import {
-  bindEvents, fireBridgeEvent,
-  ID_BAD_REALM, ID_INJECTING, INJECT_CONTENT, INJECT_INTO, INJECT_MAPPING, INJECT_PAGE,
-  MORE, FEEDBACK, FORCE_CONTENT,
-} from '../util';
+import { bindEvents, fireBridgeEvent, META_STR } from '../util';
 import { Run } from './cmd-run';
 
 /* In FF, content scripts running in a same-origin frame cannot directly call parent's functions
@@ -13,11 +9,11 @@ import { Run } from './cmd-run';
  * INIT_FUNC_NAME ids even though we change it now with each release. */
 const VAULT_WRITER = `${VM_UUID}${INIT_FUNC_NAME}VW`;
 const VAULT_WRITER_ACK = `${VAULT_WRITER}+`;
-const tardyQueue = [];
+const bridgeIds = bridge.ids;
+let tardyQueue;
+let bridgeInfo;
 let contLists;
-let pgLists;
-/** @type {Object<string,VMRealmData>} */
-let realms;
+let pageLists;
 /** @type {?boolean} */
 let pageInjectable;
 let frameEventWnd;
@@ -52,13 +48,15 @@ addHandlers({
   /**
    * FF bug workaround to enable processing of sourceURL in injected page scripts
    */
-  InjectList: IS_FIREFOX && injectList,
+  InjectList: IS_FIREFOX && injectPageList,
 });
 
-export function injectPageSandbox(contentId, webId) {
+export function injectPageSandbox() {
   pageInjectable = false;
   const vaultId = safeGetUniqId();
   const handshakeId = safeGetUniqId();
+  const contentId = safeGetUniqId();
+  const webId = safeGetUniqId();
   if (useOpener(opener) || useOpener(!IS_TOP && parent)) {
     startHandshake();
   } else {
@@ -117,121 +115,87 @@ export function injectPageSandbox(contentId, webId) {
 }
 
 /**
- * @param {string} contentId
- * @param {string} webId
  * @param {VMInjection} data
  * @param {boolean} isXml
  */
-export async function injectScripts(contentId, webId, data, isXml) {
-  const { errors, info, [MORE]: more } = data;
+export async function injectScripts(data, isXml) {
+  const { errors, info, [INJECT_MORE]: more } = data;
+  const CACHE = 'cache';
   if (errors) {
     logging.warn(errors);
   }
   if (IS_FIREFOX) {
     IS_FIREFOX = parseFloat(info.ua.browserVersion); // eslint-disable-line no-global-assign
   }
-  realms = {
-    __proto__: null,
-    [INJECT_CONTENT]: {
-      lists: contLists = { start: [], body: [], end: [], idle: [] },
-      is: 0,
-      info,
-    },
-    [INJECT_PAGE]: {
-      lists: pgLists = { start: [], body: [], end: [], idle: [] },
-      is: 0,
-      info,
-    },
-  };
-  assign(bridge.cache, data.cache);
-  if (isXml || data[FORCE_CONTENT]) {
+  bridgeInfo = createNullObj();
+  bridgeInfo[INJECT_PAGE] = info;
+  bridgeInfo[INJECT_CONTENT] = info;
+  assign(bridge[CACHE], data[CACHE]);
+  if (isXml || data[INJECT_CONTENT_FORCE]) {
     pageInjectable = false;
+  } else if (data[INJECT_PAGE] && pageInjectable == null) {
+    injectPageSandbox();
   }
-  if (data[INJECT_PAGE] && pageInjectable == null) {
-    injectPageSandbox(contentId, webId);
-  }
-  const feedback = data.scripts.map((script) => {
-    const { id } = script.props;
-    const realm = INJECT_MAPPING[script[INJECT_INTO]].find(key => (
-      key === INJECT_CONTENT || pageInjectable
-    ));
-    const { runAt } = script;
-    // If the script wants this specific realm, which is unavailable, we won't inject it at all
-    if (realm) {
-      const { pathMap } = script.custom;
-      const realmData = realms[realm];
-      realmData.lists[runAt].push(script); // 'start' or 'body' per getScriptsByURL()
-      realmData.is = true;
-      if (pathMap) bridge.pathMaps[id] = pathMap;
-    } else {
-      bridge.ids[id] = ID_BAD_REALM;
-    }
-    return [
-      script.dataKey,
-      realm === INJECT_CONTENT && runAt,
-      script.meta.unwrap && id,
-    ];
-  });
-  const moreData = sendCmd('InjectionFeedback', {
-    [FEEDBACK]: feedback,
-    [FORCE_CONTENT]: !pageInjectable,
-    [MORE]: more,
-  });
-  const hasInvoker = realms[INJECT_CONTENT].is;
+  const toContent = data.scripts
+    .filter(scr => triageScript(scr, scr[INJECT_INTO]) === INJECT_CONTENT)
+    .map(scr => [scr.id, scr.key.data]);
+  const moreData = (more || toContent.length)
+    && sendCmd('InjectionFeedback', {
+      [INJECT_CONTENT_FORCE]: !pageInjectable,
+      [INJECT_CONTENT]: toContent,
+      [INJECT_MORE]: more,
+    });
+  const hasInvoker = contLists;
   if (hasInvoker) {
-    setupContentInvoker(contentId, webId);
+    setupContentInvoker();
   }
   // Using a callback to avoid a microtask tick when the root element exists or appears.
-  await onElement('*', async () => {
-    injectAll('start');
-    const onBody = (pgLists.body.length || contLists.body.length)
-      && onElement('body', injectAll, 'body');
-    // document-end, -idle
-    if (more) {
-      data = await moreData;
-      if (data) await injectDelayedScripts(!hasInvoker && contentId, webId, data);
+  await onElement('*', injectAll, 'start');
+  if (pageLists?.body || contLists?.body) {
+    await onElement('body', injectAll, 'body');
+  }
+  if (more && (data = await moreData)) {
+    assign(bridge[CACHE], data[CACHE]);
+    if (document::getReadyState() === 'loading') {
+      await new SafePromise(resolve => {
+        /* Since most sites listen to DOMContentLoaded on `document`, we let them run first
+         * by listening on `window` which follows `document` when the event bubbles up. */
+        on('DOMContentLoaded', resolve, { once: true });
+      });
+      await 0; // let the site's listeners on `window` run first
     }
-    if (onBody) {
-      await onBody;
+    for (const scr of data.scripts) {
+      triageScript(scr);
     }
-    realms = null;
-    pgLists = null;
-    contLists = null;
-  });
-  VMInitInjection = null; // release for GC
+    if (contLists && !hasInvoker) {
+      setupContentInvoker();
+    }
+    await injectAll('end');
+    await injectAll('idle');
+  }
+  // release for GC
+  bridgeInfo = contLists = pageLists = VMInitInjection = null;
 }
 
-async function injectDelayedScripts(contentId, webId, { cache, scripts }) {
-  assign(bridge.cache, cache);
-  let needsInvoker;
-  scripts::forEach(script => {
-    const { code, runAt, custom: { pathMap } } = script;
-    const { id } = script.props;
-    if (pathMap) {
-      bridge.pathMaps[id] = pathMap;
-    }
-    if (!code) {
-      needsInvoker = true;
-      safePush(contLists[runAt], script);
-    } else if (pageInjectable) {
-      safePush(pgLists[runAt], script);
-    } else {
-      bridge.ids[id] = ID_BAD_REALM;
-    }
-  });
-  if (document::getReadyState() === 'loading') {
-    await new SafePromise(resolve => {
-      /* Since most sites listen to DOMContentLoaded on `document`, we let them run first
-       * by listening on `window` which follows `document` when the event bubbles up. */
-      window::on('DOMContentLoaded', resolve, { once: true });
-    });
-    await 0; // let the site's listeners on `window` run first
+function triageScript(script, realm) {
+  realm = (realm === INJECT_AUTO && !pageInjectable) || realm === INJECT_CONTENT
+    ? INJECT_CONTENT
+    : pageInjectable && INJECT_PAGE;
+  if (realm) {
+    const lists = realm === INJECT_CONTENT
+      ? contLists || (contLists = createNullObj())
+      : pageLists || (pageLists = createNullObj());
+    const { gmi, [META_STR]: metaStr, pathMap, runAt } = script;
+    const list = lists[runAt] || (lists[runAt] = []);
+    safePush(list, script);
+    setOwnProp(gmi, 'scriptMetaStr', metaStr[0]
+      || script.code[metaStr[1]]::slice(metaStr[2], metaStr[3]));
+    delete script[META_STR];
+    if (pathMap) bridge.pathMaps[script.id] = pathMap;
+  } else {
+    bridgeIds[script.id] = ID_BAD_REALM;
   }
-  if (needsInvoker && contentId) {
-    setupContentInvoker(contentId, webId);
-  }
-  injectAll('end');
-  injectAll('idle');
+  return realm;
 }
 
 function inject(item, iframeCb) {
@@ -297,43 +261,41 @@ function inject(item, iframeCb) {
 }
 
 function injectAll(runAt) {
-  if (process.env.DEBUG) throwIfProtoPresent(realms);
-  for (const realm in realms) { /* proto is null */// eslint-disable-line guard-for-in
-    const realmData = realms[realm];
-    const items = realmData.lists[runAt];
-    const { info } = realmData;
-    if (items.length) {
-      bridge.post('ScriptData', { info, items, runAt }, realm);
-      if (realm === INJECT_PAGE && !IS_FIREFOX) {
-        injectList(runAt);
-      }
-      safePush(tardyQueue, items);
-      nextTask()::then(tardyQueueCheck);
+  let res;
+  for (let inPage = 1; inPage >= 0; inPage--) {
+    const realm = inPage ? INJECT_PAGE : INJECT_CONTENT;
+    const lists = inPage ? pageLists : contLists;
+    const items = lists?.[runAt];
+    if (items) {
+      bridge.post('ScriptData', { items, info: bridgeInfo[realm] }, realm);
+      delete bridgeInfo[realm];
+      if (!tardyQueue) tardyQueue = createNullObj();
+      for (const { id } of items) tardyQueue[id] = 1;
+      if (!inPage) nextTask()::then(tardyQueueCheck);
+      else if (!IS_FIREFOX) res = injectPageList(runAt);
     }
   }
-  if (runAt !== 'start' && contLists[runAt].length) {
-    bridge.post('RunAt', runAt, INJECT_CONTENT);
-  }
+  return res;
 }
 
-async function injectList(runAt) {
-  const list = pgLists[runAt];
-  // Not using for-of because we don't know if @@iterator is safe.
-  for (let i = 0, item; (item = list[i]); i += 1) {
-    if (item.code) {
+async function injectPageList(runAt) {
+  const scripts = pageLists[runAt];
+  for (const scr of scripts) {
+    if (scr.code) {
       if (runAt === 'idle') await nextTask();
       if (runAt === 'end') await 0;
-      inject(item);
-      item.code = '';
-      if (item.meta?.unwrap) {
-        Run(item.props.id);
-      }
+      // Exposing window.vmXXX setter just before running the script to avoid interception
+      if (!scr.meta.unwrap) bridge.post('Plant', scr.key);
+      inject(scr);
+      scr.code = '';
+      if (scr.meta.unwrap) Run(scr.id);
     }
   }
+  tardyQueueCheck();
 }
 
-function setupContentInvoker(contentId, webId) {
-  const invokeContent = VMInitInjection(IS_FIREFOX)(webId, contentId, bridge.onHandle);
+function setupContentInvoker() {
+  const invokeContent = VMInitInjection(IS_FIREFOX)(bridge.onHandle);
   const postViaBridge = bridge.post;
   bridge.post = (cmd, params, realm, node) => {
     const fn = realm === INJECT_CONTENT
@@ -348,13 +310,10 @@ function setupContentInvoker(contentId, webId) {
  * as "still starting", so the popup can show them accordingly.
  */
 function tardyQueueCheck() {
-  for (const items of tardyQueue) {
-    for (const script of items) {
-      const id = script.props.id;
-      if (bridge.ids[id] === 1) bridge.ids[id] = ID_INJECTING;
-    }
+  for (const id in tardyQueue) {
+    if (bridgeIds[id] === 1) bridgeIds[id] = ID_INJECTING;
   }
-  tardyQueue.length = 0;
+  tardyQueue = null;
 }
 
 function tellBridgeToWriteVault(vaultId, wnd) {

--- a/src/injected/safe-globals.js
+++ b/src/injected/safe-globals.js
@@ -2,34 +2,21 @@
 
 /**
  * This file runs before safe-globals of `injected-content` and `injected-web` entries.
- * `global` is used instead of WebPack's polyfill which we disable in webpack.conf.js.
  * `export` is stripped in the final output and is only used for our NodeJS test scripts.
  * WARNING! Don't use exported functions from @/common anywhere in injected!
  */
 
-const global = (function _() {
-  return this || globalThis; // eslint-disable-line no-undef
-}());
-/** These two are unforgeable so we extract them primarily to improve minification.
- * The document's value can change only in about:blank but we don't inject there. */
-const { document, window } = global;
 export const { location } = global;
 export const PROTO = 'prototype';
 export const IS_TOP = top === window;
 export const CALLBACK_ID = '__CBID';
-export const VIOLENTMONKEY = 'Violentmonkey';
 export const kFileName = 'fileName';
-export const kResponseHeaders = 'responseHeaders';
-export const kResponseText = 'responseText';
-export const kResponseType = 'responseType';
 
 export const throwIfProtoPresent = process.env.DEBUG && (obj => {
   if (!obj || obj.__proto__) { // eslint-disable-line no-proto
     throw 'proto is not null';
   }
 });
-export const isFunction = val => typeof val === 'function';
-export const isObject = val => val != null && typeof val === 'object';
 export const isString = val => typeof val === 'string';
 
 export const getOwnProp = (obj, key, defVal) => {

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -5,60 +5,38 @@ import './gm-values';
 import './notifications';
 import './requests';
 import './tabs';
-import { bindEvents, INJECT_PAGE, INJECT_CONTENT } from '../util';
+import { bindEvents } from '../util';
 
 // Make sure to call safe::methods() in code that may run after userscripts
 
-/** document-body scripts in content mode are inserted via executeScript at document-start
- * in inert state, then wait for content bridge to call RunAt('body'). */
-let runAtBodyQueue;
+const toRun = createNullObj();
 
-export default function initialize(
-  webId,
-  contentId,
-  invokeHost,
-) {
-  let invokeGuest;
+export default function initialize(invokeHost) {
   if (PAGE_MODE_HANDSHAKE) {
     window::on(PAGE_MODE_HANDSHAKE + '*', e => {
       e = e::getDetail();
-      webId = e[0];
-      contentId = e[1];
+      bindEvents(e[0], e[1], bridge);
     }, { __proto__: null, once: true, capture: true });
     window::fire(new SafeCustomEvent(PAGE_MODE_HANDSHAKE));
-  }
-  if (invokeHost) {
-    bridge.mode = INJECT_CONTENT;
-    bridge.post = (cmd, data, realm, node) => {
-      invokeHost({ cmd, data, node }, INJECT_CONTENT);
-    };
-    invokeGuest = (cmd, data, realm, node) => {
-      if (process.env.DEBUG) console.info('[bridge.guest.content] received', { cmd, data, node });
-      bridge.onHandle({ cmd, data, node });
-    };
-    global.chrome = undefined;
-    global.browser = undefined;
-    addHandlers({
-      RunAt() {
-        // executeScript code may run after <body> appeared
-        if (runAtBodyQueue) {
-          for (const fn of runAtBodyQueue) fn();
-        }
-        // allowing the belated code to run immediately
-        runAtBodyQueue = false;
-      },
-    });
-  } else {
     bridge.mode = INJECT_PAGE;
-    bindEvents(webId, contentId, bridge);
     addHandlers({
       /** @this {Node} contentWindow */
       WriteVault(id) {
         this[id] = VAULT;
       },
     });
+  } else {
+    bridge.mode = INJECT_CONTENT;
+    bridge.post = (cmd, data, realm, node) => {
+      invokeHost({ cmd, data, node }, INJECT_CONTENT);
+    };
+    global.chrome = undefined;
+    global.browser = undefined;
+    return (cmd, data, realm, node) => {
+      if (process.env.DEBUG) console.info('[bridge.guest.content] received', { cmd, data, node });
+      bridge.onHandle({ cmd, data, node });
+    };
   }
-  return invokeGuest;
 }
 
 addHandlers({
@@ -73,17 +51,43 @@ addHandlers({
     delete bridge.callbacks[id];
     if (fn) this::fn(data);
   },
-  ScriptData({ info, items, runAt }) {
+  async Plant({ data: dataKey, win: winKey }) {
+    setOwnProp(window, winKey, onCodeSet, true, 'set');
+    /* Cleaning up for a script that didn't compile at all due to a syntax error.
+     * Note that winKey can be intercepted via MutationEvent in this case. */
+    await 0;
+    delete toRun[dataKey];
+    delete window[winKey];
+  },
+  /**
+   * @param {VMInjection.Info} info
+   * @param {VMInjection.Script[]} items
+   */
+  ScriptData({ info, items }) {
     if (info) {
       assign(bridge, info);
     }
-    if (items) {
-      items::forEach(createScriptData);
-      // FF bug workaround to enable processing of sourceURL in injected page scripts
-      if (IS_FIREFOX && PAGE_MODE_HANDSHAKE) {
-        bridge.post('InjectList', runAt);
+    const toRunNow = [];
+    for (const script of items) {
+      const { key } = script;
+      toRun[key.data] = script;
+      store.values[script.id] = nullObjFrom(script.val);
+      if (!PAGE_MODE_HANDSHAKE) {
+        const winKey = key.win;
+        const data = window[winKey];
+        if (data) { // executeScript ran before GetInjected response
+          safePush(toRunNow, data);
+          delete window[winKey];
+        } else {
+          safeDefineProperty(window, winKey, {
+            configurable: true,
+            set: onCodeSet,
+          });
+        }
       }
     }
+    if (!PAGE_MODE_HANDSHAKE) toRunNow::forEach(onCodeSet);
+    else if (IS_FIREFOX) bridge.post('InjectList', items[0].runAt);
   },
   Expose() {
     external[VIOLENTMONKEY] = {
@@ -95,38 +99,18 @@ addHandlers({
   },
 });
 
-function createScriptData(item) {
-  const { dataKey } = item;
-  store.values[item.props.id] = nullObjFrom(item.values);
-  if (window[dataKey]) { // executeScript ran before GetInjected response
-    onCodeSet(item, window[dataKey]);
-  } else if (!item.meta.unwrap) {
-    safeDefineProperty(window, dataKey, {
-      configurable: true,
-      set: fn => onCodeSet(item, fn),
-    });
-  }
-}
-
-async function onCodeSet(item, fn) {
-  const { dataKey } = item;
-  // deleting now to prevent interception via DOMNodeRemoved on el::remove()
-  delete window[dataKey];
+function onCodeSet(fn) {
+  const item = toRun[fn.name];
+  const el = document::getCurrentScript();
+  const { gm, wrapper = global } = makeGmApiWrapper(item);
+  // Deleting now to prevent interception via DOMNodeRemoved on el::remove()
+  delete window[item.key.win];
   if (process.env.DEBUG) {
     log('info', [bridge.mode], item.displayName);
   }
-  const run = () => {
-    bridge.post('Run', item.props.id);
-    const { gm, wrapper } = makeGmApiWrapper(item);
-    (wrapper || global)::fn(gm, logging.error);
-  };
-  const el = document::getCurrentScript();
   if (el) {
     el::remove();
   }
-  if (!PAGE_MODE_HANDSHAKE && runAtBodyQueue !== false && item.runAt === 'body') {
-    safePush(runAtBodyQueue || (runAtBodyQueue = []), run);
-  } else {
-    run();
-  }
+  bridge.post('Run', item.id);
+  wrapper::fn(gm, logging.error);
 }

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -134,7 +134,6 @@
 import { reactive } from 'vue';
 import Tooltip from 'vueleton/lib/tooltip';
 import { debounce, i18n } from '@/common';
-import { INJECT_AUTO, INJECT_PAGE, INJECT_CONTENT } from '@/common/consts';
 import SettingCheck from '@/common/ui/setting-check';
 import { forEachEntry, mapEntry } from '@/common/object';
 import options from '@/common/options';

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -1,8 +1,5 @@
 import '@/common/browser';
 import { sendCmdDirectly } from '@/common';
-import {
-  ID_BAD_REALM, ID_INJECTING, INJECT_CONTENT, INJECT_INTO, INJECT_PAGE,
-} from '@/common/consts';
 import handlers from '@/common/handlers';
 import { loadScriptIcon } from '@/common/load-script-icon';
 import { forEachValue, mapEntry } from '@/common/object';

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -192,7 +192,6 @@
 <script>
 import { reactive } from 'vue';
 import Tooltip from 'vueleton/lib/tooltip';
-import { INJECT_AUTO } from '@/common/consts';
 import options from '@/common/options';
 import {
   getScriptHome, getScriptName, getScriptSupportUrl, getScriptUpdateUrl,

--- a/test/mock/polyfill.js
+++ b/test/mock/polyfill.js
@@ -34,6 +34,7 @@ Object.defineProperties(global, domProps);
 delete MessagePort.prototype.onmessage; // to avoid hanging
 global.PAGE_MODE_HANDSHAKE = 123;
 global.VAULT_ID = false;
+Object.assign(global, require('@/common/safe-globals-shared'));
 Object.assign(global, require('@/common/safe-globals'));
 Object.assign(global, require('@/injected/safe-globals'));
 Object.assign(global, require('@/injected/content/safe-globals'));


### PR DESCRIPTION
While fixing the bug described in the title I did a few more fixes/speedups and while doing that I refactored injection-related code considerably for which I'd like at least a cursory review from you, @gera2ld.

* preinject.js now reuses results of each individual `preparedScript` if it's still cached
* all injection-related consts are extracted to safe-globals-shared.js because importing a lot of these consts in like every file has been an increasing PITA for a while.