### PR TITLE
add "?filter_locale=0" to show results for all languages

### DIFF
--- a/src/popup/views/app.vue
+++ b/src/popup/views/app.vue
@@ -334,7 +334,7 @@ export default {
     findUrls() {
       const query = encodeURIComponent(store.domain);
       return {
-        [`${i18n('menuFindScripts')} (GF)`]: `https://greasyfork.org/scripts/by-site/${query}`,
+        [`${i18n('menuFindScripts')} (GF)`]: `https://greasyfork.org/scripts/by-site/${query}?filter_locale=0`,
         OUJS: `https://openuserjs.org/?q=${query}`,
       };
     },


### PR DESCRIPTION
Greasyfork.org will by default only show results for your location (in my case germany). 
This is bad as most scripts you want to use are not translated to german and do not show up. 
We always have to click on show all languages to get good results (this annoyes me enough to make this pr). 

This pr adds "?filter_locale=0" to the url and will automatically show all results (you can go back to your locations result by clicking an an link at the top of the page).