### PR TITLE
chore: strip "default" from labelInjectionMode

### DIFF
--- a/src/_locales/es/messages.yml
+++ b/src/_locales/es/messages.yml
@@ -396,7 +396,7 @@ labelInjectionMode:
   description: >-
     Label for option in advanced settings and in script settings. Don't forget
     the space after ":" if the translated language separates words with spaces.
-  message: 'Modo de inyección predeterminado:'
+  message: 'Modo de inyección: '
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
   message: Instalando script

--- a/src/_locales/es_419/messages.yml
+++ b/src/_locales/es_419/messages.yml
@@ -403,7 +403,7 @@ labelInjectionMode:
   description: >-
     Label for option in advanced settings and in script settings. Don't forget
     the space after ":" if the translated language separates words with spaces.
-  message: 'Modo de inyección predeterminado: '
+  message: 'Modo de inyección: '
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
   message: Instalando script

--- a/src/_locales/fr/messages.yml
+++ b/src/_locales/fr/messages.yml
@@ -144,7 +144,7 @@ editHelpDocumention:
   message: 'Documentation on userscript metadata block and <code>GM</code> API:'
 editHelpKeyboard:
   description: Label in the editor help tab for the keyboard shortcuts.
-  message: "Raccourcis clavier\_:"
+  message: "Raccourcis clavier\_: "
 editHowToHint:
   description: The text of the how-to link in the editor header.
   message: "Vous utilisez un autre éditeur de texte\_?"
@@ -234,7 +234,7 @@ headerRecycleBin:
   message: Corbeille
 hintInputURL:
   description: Hint for a prompt box to input URL of a user script.
-  message: "URL source\_:"
+  message: "URL source\_: "
 hintRecycleBin:
   description: Hint for recycle bin.
   message: Les scripts supprimés sont listés ici et conservés pendant 7 jours.
@@ -300,7 +300,7 @@ labelBadge:
   message: "Montrer sur le badge\_: "
 labelBadgeColors:
   description: Label for option group to set badge colors.
-  message: 'Couleurs des badges :'
+  message: 'Couleurs des badges\_: '
 labelBadgeNone:
   description: Option to display nothing on badge.
   message: Rien
@@ -336,7 +336,7 @@ labelDonate:
   touched: false
 labelDownloadURL:
   description: Label of script @downloadURL in custom meta data.
-  message: "URL de téléchargement\_:"
+  message: "URL de téléchargement\_: "
 labelEditValue:
   description: Label shown in the panel to edit a script value.
   message: Éditer la valeur du script
@@ -384,7 +384,7 @@ labelHomepage:
   message: Page d’accueil
 labelHomepageURL:
   description: Label of script @homepageURL in custom meta data.
-  message: "URL de la page d’accueil\_:"
+  message: "URL de la page d’accueil\_: "
 labelImportScriptData:
   description: Option to import script data along with scripts.
   message: Importer les données du script
@@ -398,7 +398,7 @@ labelInjectionMode:
   description: >-
     Label for option in advanced settings and in script settings. Don't forget
     the space after ":" if the translated language separates words with spaces.
-  message: "Mode d’injection par défaut\_:"
+  message: "Mode d’injection\_: "
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
   message: Installation du script
@@ -416,7 +416,7 @@ labelMatch:
   message: Règles @match
 labelName:
   description: Label of script name.
-  message: "Nom\_:"
+  message: "Nom\_: "
 labelNoFrames:
   description: Label of script @noframes properties in custom meta data.
   message: 'Exécution dans les fenêtres :'
@@ -431,7 +431,7 @@ labelNotifyThisUpdated:
     A per-script option in editor to enable notification when this script is
     updated. The text follows "Allow update" checkbox option so it's like a
     continuation of the phrase.
-  message: ", puis envoyer une notification\_:"
+  message: ", puis envoyer une notification\_: "
 labelNotifyUpdates:
   description: Option to show notification when script is updated.
   message: Notification de mise à jour de script
@@ -527,7 +527,7 @@ labelTranslator:
   touched: false
 labelUpdateURL:
   description: Label of script @updateURL in custom meta data.
-  message: "URL de mise à jour\_:"
+  message: "URL de mise à jour\_: "
 labelViewSingleColumn:
   description: >-
     Label for option in dashboard script list to show the scripts in single
@@ -582,7 +582,7 @@ menuExcludeHint:
     Pour appliquer les changements à tous les autres onglets merci de les
     rafraichir manuellement.
 
-    Utilisez l'onglet "Paramètres" de l'éditeur pour plus de flexibilité. 
+    Utilisez l'onglet "Paramètres" de l'éditeur pour plus de flexibilité.
 menuFeedback:
   description: >-
     Menu item in popup to open the selected script's feedback page. Please use a

--- a/src/_locales/it/messages.yml
+++ b/src/_locales/it/messages.yml
@@ -394,7 +394,7 @@ labelInjectionMode:
   description: >-
     Label for option in advanced settings and in script settings. Don't forget
     the space after ":" if the translated language separates words with spaces.
-  message: 'Default injection mode: '
+  message: ''
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
   message: Installando script

--- a/src/_locales/ja/messages.yml
+++ b/src/_locales/ja/messages.yml
@@ -377,7 +377,7 @@ labelInjectionMode:
   description: >-
     Label for option in advanced settings and in script settings. Don't forget
     the space after ":" if the translated language separates words with spaces.
-  message: '既定のインジェクションモード: '
+  message: 'インジェクションモード: '
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
   message: スクリプトのインストール
@@ -547,7 +547,7 @@ menuExcludeHint:
   message: |2-
      一般設定でこのオプションを有効にすると、現在のタブが自動再ロードされます。
     他のすべてのタブに変更を適用するには、手動で再ロードしてください。
-    柔軟性を高めるには、エディタの「設定」タブを使用します。 
+    柔軟性を高めるには、エディタの「設定」タブを使用します。
 menuFeedback:
   description: >-
     Menu item in popup to open the selected script's feedback page. Please use a

--- a/src/_locales/ko/messages.yml
+++ b/src/_locales/ko/messages.yml
@@ -376,7 +376,7 @@ labelInjectionMode:
   description: >-
     Label for option in advanced settings and in script settings. Don't forget
     the space after ":" if the translated language separates words with spaces.
-  message: '기본 인젝션 모드: '
+  message: '인젝션 모드: '
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
   message: 스크립트 설치

--- a/src/_locales/pt_BR/messages.yml
+++ b/src/_locales/pt_BR/messages.yml
@@ -394,7 +394,7 @@ labelInjectionMode:
   description: >-
     Label for option in advanced settings and in script settings. Don't forget
     the space after ":" if the translated language separates words with spaces.
-  message: 'Modo de injeção padrão: '
+  message: 'Modo de injeção: '
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
   message: Instalando script

--- a/src/_locales/pt_PT/messages.yml
+++ b/src/_locales/pt_PT/messages.yml
@@ -379,7 +379,7 @@ labelInjectionMode:
   description: >-
     Label for option in advanced settings and in script settings. Don't forget
     the space after ":" if the translated language separates words with spaces.
-  message: 'Modo de injeção predefinido: '
+  message: 'Modo de injeção: '
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
   message: A instalar o script

--- a/src/_locales/ro/messages.yml
+++ b/src/_locales/ro/messages.yml
@@ -138,7 +138,7 @@ editHelpDocumention:
   description: Label in the editor help tab for the documentation link.
   message: >-
     Documentație cu privire la blockurile metadatelor usescripturilor și
-    API-urile <code>GM</code>: 
+    API-urile <code>GM</code>:
 editHelpKeyboard:
   description: Label in the editor help tab for the keyboard shortcuts.
   message: Comenzi rapide de la tastatură
@@ -395,7 +395,7 @@ labelInjectionMode:
   description: >-
     Label for option in advanced settings and in script settings. Don't forget
     the space after ":" if the translated language separates words with spaces.
-  message: 'Modul de injectare implicit: '
+  message: 'Modul de injectare: '
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
   message: Instalarea scriptului

--- a/src/_locales/ru/messages.yml
+++ b/src/_locales/ru/messages.yml
@@ -384,7 +384,7 @@ labelInjectionMode:
   description: >-
     Label for option in advanced settings and in script settings. Don't forget
     the space after ":" if the translated language separates words with spaces.
-  message: 'Режим инъекции по умолчанию: '
+  message: 'Режим инъекции: '
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
   message: Установка скрипта...

--- a/src/_locales/tr/messages.yml
+++ b/src/_locales/tr/messages.yml
@@ -388,7 +388,7 @@ labelInjectionMode:
   description: >-
     Label for option in advanced settings and in script settings. Don't forget
     the space after ":" if the translated language separates words with spaces.
-  message: 'Varsayılan enjeksiyon modu:'
+  message: 'Enjeksiyon modu:'
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
   message: Betik yükleniyor
@@ -676,7 +676,7 @@ msgNamespaceConflict:
   message: >-
     Böyle bir betik ya hâlihazırda yüklü ya da geri dönüşüm kutusunda bulunuyor.
     Lütfen farklı bir @name ve @namespace kullanın veya çakışmayı oluşturan
-    betiği düzenleyin.  
+    betiği düzenleyin.
 msgNamespaceConflictRestore:
   description: >-
     Message shown when namespace of the script to restore from recycle bin

--- a/src/_locales/vi/messages.yml
+++ b/src/_locales/vi/messages.yml
@@ -382,7 +382,7 @@ labelInjectionMode:
   description: >-
     Label for option in advanced settings and in script settings. Don't forget
     the space after ":" if the translated language separates words with spaces.
-  message: 'Chế độ tiêm mặc định: '
+  message: 'Chế độ tiêm: '
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
   message: Đang cài đặt script

--- a/src/_locales/zh_CN/messages.yml
+++ b/src/_locales/zh_CN/messages.yml
@@ -376,7 +376,7 @@ labelInjectionMode:
   description: >-
     Label for option in advanced settings and in script settings. Don't forget
     the space after ":" if the translated language separates words with spaces.
-  message: 默认注入模式：
+  message: 注入模式：
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
   message: 安装脚本

--- a/src/_locales/zh_TW/messages.yml
+++ b/src/_locales/zh_TW/messages.yml
@@ -377,7 +377,7 @@ labelInjectionMode:
   description: >-
     Label for option in advanced settings and in script settings. Don't forget
     the space after ":" if the translated language separates words with spaces.
-  message: 預設注入模式：
+  message: 注入模式：
 labelInstall:
   description: Shown in the title of the confirm page while trying to install a script.
   message: 安裝腳本


### PR DESCRIPTION
Weirdly most languages retained the same translation with the word "Default" in #1774 even though they all should have been cleared when I updated the original labelInjectionMode. Either most translators have reused the old message by mistake or it's a bug in transifex.