### PR TITLE
feat: reload tab without scripts + icon context menu

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -808,6 +808,15 @@ sideMenuInstalled:
 sideMenuSettings:
   description: 'Side menu: Settings'
   message: Settings
+skipScriptsCmd:
+  description: Title of the hotkey in the browser UI for customizing the hotkeys.
+  message: Reload page without userscripts
+skipScriptsHint:
+  description: Tooltip shown over the global enabled/disabled switch in popup.
+  message: (right-click to reload the page without userscripts)
+skipScriptsMsg:
+  description: Message shown in the popup if the tab was reloaded without scripts.
+  message: You disabled userscripts for this page. To run them, reload or navigate the tab.
 titleBadgeColor:
   description: Tooltip for option to set badge color.
   message: Normal badge color

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -15,6 +15,7 @@ import './utils/icon';
 import './utils/notifications';
 import './utils/preinject';
 import './utils/script';
+import './utils/storage-fetch';
 import './utils/tab-redirector';
 import './utils/tester';
 import './utils/update';

--- a/src/background/utils/hotkeys.js
+++ b/src/background/utils/hotkeys.js
@@ -1,10 +1,14 @@
+import { getActiveTab } from '@/common';
 import { postInitialize } from './init';
 import { commands } from './message';
+import { reloadAndSkipScripts } from './preinject';
 
 postInitialize.push(() => {
   browser.commands?.onCommand.addListener((cmd) => {
     if (cmd === 'newScript') {
       commands.OpenEditor();
+    } else if (cmd === SKIP_SCRIPTS) {
+      getActiveTab().then(reloadAndSkipScripts);
     } else {
       const route = cmd === TAB_SETTINGS ? `#${cmd}` : '';
       commands.TabOpen({ url: `${extensionOptionsPage}${route}` });

--- a/src/background/utils/icon.js
+++ b/src/background/utils/icon.js
@@ -1,10 +1,11 @@
-import { i18n, makeDataUri, noop } from '@/common';
-import { BLACKLIST, INJECTABLE_TAB_URL_RE } from '@/common/consts';
-import { objectPick } from '@/common/object';
+import { i18n, ignoreChromeErrors, makeDataUri, noop } from '@/common';
+import { BLACKLIST, INJECTABLE_URL_RE } from '@/common/consts';
+import { nest, objectPick } from '@/common/object';
 import { postInitialize } from './init';
 import { addOwnCommands, addPublicCommands, forEachTab } from './message';
-import { getOption, hookOptions } from './options';
-import { getTabUrl } from './tabs';
+import { getOption, hookOptions, setOption } from './options';
+import { INJECT, reloadAndSkipScripts } from './preinject';
+import { getTabUrl, tabsOnRemoved, tabsOnUpdated } from './tabs';
 import { testBlacklist } from './tester';
 import storage from './storage';
 
@@ -20,23 +21,25 @@ addPublicCommands({
   SetBadge: setBadge,
 });
 
+let isApplied;
+/** @type {VMBadgeMode} */
+let showBadge;
+let badgeColor;
+let badgeColorBlocked;
 /** We don't set 19px because FF and Vivaldi scale it down to 16px instead of our own crisp 16px */
 const SIZES = [16, 32];
 /** Caching own icon to improve dashboard loading speed, as well as browserAction API
  * (e.g. Chrome wastes 40ms in our extension's process to read 4 icons for every tab). */
-const iconCache = {};
-
+const iconCache = createNullObj();
 // Firefox Android does not support such APIs, use noop
-
 const browserAction = (() => {
   // Using `chrome` namespace in order to skip our browser.js polyfill in Chrome
   const api = chrome.browserAction;
-  // Suppress the "no tab id" error when setting an icon/badge as it cannot be reliably prevented
-  const ignoreErrors = () => chrome.runtime.lastError;
   // Some methods like setBadgeText added callbacks only in Chrome 67+.
   const makeMethod = fn => (...args) => {
     try {
-      api::fn(...args, ignoreErrors);
+      // Suppress the "no tab id" error when setting an icon/badge as it cannot be reliably prevented
+      api::fn(...args, ignoreChromeErrors);
     } catch (e) {
       api::fn(...args);
     }
@@ -48,24 +51,29 @@ const browserAction = (() => {
     'setTitle',
   ], fn => (fn ? makeMethod(fn) : noop));
 })();
+// Promisifying explicitly because this API returns an id in Firefox and not a Promise
+const contextMenus = chrome.contextMenus;
 
-const badges = {};
+export const badges = createNullObj();
+export const BROWSER_ACTION = 'browser_action';
 const KEY_IS_APPLIED = 'isApplied';
 const KEY_SHOW_BADGE = 'showBadge';
 const KEY_BADGE_COLOR = 'badgeColor';
 const KEY_BADGE_COLOR_BLOCKED = 'badgeColorBlocked';
-/** @type {boolean} */
-let isApplied;
-/** @type {VMBadgeMode} */
-let showBadge;
-/** @type {string} */
-let badgeColor;
-/** @type {string} */
-let badgeColorBlocked;
-/** @type {string} */
-let titleBlacklisted;
-/** @type {string} */
-let titleNoninjectable;
+const titleBlacklisted = i18n('failureReasonBlacklisted');
+const titleDefault = extensionManifest[BROWSER_ACTION].default_title;
+const iconDefault = extensionManifest[BROWSER_ACTION].default_icon[16].match(/\d+(\w*)\./)[1];
+const titleDisabled = i18n('menuScriptDisabled');
+const titleNoninjectable = i18n('failureReasonNoninjectable');
+const titleSkipped = i18n('skipScriptsMsg');
+const getFailureReason = (url, data) => !INJECTABLE_URL_RE.test(url) ? titleNoninjectable
+  : testBlacklist(url) ? titleBlacklisted
+    : !isApplied ? titleDisabled
+      : data && (
+        data[INJECT] === SKIP_SCRIPTS
+          ? titleSkipped
+          : titleDefault
+      );
 
 hookOptions((changes) => {
   let v;
@@ -78,6 +86,7 @@ hookOptions((changes) => {
   if ((v = changes[KEY_SHOW_BADGE]) != null) {
     showBadge = v;
     jobs.push(updateBadge);
+    contextMenus?.update(KEY_SHOW_BADGE + ':' + showBadge, {checked: true});
   }
   if ((v = changes[KEY_BADGE_COLOR]) && (badgeColor = v)
   || (v = changes[KEY_BADGE_COLOR_BLOCKED]) && (badgeColorBlocked = v)) {
@@ -91,91 +100,123 @@ hookOptions((changes) => {
   }
 });
 
-postInitialize.push(() => {
+postInitialize.push(async () => {
   isApplied = getOption(KEY_IS_APPLIED);
   showBadge = getOption(KEY_SHOW_BADGE);
   badgeColor = getOption(KEY_BADGE_COLOR);
   badgeColorBlocked = getOption(KEY_BADGE_COLOR_BLOCKED);
-  titleBlacklisted = i18n('failureReasonBlacklisted');
-  titleNoninjectable = i18n('failureReasonNoninjectable');
   forEachTab(updateState);
   if (!isApplied) setIcon(); // sets the dimmed icon as default
-});
-
-browser.tabs.onRemoved.addListener((id) => {
-  delete badges[id];
-});
-
-browser.tabs.onUpdated.addListener((tabId, info, tab) => {
-  const { url } = info;
-  if (info.status === 'loading'
-      // at least about:newtab in Firefox may open without 'loading' status
-      || info.favIconUrl && tab.url.startsWith('about:')) {
-    updateState(tab, url);
+  if (contextMenus) {
+    const addToIcon = (id, title, opts) => (
+      new Promise(resolve => (
+        contextMenus.create({
+          contexts: [BROWSER_ACTION],
+          id,
+          title,
+          ...opts,
+        }, resolve)
+      ))
+    ).then(ignoreChromeErrors);
+    const badgeChild = { parentId: KEY_SHOW_BADGE, type: 'radio' };
+    await addToIcon(SKIP_SCRIPTS, i18n('skipScriptsCmd'));
+    for (const args of [
+      [KEY_SHOW_BADGE, i18n('labelBadge')],
+      [`${KEY_SHOW_BADGE}:`, i18n('labelBadgeNone'), badgeChild],
+      [`${KEY_SHOW_BADGE}:unique`, i18n('labelBadgeUnique'), badgeChild],
+      [`${KEY_SHOW_BADGE}:total`, i18n('labelBadgeTotal'), badgeChild],
+    ]) {
+      await addToIcon(...args);
+    }
+    contextMenus.update(KEY_SHOW_BADGE + ':' + showBadge, { checked: true });
   }
 });
 
-function setBadge(ids, { tab, frameId }) {
-  const tabId = tab.id;
-  const data = badges[tabId] || {};
-  if (!data.idMap || frameId === 0) {
-    // 1) keeping data object to preserve data.blocked
-    // 2) 'total' and 'unique' must match showBadge in options-defaults.js
-    data.total = 0;
-    data.unique = 0;
-    data.idMap = {};
-    badges[tabId] = data;
+contextMenus?.onClicked.addListener(({ menuItemId: id }, tab) => {
+  if (id === SKIP_SCRIPTS) {
+    reloadAndSkipScripts(tab);
+  } else if (id.startsWith(KEY_SHOW_BADGE)) {
+    setOption(KEY_SHOW_BADGE, id.slice(KEY_SHOW_BADGE.length + 1));
   }
-  data.total += ids.length;
-  if (ids) {
-    ids.forEach((id) => {
-      data.idMap[id] = 1;
-    });
-    data.unique = Object.keys(data.idMap).length;
+});
+tabsOnRemoved.addListener(id => delete badges[id]);
+tabsOnUpdated.addListener((tabId, { url }, tab) => {
+  if (url) {
+    const title = getFailureReason(url);
+    if (title) updateState(tab, resetBadgeData(tabId), title);
   }
-  updateBadgeColor(tab, data);
-  updateBadge(tab, data);
+}, ...IS_FIREFOX >= 61 ? [{ properties: ['status'] }] : []);
+
+function resetBadgeData(tabId, isInjected) {
+  // 'total' and 'unique' must match showBadge in options-defaults.js
+  const data = nest(badges, tabId);
+  data.icon = iconDefault;
+  data.idMap = new Set();
+  data.totalMap = createNullObj();
+  data.total = 0;
+  data.unique = 0;
+  data[INJECT] = isInjected;
+  return data;
 }
 
-function updateBadge(tab, data = badges[tab.id]) {
+/**
+ * @param {Object} params
+ * @param {chrome.runtime.MessageSender} src
+ */
+function setBadge({ [IDS]: ids, reset }, { tab, frameId }) {
+  const tabId = tab.id;
+  const data = (frameId || !reset) && badges[tabId] || resetBadgeData(tabId);
+  if (ids === SKIP_SCRIPTS) {
+    data[INJECT] = SKIP_SCRIPTS;
+  } else if (ids) {
+    const { idMap, totalMap } = data;
+    // uniques
+    ids.forEach(idMap.add, idMap);
+    data.unique = idMap.size;
+    // totals
+    let total = totalMap[frameId] = ids.length;
+    for (const id in totalMap) if (id !== frameId) total += totalMap[id];
+    data.total = total;
+    data[INJECT] = true;
+  }
+  updateBadgeColor(tab, data);
+  updateState(tab, data);
+}
+
+function updateBadge({ id: tabId }, data = badges[tabId]) {
   if (data) {
     browserAction.setBadgeText({
       text: `${data[showBadge] || ''}`,
-      tabId: tab.id,
+      tabId,
     });
   }
 }
 
-function updateBadgeColor(tab, data = badges[tab.id]) {
+function updateBadgeColor({ id: tabId }, data = badges[tabId]) {
   if (data) {
     browserAction.setBadgeBackgroundColor({
-      color: data.blocked ? badgeColorBlocked : badgeColor,
-      tabId: tab.id,
+      color: data[INJECT] ? badgeColor : badgeColorBlocked,
+      tabId,
     });
   }
 }
 
-// Chrome 79+ uses pendingUrl while the tab connects to the newly navigated URL
-// https://groups.google.com/a/chromium.org/forum/#!topic/chromium-extensions/5zu_PT0arls
-function updateState(tab, url = getTabUrl(tab)) {
+function updateState(tab, data, title) {
   const tabId = tab.id;
-  const injectable = INJECTABLE_TAB_URL_RE.test(url);
-  const blacklisted = injectable ? testBlacklist(url) : undefined;
-  const title = blacklisted && titleBlacklisted || !injectable && titleNoninjectable || '';
-  // if the user unblacklisted this previously blocked tab in settings,
-  // but didn't reload the tab yet, we need to restore the icon and the title
-  if (title || (badges[tabId] || {}).blocked) {
-    // Firefox Android doesn't fall back on empty values
-    browserAction.setTitle({ title: title || i18n('extName'), tabId });
-    const data = title ? { blocked: true } : {};
-    badges[tabId] = data;
-    setIcon(tab, data);
-    updateBadge(tab, data);
-  }
+  if (!data) data = badges[tabId] || resetBadgeData(tabId);
+  if (!title) title = getFailureReason(getTabUrl(tab), data);
+  // data[BLACKLIST] = title === titleBlacklisted;
+  browserAction.setTitle({ tabId, title });
+  setIcon(tab, data);
+  updateBadge(tab, data);
 }
 
-async function setIcon(tab = {}, data = {}) {
-  const mod = data.blocked && 'b' || !isApplied && 'w' || '';
+async function setIcon({ id: tabId } = {}, data = badges[tabId] || {}) {
+  const mod = !isApplied ? 'w'
+    : data[INJECT] !== true ? 'b'
+      : '';
+  if (data.icon === mod) return;
+  data.icon = mod;
   const pathData = {};
   const iconData = {};
   for (const n of SIZES) {
@@ -186,7 +227,7 @@ async function setIcon(tab = {}, data = {}) {
   }
   // imageData doesn't work in Firefox Android, so we also set path here
   browserAction.setIcon({
-    tabId: tab.id,
+    tabId,
     path: pathData,
     imageData: iconData,
   });

--- a/src/background/utils/index.js
+++ b/src/background/utils/index.js
@@ -1,4 +1,3 @@
-import './storage-fetch';
 export { default as cache } from './cache';
 export { default as getEventEmitter } from './events';
 export * from './message';

--- a/src/background/utils/tab-redirector.js
+++ b/src/background/utils/tab-redirector.js
@@ -3,7 +3,7 @@ import ua from '@/common/ua';
 import cache from './cache';
 import { addPublicCommands, commands } from './message';
 import { parseMeta, isUserScript } from './script';
-import { getTabUrl } from './tabs';
+import { getTabUrl, tabsOnUpdated } from './tabs';
 
 const CONFIRM_URL_BASE = `${extensionRoot}confirm/index.html#`;
 
@@ -77,10 +77,12 @@ async function maybeInstallUserJs(tabId, url) {
 }
 
 if (virtualUrlRe) {
-  const listener = (tabId, { url }) => url && maybeRedirectVirtualUrlFF(tabId, url);
-  const apiEvent = browser.tabs.onUpdated;
-  const addListener = apiEvent.addListener.bind(apiEvent, listener);
-  try { addListener({ properties: ['url'] }); } catch (e) { addListener(); }
+  tabsOnUpdated.addListener(
+    (tabId, { url }) => url && maybeRedirectVirtualUrlFF(tabId, url),
+    ...IS_FIREFOX >= 61
+      ? [{ properties: [IS_FIREFOX >= 88 ? 'url' : 'status'] }]
+      : []
+  );
 }
 
 browser.tabs.onCreated.addListener((tab) => {

--- a/src/background/utils/tabs.js
+++ b/src/background/utils/tabs.js
@@ -23,6 +23,8 @@ const NEWTAB_URL_RE = re`/
 export const getTabUrl = tab => (
   tab.pendingUrl || tab.url || ''
 );
+export const tabsOnUpdated = browser.tabs.onUpdated;
+export const tabsOnRemoved = browser.tabs.onRemoved;
 let cookieStorePrefix;
 
 addOwnCommands({
@@ -150,7 +152,7 @@ addPublicCommands({
   },
 });
 
-browser.tabs.onRemoved.addListener((id) => {
+tabsOnRemoved.addListener((id) => {
   const openerId = openers[id];
   if (openerId >= 0) {
     sendTabCmd(openerId, 'TabClosed', id);

--- a/src/background/utils/values.js
+++ b/src/background/utils/values.js
@@ -1,10 +1,9 @@
 import { isEmpty, sendTabCmd } from '@/common';
-import { forEachEntry, objectGet, objectSet } from '@/common/object';
+import { forEachEntry, nest, objectGet, objectSet } from '@/common/object';
 import { getScript } from './db';
 import { addOwnCommands, addPublicCommands } from './message';
 import storage from './storage';
 
-const nest = (obj, key) => obj[key] || (obj[key] = {}); // eslint-disable-line no-return-assign
 /** { scriptId: { tabId: { frameId: {key: raw}, ... }, ... } } */
 const openers = {};
 let chain = Promise.resolve();

--- a/src/common/consts.js
+++ b/src/common/consts.js
@@ -14,7 +14,6 @@ export const USERSCRIPT_META_INTRO = '// ==UserScript==';
 export const METABLOCK_RE = /((?:^|\n)\s*\/\/\x20==UserScript==)([\s\S]*?\n)\s*\/\/\x20==\/UserScript==|$/;
 export const META_STR = 'metaStr';
 export const NEWLINE_END_RE = /\n((?!\n)\s)*$/;
-export const INJECTABLE_TAB_URL_RE = /^(https?|file|ftps?):/;
 export const WATCH_STORAGE = 'watchStorage';
 // `browser` is a local variable since we remove the global `chrome` and `browser` in injected*
 // to prevent exposing them to userscripts with `@inject-into content`
@@ -35,3 +34,9 @@ export const KNOWN_INJECT_INTO = {
   [PAGE]: 1,
   [CONTENT]: 1,
 };
+export let INJECTABLE_URL_RE;
+if (!process.env.IS_INJECTED && !process.env.TEST) {
+  chrome.extension.isAllowedFileSchemeAccess(ok => {
+    INJECTABLE_URL_RE = ok ? /^(https?|file|ftps?):/ : /^(ht|f)tps?:/;
+  });
+}

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -17,6 +17,7 @@ if (process.env.DEV && process.env.IS_INJECTED !== 'injected-web') {
   }
 }
 
+export const ignoreChromeErrors = () => chrome.runtime.lastError;
 export const browserWindows = browser.windows;
 export const defaultImage = !process.env.IS_INJECTED && `${ICON_PREFIX}128.png`;
 /** Will be encoded to avoid splitting the URL in devtools UI */

--- a/src/common/object.js
+++ b/src/common/object.js
@@ -156,3 +156,7 @@ export function deepSize(val) {
   if (Array.isArray(val)) return val.reduce((sum, v) => sum + 1 + deepSize(v), 2);
   return Object.keys(val).reduce((sum, k) => sum + k.length + 4 + deepSize(val[k]), 2);
 }
+
+export function nest(obj, key) {
+  return obj[key] || (obj[key] = createNullObj());
+}

--- a/src/common/safe-globals-shared.js
+++ b/src/common/safe-globals-shared.js
@@ -28,5 +28,6 @@ export const kResponseText = 'responseText';
 export const kResponseType = 'responseType';
 export const kSessionId = 'sessionId';
 export const kXhrType = 'xhrType';
+export const SKIP_SCRIPTS = 'SkipScripts';
 export const isFunction = val => typeof val === 'function';
 export const isObject = val => val != null && typeof val === 'object';

--- a/src/common/safe-globals.js
+++ b/src/common/safe-globals.js
@@ -20,6 +20,7 @@ export const SafeError = Error; // alias used by browser.js
 export const { apply: safeApply } = Reflect;
 export const hasOwnProperty = safeApply.call.bind(({}).hasOwnProperty);
 export const safeCall = Object.call.bind(Object.call);
+export const createNullObj = Object.create.bind(Object, null);
 export const IS_FIREFOX = !chrome.app;
 export const ROUTE_SCRIPTS = '#' + SCRIPTS;
 export const extensionRoot = chrome.runtime.getURL('/');

--- a/src/injected/content/cmd-run.js
+++ b/src/injected/content/cmd-run.js
@@ -3,13 +3,20 @@ import { sendSetPopup } from './gm-api-content';
 import { nextTask, sendCmd } from './util';
 
 const getPersisted = describeProperty(PageTransitionEvent[PROTO], 'persisted').get;
-const runningIds = [];
+let runningIds;
 let pending;
+let sent;
 
 onScripts.push(() => {
   addHandlers({ Run });
+  runningIds = [];
+});
+on('pageshow', evt => {
   // isTrusted is `unforgeable` per DOM spec
-  on('pageshow', evt => evt.isTrusted && evt::getPersisted() && sendSetBadge());
+  if (evt.isTrusted && evt::getPersisted()) {
+    sent = false;
+    sendSetBadge();
+  }
 });
 
 export function Run(id, realm) {
@@ -18,9 +25,21 @@ export function Run(id, realm) {
   if (!pending) pending = sendSetBadge(2);
 }
 
-async function sendSetBadge(numThrottles) {
-  while (--numThrottles >= 0) await nextTask();
-  sendCmd('SetBadge', runningIds); // not awaiting to clear `pending` immediately
-  sendSetPopup(true);
+export async function sendSetBadge(delayed) {
+  if (delayed === AUTO && (pending || sent)) {
+    return;
+  }
+  while (--delayed >= 0) {
+    await nextTask();
+  }
+  // not awaiting to clear `pending` immediately
+  sendCmd('SetBadge', { [IDS]: runningIds, reset: !sent });
+  sendSetPopup(!!pending);
   pending = false;
+  sent = true;
+}
+
+export function sendSkipScripts() {
+  runningIds = SKIP_SCRIPTS;
+  sendSetBadge();
 }

--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -1,13 +1,12 @@
 import bridge, { addBackgroundHandlers, addHandlers, onScripts } from './bridge';
 import { onClipboardCopy } from './clipboard';
-import { sendSetPopup } from './gm-api-content';
 import { injectPageSandbox, injectScripts } from './inject';
 import './notifications';
 import './requests';
 import './tabs';
 import { sendCmd } from './util';
 import { isEmpty } from '../util';
-import { Run } from './cmd-run';
+import { Run, sendSkipScripts, sendSetBadge } from './cmd-run';
 
 const { [IDS]: ids } = bridge;
 
@@ -33,20 +32,23 @@ async function init() {
       : await dataPromise
   );
   assign(ids, data[IDS]);
-  bridge[INJECT_INTO] = data[INJECT_INTO];
+  if (IS_FIREFOX && !data.clipFF) {
+    off('copy', onClipboardCopy, true);
+  }
+  if ((bridge[INJECT_INTO] = data[INJECT_INTO]) === SKIP_SCRIPTS) {
+    sendSkipScripts();
+    return;
+  }
   if (data[EXPOSE] && !isXml && injectPageSandbox(data)) {
     addHandlers({ GetScriptVer: true });
     bridge.post('Expose');
-  }
-  if (IS_FIREFOX && !data.clipFF) {
-    off('copy', onClipboardCopy, true);
   }
   if (data[SCRIPTS]) {
     onScripts.forEach(fn => fn(data));
     await injectScripts(data, isXml);
   }
   onScripts.length = 0;
-  sendSetPopup();
+  sendSetBadge(AUTO);
 }
 
 addBackgroundHandlers({

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -12,8 +12,8 @@ default_locale: en
 browser_action:
   browser_style: true
   default_icon:
-    '16': public/images/icon16.png
-    '32': public/images/icon32.png
+    '16': public/images/icon16b.png
+    '32': public/images/icon32b.png
   default_title: __MSG_extName__
   default_popup: popup/index.html
 background:
@@ -38,6 +38,7 @@ permissions:
   - storage
   - unlimitedStorage
   - clipboardWrite
+  - contextMenus
   - cookies
 commands:
   _execute_browser_action: {}
@@ -47,6 +48,8 @@ commands:
     description: __MSG_labelSettings__
   newScript:
     description: __MSG_menuNewScript__
+  SkipScripts:
+    description: __MSG_skipScriptsCmd__
 
 minimum_chrome_version: '57.0'
 

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -62,9 +62,9 @@ footer {
   margin: 0 $logoMLR;
   img {
     width: $logoSize;
-  }
-  &.disabled > img {
-    opacity: .5;
+    .scripts-disabled & {
+      opacity: .5;
+    }
   }
 }
 
@@ -89,10 +89,8 @@ footer {
   }
 }
 
-.ext-name {
-  &.disabled {
-    color: var(--fill-8);
-  }
+.scripts-disabled .ext-name {
+  color: var(--fill-8);
 }
 
 .script-icon {
@@ -279,7 +277,7 @@ footer {
 
 .failure-reason {
   padding: .5rem $itemPaddingX .5rem $leftPaneWidth;
-  [data-failure-reason=""] > & {
+  .page-popup:not(.noninjectable) & {
     // Making the warning noticeable at the bottom of the script list
     background: hsla(30, 100%, 50%, .2);
   }

--- a/src/popup/utils/index.js
+++ b/src/popup/utils/index.js
@@ -9,6 +9,8 @@ export const store = reactive({
   injectionFailure: null,
   injectable: true,
   blacklisted: false,
+  skipped: false,
+  tab: null,
 });
 
 export const mutex = {
@@ -20,3 +22,9 @@ export const mutex = {
     });
   },
 };
+
+export function resetStoredScripts() {
+  store.idMap = {};
+  store.scripts.length = 0;
+  store.frameScripts.length = 0;
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -213,7 +213,7 @@ declare interface VMInjection extends VMInjectionDisabled {
   /** content bridge adds the actually running ids and sends via SetPopup */
   ids: number[];
   info: VMInjection.Info;
-  injectInto: VMScriptInjectInto;
+  injectInto: VMScriptInjectInto | 'SkipScripts';
   /** cache key for envDelayed, which also tells content bridge to expect envDelayed */
   more: string;
   nonce?: string;


### PR DESCRIPTION
Fixes #1796.

![image](https://github.com/violentmonkey/violentmonkey/assets/1310400/5fa09159-d547-4b21-a2a8-470c4c2c95a5)

![image](https://github.com/violentmonkey/violentmonkey/assets/1310400/02cd2bfb-d9a8-4409-91ad-5e0e6dc5c0cb)

![image](https://github.com/violentmonkey/violentmonkey/assets/1310400/8651fba7-6e1d-4f63-a088-016600ec0168)

The default icon is gray now.
The color icon is displayed when scripts are actually injected.

