### PR TITLE
fix: clarify 'Track local file' checkbox label

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -245,7 +245,7 @@ installOptionClose:
   message: Close after installation
 installOptionTrack:
   description: Option to track the loading local file until page is closed.
-  message: Track changes in local file while this page is open
+  message: Track edits in local file while this page is open
 installOptionTrackTooltip:
   description: >-
     Tooltip in Firefox 68+ for the option to track the loading local file before

--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -244,8 +244,8 @@ installOptionClose:
   description: Option to close confirm window after installation.
   message: Close after installation
 installOptionTrack:
-  description: Option to track the loading local file until window is closed.
-  message: Track local file until this window is closed
+  description: Option to track the loading local file until page is closed.
+  message: Track changes in local file while this page is open
 installOptionTrackTooltip:
   description: >-
     Tooltip in Firefox 68+ for the option to track the loading local file before

--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -244,8 +244,8 @@ installOptionClose:
   description: Option to close confirm window after installation.
   message: Close after installation
 installOptionTrack:
-  description: Option to track the loading local file before window is closed.
-  message: Track local file before this window is closed
+  description: Option to track the loading local file until window is closed.
+  message: Track local file until this window is closed
 installOptionTrackTooltip:
   description: >-
     Tooltip in Firefox 68+ for the option to track the loading local file before


### PR DESCRIPTION
Before I learned from experience how the checkbox worked, I interpreted the label as if ticking the checkbox and then closing the tab would make Violentmonkey track the file.