### PR TITLE
feat: add zombieTimeout to GM_notification

### DIFF
--- a/src/background/utils/notifications.js
+++ b/src/background/utils/notifications.js
@@ -56,6 +56,7 @@ export function clearNotifications(tabId, frameId) {
     const op = openers[nid];
     if (op[0] === tabId && (!frameId || op[1] === frameId)) {
       if (op[2]) setTimeout(removeNotification, op[2], nid);
+      else removeNotification(nid);
       delete openers[nid];
     }
   }

--- a/src/background/utils/preinject.js
+++ b/src/background/utils/preinject.js
@@ -9,6 +9,7 @@ import { CACHE_KEYS, getScriptsByURL, PROMISE, REQ_KEYS, VALUE_IDS } from './db'
 import { setBadge } from './icon';
 import { postInitialize } from './init';
 import { addOwnCommands, addPublicCommands } from './message';
+import { clearNotifications } from './notifications';
 import { getOption, hookOptions } from './options';
 import { popupTabs } from './popup-tracker';
 import { clearRequestsByTabId, reifyRequests } from './requests';
@@ -202,6 +203,7 @@ addPublicCommands({
     if (isTop === 3) {
       reifyValueOpener(ids, docId);
       reifyRequests(tabId, docId);
+      clearNotifications(tabId);
     }
     if (reset === 'bfcache' && +ids?.[0]) {
       addValueOpener(ids, tabId, getFrameDocId(isTop, docId, src[kFrameId]));
@@ -606,4 +608,5 @@ function onTabReplaced(addedId, removedId) {
 function clearFrameData(tabId, frameId) {
   clearRequestsByTabId(tabId, frameId);
   clearValueOpener(tabId, frameId);
+  clearNotifications(tabId, frameId);
 }


### PR DESCRIPTION
* auto-remove notification once its initiator context is dead
* to prevent removal, the userscript can specify `zombieTimeout` (number of milliseconds) in `GM_notification` - I wonder if we should limit it to 24hours maybe just in case?