### PR TITLE
refactor: replace `tldjs` w/ `tldts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@violentmonkey/shortcut": "^1.2.6",
     "@zip.js/zip.js": "2.4.4",
     "codemirror": "^5.65.10",
-    "tldjs": "^2.3.1",
+    "tldts": "^6.0.14",
     "vue": "^3.2.45",
     "vueleton": "^2.0.2"
   },

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -2,7 +2,7 @@ import '@/common/browser';
 import { makePause, sendCmd } from '@/common';
 import { TIMEOUT_24HOURS, TIMEOUT_MAX } from '@/common/consts';
 import { deepCopy } from '@/common/object';
-import { getDomain } from 'tldts';
+import { getDomain } from '@/common/tld';
 import * as sync from './sync';
 import { addOwnCommands, addPublicCommands, commands } from './utils';
 import { getData, getSizes, checkRemove } from './utils/db';

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -41,7 +41,7 @@ addOwnCommands({
     const host = url && new URL(url).hostname;
     return {
       host,
-      domain: host && getDomain(host, { allowPrivateDomains: true }) || host,
+      domain: host && getDomain(host) || host,
     };
   },
 });

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -2,7 +2,7 @@ import '@/common/browser';
 import { makePause, sendCmd } from '@/common';
 import { TIMEOUT_24HOURS, TIMEOUT_MAX } from '@/common/consts';
 import { deepCopy } from '@/common/object';
-import { getDomain } from 'tldjs/tld';
+import { getDomain } from 'tldts';
 import * as sync from './sync';
 import { addOwnCommands, addPublicCommands, commands } from './utils';
 import { getData, getSizes, checkRemove } from './utils/db';
@@ -41,7 +41,7 @@ addOwnCommands({
     const host = url && new URL(url).hostname;
     return {
       host,
-      domain: host && getDomain(host) || host,
+      domain: host && getDomain(host, { allowPrivateDomains: true }) || host,
     };
   },
 });

--- a/src/background/utils/tester.js
+++ b/src/background/utils/tester.js
@@ -261,7 +261,7 @@ function matchTld(tstr) {
   const matches = tstr.match(this);
   const suffix = matches?.[1]?.slice(1).toLowerCase();
   // Must return a proper boolean
-  return !!suffix && getPublicSuffix(suffix, { allowPrivateDomains: true }) === suffix;
+  return !!suffix && getPublicSuffix(suffix) === suffix;
 }
 
 function hostMatcher(rule) {

--- a/src/background/utils/tester.js
+++ b/src/background/utils/tester.js
@@ -2,7 +2,7 @@
 import { getScriptPrettyUrl } from '@/common';
 import { BLACKLIST, BLACKLIST_ERRORS } from '@/common/consts';
 import initCache from '@/common/cache';
-import { getPublicSuffix } from 'tldts';
+import { getPublicSuffix } from '@/common/tld';
 import { postInitialize } from './init';
 import { getOption, hookOptions } from './options';
 import storage from './storage';

--- a/src/background/utils/tester.js
+++ b/src/background/utils/tester.js
@@ -2,7 +2,7 @@
 import { getScriptPrettyUrl } from '@/common';
 import { BLACKLIST, BLACKLIST_ERRORS } from '@/common/consts';
 import initCache from '@/common/cache';
-import { getPublicSuffix } from 'tldjs/tld';
+import { getPublicSuffix } from 'tldts';
 import { postInitialize } from './init';
 import { getOption, hookOptions } from './options';
 import storage from './storage';
@@ -261,7 +261,7 @@ function matchTld(tstr) {
   const matches = tstr.match(this);
   const suffix = matches?.[1]?.slice(1).toLowerCase();
   // Must return a proper boolean
-  return !!suffix && getPublicSuffix(suffix) === suffix;
+  return !!suffix && getPublicSuffix(suffix, { allowPrivateDomains: true }) === suffix;
 }
 
 function hostMatcher(rule) {

--- a/src/common/tld.js
+++ b/src/common/tld.js
@@ -1,0 +1,10 @@
+import { getDomain as getDomain_, getPublicSuffix as getPublicSuffix_ } from 'tldts';
+
+/**
+ * tldts does not respect the public suffix list by default, but can be opt in manually
+ * with the option `allowPrivateDomains`. Hoist the `sharedOpts` can also help avoid
+ * re-creating the object every time.
+ */
+const sharedOpts = { allowPrivateDomains: true };
+export const getDomain = url => getDomain_(url, sharedOpts);
+export const getPublicSuffix = url => getPublicSuffix_(url, sharedOpts);

--- a/test/mock/polyfill.js
+++ b/test/mock/polyfill.js
@@ -1,13 +1,9 @@
-import tldRules from 'tldjs/rules.json';
-
 global.chrome =
 global.browser = {
   storage: {
     local: {
       get() {
-        return Promise.resolve({
-          'dat:tldRules': tldRules,
-        });
+        return Promise.resolve({});
       },
       set() {
         return Promise.resolve();

--- a/yarn.lock
+++ b/yarn.lock
@@ -8603,11 +8603,6 @@ pumpify@^1.3.5:
     inherits "^2.0.3"
     pump "^2.0.0"
 
-punycode@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-  integrity sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==
-
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -9976,12 +9971,17 @@ time-stamp@^1.0.0:
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
   integrity sha512-gLCeArryy2yNTRzTGKbZbloctj64jkZ57hj5zdraXue6aFgd6PmvVtEyiUU+hvU0v7q08oVv8r8ev0tRo6bvgw==
 
-tldjs@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tldjs/-/tldjs-2.3.1.tgz#cf09c3eb5d7403a9e214b7d65f3cf9651c0ab039"
-  integrity sha512-W/YVH/QczLUxVjnQhFC61Iq232NWu3TqDdO0S/MtXVz4xybejBov4ud+CIwN9aYqjOecEqIy0PscGkwpG9ZyTw==
+tldts-core@^6.0.14:
+  version "6.0.14"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-6.0.14.tgz#66a325500fc46826b85719b588715f23e167b0e7"
+  integrity sha512-ESYhU/bgs6jiHlnl5h029f+0dB7EKRiTaxM/jHLZ6powScbmsgsrFcFjmyrjDgCvI/BRY79TEBBClmqLNEPyjQ==
+
+tldts@^6.0.14:
+  version "6.0.14"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-6.0.14.tgz#bd126027d456b61e833aa4a49b85f4e7074c3f97"
+  integrity sha512-mYU7xwVGfiiC4lkWr4h3Q6U4kfAq3aWP1KsJZyRlVVeDQ3ZSBLmE20543dWSqI0U799PNzhpHObex5n60TeBGw==
   dependencies:
-    punycode "^1.4.1"
+    tldts-core "^6.0.14"
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
The PR replaces `tldjs` with `tldts`.

`tldjs` is no longer actively maintained. The latest commit of the `tldjs` repository occurred 5 years ago and the prior npm publish of the `tldjs` package was 6 years ago, while the `tldts` remains actively maintained.

Also, `tldts` is about 2x faster than `tldjs`, see benchmark suite: https://replit.com/@isukkaw/tldjs-vs-tldts
