### PR TITLE
fix: popup + big font zoom + small display

### DIFF
--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -195,6 +195,7 @@ footer {
     }
   }
   &.expand {
+    overflow-y: auto;
     > .submenu {
       display: block;
       border-color: var(--fill-4);

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="page-popup"
+    class="page-popup flex flex-col"
     @click="activeExtras && toggleExtras(null)"
     @click.capture.prevent="onOpenUrl"
     @contextmenu="activeExtras && (toggleExtras(null), $event.preventDefault())"
@@ -62,7 +62,7 @@
     </div>
     <div
       v-for="scope in injectionScopes"
-      class="menu menu-scripts"
+      class="menu menu-scripts flex flex-col"
       :class="{
         expand: activeMenu === scope.name,
         'block-scroll': activeExtras,
@@ -518,6 +518,7 @@ export default {
   mounted() {
     this::focusMe();
     keyboardService.enable();
+    this.$el.style.maxHeight = Math.min(600, screen.availHeight - window.screenY - 8) + 'px';
     this.disposeList = [
       keyboardService.register('escape', () => {
         const item = this.activeExtras;


### PR DESCRIPTION
Fixes #1663.

Testing:

1. set OS font zoom to 200% or more
2. optionally resize the browser window's top border to the middle of the screen - to halve the available height for the popup
3. make sure you have a lot of scripts in the list or use the [html from the report](https://github.com/violentmonkey/violentmonkey/files/10088142/Copy.outerHTML.txt).