### PR TITLE
fix: wrong way to remove suffix from icon URL

### DIFF
--- a/src/common/safe-globals.js
+++ b/src/common/safe-globals.js
@@ -27,4 +27,4 @@ export const extensionOrigin = extensionRoot.slice(0, -1);
 export const extensionManifest = chrome.runtime.getManifest();
 // Using getURL because in Firefox manifest contains resolved (full) URLs
 export const extensionOptionsPage = chrome.runtime.getURL(extensionManifest.options_page);
-export const ICON_PREFIX = chrome.runtime.getURL(extensionManifest.icons[16].split('16')[0]);
+export const ICON_PREFIX = chrome.runtime.getURL(extensionManifest.icons[16].replace("16.png", ""));


### PR DESCRIPTION
I'm sorry but it is possible to have characters "16" in the randomly generated UUID of the extension:

![screenshot](https://user-images.githubusercontent.com/9620335/220433588-9e115e7b-2547-42db-b421-f0f68fd96091.png)

And the real question is: why `split()`?