### PR TITLE
feat: simplified excluding of domain in popup

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -33,13 +33,16 @@ addOwnCommands({
     return data;
   },
   GetSizes: getSizes,
-  /** @return {Promise<Object>} */
-  async GetTabDomain() {
-    const tab = await getActiveTab() || {};
-    const url = getTabUrl(tab);
-    const host = url.match(/^https?:\/\/([^/]+)|$/)[1];
+  /**
+   * @param {string} [url]
+   * @return {Promise<Object>}
+   */
+  async GetTabDomain(url) {
+    const tab = !url && await getActiveTab() || {};
+    const host = new URL(url || getTabUrl(tab)).hostname;
     return {
       tab,
+      host,
       domain: host && tld.getDomain(host) || host,
     };
   },

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -326,7 +326,11 @@ footer {
 .excludes-menu {
   padding: .25rem .5rem .25rem $leftPaneWidth;
   button {
-    margin: .5rem .5rem 0 0;
+    text-align: left;
+    max-width: 100%;
+  }
+  input {
+    width: 100%;
   }
   details {
     summary {


### PR DESCRIPTION
Clicking the button adds the exception and confirms the UI.
The button's title shows the text that will be used i.e. `*://domain/*`

The input now shows just the new entry, not all excludes of the script as before, because it's too small. The users can open the editor to edit the entire list conveniently (this isn't mentioned anywhere in the UI though).

Type | image
-|-
Short | ![pic](https://user-images.githubusercontent.com/1310400/218315612-8d57e7ab-95f9-4615-8367-6ae2fe0f0872.png)
Medium | ![image](https://user-images.githubusercontent.com/1310400/218316410-43ba0209-8828-49db-bd5e-52d664ad8dca.png)
Super-long + info expanded | ![image](https://user-images.githubusercontent.com/1310400/218316497-2fac1392-c8a7-4c9a-ab78-87d41faeb57e.png)
