### PR TITLE
fix: set popup height to 100% in mobile browsers

### DIFF
--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -212,7 +212,6 @@ footer {
 .submenu {
   display: none;
   min-height: 2rem;
-  max-height: 30rem;
   overflow-y: auto;
   background: var(--bg);
   border-top: 1px dashed var(--fill-3);

--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -512,7 +512,8 @@ export default {
   mounted() {
     focusMe(this.$el);
     keyboardService.enable();
-    this.$el.style.maxHeight = Math.min(600, screen.availHeight - window.screenY - 8) + 'px';
+    // innerHeight may be bigger than 600px in a mobile browser which displays the popup as a fullscreen page
+    this.$el.style.maxHeight = Math.min(Math.max(600, innerHeight), screen.availHeight - window.screenY - 8) + 'px';
     this.disposeList = [
       keyboardService.register('escape', () => {
         const item = this.activeExtras;


### PR DESCRIPTION
fixes #1736

Works in my emulator, but maybe it doesn't in a real phone? @gera2ld, please test.
I tested only in Firefox because Kiwi doesn't start in the emulator.