### PR TITLE
fix: speed up imports by throttling render

### DIFF
--- a/src/options/utils/index.js
+++ b/src/options/utils/index.js
@@ -5,7 +5,11 @@ export const store = reactive({
   route,
   scripts: [],
   removedScripts: [],
+  importing: null,
+  loading: false,
   /** Whether removed scripts need to be filtered from `store.scripts`. */
   needRefresh: false,
   storageSize: 0,
+  sync: [],
+  title: null,
 });


### PR DESCRIPTION
Importing a few megabyte zip that has many differences to the current database was very slow if the script list was already shown. It took several seconds when going from 60 to 130 scripts on my fast desktop computer, which means it would be a minute on a mobile phone. With throttling this operation takes just ~1 second as tested on the same old database in a clean install.

P.S. When adding `importing` to `store` I've also moved 3 needlessly(?) separated props from index.js.