### PR TITLE
fix: require Firefox 57+

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,2 +1,2 @@
 Chrome >= 57
-Firefox >= 53
+Firefox >= 57

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -126,5 +126,4 @@ initialize(() => {
   sync.initialize();
   checkRemove();
   setInterval(checkRemove, TIMEOUT_24HOURS);
-  chrome.declarativeContent?.onPageChanged.removeRules(); // TODO: remove by the end of 2023
 });

--- a/src/common/ui/index.js
+++ b/src/common/ui/index.js
@@ -21,8 +21,7 @@ function showUnhandledError(err) {
     padding: 1em;
   `.replace(/;/g, '!important;');
   el.textContent = `${IS_FIREFOX && err.message || ''}\n${err.stack || ''}`.trim() || err;
-  // TODO: remove `?.` when strict_min_version>=53
-  el.onclick = () => getSelection().setBaseAndExtent?.(el, 0, el, 1);
+  el.onclick = () => getSelection().setBaseAndExtent(el, 0, el, 1);
   (document.body || document.documentElement).appendChild(el);
 }
 

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -40,7 +40,6 @@ permissions:
   - unlimitedStorage
   - clipboardWrite
   - cookies
-  - declarativeContent
 commands:
   _execute_browser_action: {}
   dashboard:
@@ -55,5 +54,4 @@ minimum_chrome_version: '57.0'
 browser_specific_settings:
   gecko:
     id: '{aecec67f-0d10-4fa7-b7c7-609a2db280cf}'
-    # our browserlistrc uses 53 to skip unnecessary polyfills but we're actually compatible with 52
-    strict_min_version: '52.0'
+    strict_min_version: '57.0'


### PR DESCRIPTION
Increasing `strict_min_version` to 57, the first multi-process Firefox Quantum.

Currently it's 52 but Firefox 52 doesn't properly support many of the `browser` API we use in Violentmonkey anyway, i.e. the extension is half-broken. The reason people still use it is probably because 52 is the last version that can run in Windows XP. However it's so terribly slow compared to the modern Firefox (at least WebExtensions API) that they are really shooting themselves in the leg by still using it.

Here's the AMO statistics for the outdated FF:

version|daily update checks
-|-
Firefox 52 | ~80
Firefox 56 | ~40
Firefox 68 | ~5
Firefox 72 | ~25
Firefox 78 | ~40
Firefox 92 | ~40
Firefox 93 | ~40
Firefox 94 | ~50
Firefox 95 | ~70

---

This will get rid of ~30 manifest warnings in the AMO dashboard generated by their [linter](https://github.com/mozilla/addons-linter). I've also removed `declarativeContent`, which we don't use anymore (its RequestContentScript action is already deprecated and will be superseded by a new userscript API). Removing it also removed the warning about `<all_urls>` - it was a bug in their linter.

Only one warning will remain about Vue's `innerHTML`.

Hopefully it will improve review times on AMO.