### PR TITLE
chore: use numeric version for AMO beta

### DIFF
--- a/scripts/amo-upload.mjs
+++ b/scripts/amo-upload.mjs
@@ -8,10 +8,9 @@ import { hasAsset } from './release-helper.js';
 async function main() {
   const manifest = await readManifest();
   const rawVersion = process.env.VERSION;
-  // version may be suffixed for unlisted version
   const version = getVersion();
   const beta = isBeta();
-  const fileName = `violentmonkey-${version}-an+fx.xpi`;
+  const fileName = `violentmonkey-${version}${beta ? 'b' : ''}-an+fx.xpi`;
   const url = `https://github.com/violentmonkey/violentmonkey/releases/download/v${rawVersion}/${fileName}`;
 
   if (await hasAsset(fileName)) {
@@ -29,7 +28,7 @@ async function main() {
   };
 
   const tempFile = join(process.env.TEMP_DIR, Math.random().toString(36).slice(2, 8).toString());
-  const releaseUrl = `https://github.com/violentmonkey/violentmonkey/releases/tag/v${version.replace('b', '')}`;
+  const releaseUrl = `https://github.com/violentmonkey/violentmonkey/releases/tag/v${version}`;
   await signAddon({
     apiKey: process.env.AMO_KEY,
     apiSecret: process.env.AMO_SECRET,

--- a/scripts/version-helper.js
+++ b/scripts/version-helper.js
@@ -6,11 +6,7 @@ const pkg = require('../package.json');
  * > manifest.version = `${pkg.version}.${pkg.beta}`
  */
 function getVersion() {
-  return `${pkg.version.match(/\d+\.\d+/)[0]}.${pkg.beta || 0}${
-  // Create a beta release with the same code as in stable release.
-  // Used in unlisted version.
-    process.env.BETA ? 'b' : ''
-  }`;
+  return `${pkg.version.match(/\d+\.\d+/)[0]}.${pkg.beta || 0}`;
 }
 
 function isBeta() {


### PR DESCRIPTION
Fixes AMO warning:

> The version string should be simplified because it won't be compatible with Manifest Version 3 and above. The version should be a string with 1 to 4 numbers separated with dots. Each number should have up to 9 digits and leading zeros will no longer be allowed. Letters will no longer be allowed either.

Not sure I did it correctly, please review, @gera2ld.