### PR TITLE
Determine cookie store ID prefix dynamically.

### DIFF
--- a/src/background/utils/requests.js
+++ b/src/background/utils/requests.js
@@ -7,6 +7,13 @@ import { addPublicCommands, commands } from './message';
 import {
   FORBIDDEN_HEADER_RE, VM_VERIFY, isCookie, requests, toggleHeaderInjector, verify,
 } from './requests-core';
+import { preInitialize } from './init';
+
+// prefix for firefox cookie store ids
+let store_prefix = null;
+if (IS_FIREFOX)
+  preInitialize.push(async () =>
+    store_prefix = (await browser.cookies.getAllCookieStores())[0].id.split("-")[0]);
 
 addPublicCommands({
   /**
@@ -208,7 +215,7 @@ async function httpRequest(opts, events, src, cb) {
     req.noNativeCookie = true;
     for (const store of await browser.cookies.getAllCookieStores()) {
       if (store.tabIds.includes(tab.id)) {
-        if (IS_FIREFOX ? store.id !== 'firefox-default' : store.id !== '0') {
+        if (IS_FIREFOX ? store.id !== `${store_prefix}-default` : store.id !== '0') {
           /* Cookie routing. For the main store we rely on the browser.
            * The ids are hard-coded as `stores` may omit the main store if no such tabs are open. */
           req.storeId = store.id;

--- a/src/background/utils/tabs.js
+++ b/src/background/utils/tabs.js
@@ -2,6 +2,13 @@ import { browserWindows, getActiveTab, noop, sendTabCmd, getFullUrl } from '@/co
 import ua from '@/common/ua';
 import { addOwnCommands, addPublicCommands, commands } from './message';
 import { getOption } from './options';
+import { preInitialize } from './init';
+
+// prefix for firefox cookie store ids 
+let store_prefix = null;
+if (IS_FIREFOX)
+  preInitialize.push(async () =>
+    store_prefix = (await browser.cookies.getAllCookieStores())[0].id.split("-")[0]);
 
 const openers = {};
 const openerTabIdSupported = !IS_FIREFOX // supported in Chrome
@@ -153,6 +160,6 @@ browser.tabs.onRemoved.addListener((id) => {
 });
 
 function getContainerId(index) {
-  return index === 0 && 'firefox-default'
-         || index > 0 && `firefox-container-${index}`;
+  return index === 0 && `${store_prefix}-default`
+         || index > 0 && `${store_prefix}-container-${index}`;
 }


### PR DESCRIPTION
Determine the cookie store ID prefix on startup dynamically instead of hard coding it as `firefox`. Allows the extension to work on GNU IceCat and fixes https://github.com/violentmonkey/violentmonkey/issues/1783.