### PR TITLE
feat: show option to allow edits in updated scripts

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -807,7 +807,7 @@ readonly:
   message: Read-only
 readonlyNote:
   description: Warning when trying to type in the editor.
-  message: Auto-updated script is read-only until you disable updates or allow editing.
+  message: Auto-updated script is read-only unless you disable updates or allow editing.
 readonlyOpt:
   description: Option label in the editor, displayed along with readonlyOptWarn.
   message: Allow edits

--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -169,9 +169,6 @@ editNavSettings:
 editNavValues:
   description: Label of values tab in script editor.
   message: Values
-editReadonly:
-  description: Text of the warning when opening an auto-updated script in the editor.
-  message: To enable editing, disallow updates in the Settings tab and click "Save".
 editValueAll:
   description: Button to show/edit the entire script value storage.
   message: All
@@ -805,6 +802,18 @@ optionUpdate:
     Label of the update section in settings and notification title for script
     updates.
   message: Update
+readonly:
+  description: Text in the editor's header for non-editable scripts.
+  message: Read-only
+readonlyNote:
+  description: Warning when trying to type in the editor.
+  message: Auto-updated script is read-only until you disable updates or allow editing.
+readonlyOpt:
+  description: Option label in the editor, displayed along with readonlyOptWarn.
+  message: Allow edits
+readonlyOptWarn:
+  description: Text next to readonlyOpt label in the editor.
+  message: (next update will overwite them)
 reloadTab:
   description: Label of action to reload the tab
   message: Reload tab

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -70,6 +70,7 @@ import 'codemirror/addon/hint/show-hint';
 import 'codemirror/addon/hint/javascript-hint';
 import 'codemirror/addon/hint/anyword-hint';
 import CodeMirror from 'codemirror';
+import { watchEffect } from 'vue';
 import Tooltip from 'vueleton/lib/tooltip';
 import ToggleButton from '@/common/ui/toggle-button';
 import { debounce, getUniqId, i18n, sendCmdDirectly } from '@/common';
@@ -244,7 +245,7 @@ export default {
       this.placeholders = new Map();
       this.placeholderId = 0;
       maxDisplayLength = cm.options.maxDisplayLength;
-      cm.setOption('readOnly', this.readOnly);
+      watchEffect(() => cm.setOption('readOnly', this.readOnly));
       // these are active only in the code nav tab
       cm.state.commands = Object.assign({
         // call own methods explicitly to strip `cm` parameter passed by CodeMirror

--- a/src/common/ui/style/style.css
+++ b/src/common/ui/style/style.css
@@ -410,6 +410,13 @@ body .vl-tooltip {
   }
 }
 
+.scary-switch:checked {
+  accent-color: red;
+  & + span {
+    color: red;
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   input[type="radio"]:not(:checked),
   input[type="checkbox"]:not(:checked) {

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -10,7 +10,6 @@ import '@/common/ui/favicon';
 import '@/common/ui/style';
 import { store } from './utils';
 import App from './views/app';
-import { watchEffect } from 'vue';
 
 // Same order as getSizes and sizesPrefixRe
 const SIZE_TITLES = [
@@ -56,10 +55,8 @@ function initScript(script, sizes) {
     sizes: str.slice(0, -1).replace(/\x20/g, '\xA0').replace(/[^B]$/gm, '$&B'),
     sizeNum: total,
   };
-  watchEffect(() => {
-    script.$canUpdate = getScriptUpdateUrl(script)
-      && (script.config.shouldUpdate ? 1 : -1 /* manual */);
-  });
+  script.$canUpdate = getScriptUpdateUrl(script)
+    && (script.config.shouldUpdate ? 1 : -1 /* manual */);
   loadScriptIcon(script, store, true);
 }
 

--- a/src/options/style.css
+++ b/src/options/style.css
@@ -69,6 +69,9 @@ aside {
 .text-red {
   color: red;
 }
+.text-upper {
+  text-transform: uppercase;
+}
 section {
   padding: 0 0 $tabPadY;
   > h3 {

--- a/src/options/style.css
+++ b/src/options/style.css
@@ -69,9 +69,6 @@ aside {
 .text-red {
   color: red;
 }
-.text-right {
-  text-align: right;
-}
 section {
   padding: 0 0 $tabPadY;
   > h3 {

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -13,12 +13,8 @@
         <span class="subtle" v-if="script.config.removed" v-text="i18n('headerRecycleBin') + ' / '"/>
         {{scriptName}}
       </div>
-      <a class="frozen-hint text-right text-red" v-text="i18n('readonly')" v-if="frozen"
-         v-bind="script.config.removed ? {} : {
-           tabIndex: 0,
-           onclick: showNote,
-         }"/>
-      <div class="edit-hint text-right ellipsis" v-else>
+      <p v-if="frozen" class="text-upper text-right text-red" v-text="i18n('readonly')"/>
+      <div v-else class="edit-hint text-right ellipsis">
         <a href="https://violentmonkey.github.io/posts/how-to-edit-scripts-with-your-favorite-editor/"
            target="_blank"
            rel="noopener noreferrer"
@@ -343,9 +339,6 @@ export default {
     saveClose() {
       this.save().then(this.close);
     },
-    showNote() {
-      this.note = true;
-    },
     switchPanel(step) {
       const keys = Object.keys(this.navItems);
       this.nav = keys[(keys.indexOf(this.nav) + step + keys.length) % keys.length];
@@ -361,20 +354,10 @@ export default {
       const { config } = script;
       const { removed } = config;
       const remote = script._remote = !!getScriptUpdateUrl(script);
-      const frozen = !!(
-        removed ||
-        this.readOnly ||
-        remote && (collectShouldUpdate(config) === 1)
-      );
-      if (this.frozen !== frozen) {
-        this.frozen = frozen;
-        if (!removed) {
-          this.$nextTick(() => {
-            this.$refs.code.$el::(frozen ? addEventListener : removeEventListener)(
-              'keypress', this.showNote, {once: true});
-          });
-        }
-      }
+      const remoteMode = remote && collectShouldUpdate(config);
+      const frozen = !!(removed || remoteMode === 1 || this.readOnly);
+      this.frozen = frozen;
+      this.note = !removed && (frozen || remoteMode >= 1);
       if (!removed && evt) this.onDirty();
     },
     onDirty() {
@@ -489,12 +472,6 @@ export default {
     background: var(--bg);
     padding: .5em 1em;
     border-bottom: var(--border);
-  }
-  .frozen-hint {
-    text-transform: uppercase;
-    &[tabindex]:hover {
-      text-decoration: underline;
-    }
   }
   &.readOnly &-header button:nth-last-child(n + 2) {
     display: none;

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -35,7 +35,7 @@
     <div class="frozen-note mr-2c flex flex-wrap" v-if="note && nav === 'code'">
       <p v-text="i18n('readonlyNote')"/>
       <keep-alive>
-        <VMSettingsUpdate class="flex ml-2c" :script="script" @change="onChange"/>
+        <VMSettingsUpdate class="flex ml-2c" :script="script" @change="onChangeLater"/>
       </keep-alive>
     </div>
 
@@ -55,7 +55,7 @@
       class="edit-body"
       v-if="nav === 'settings'"
       v-bind="{readOnly, script}"
-      @input="onChange"
+      @input="onChangeLater"
     />
     <vm-values
       class="edit-body"
@@ -248,6 +248,7 @@ export default {
     script: 'onScript',
   },
   created() {
+    this.onChangeLater = debounce(this.onChange);
     this.script = deepCopy(this.initial);
     this.toggleUnloadSentry = getUnloadSentry(null, () => {
       this.$refs.code.cm.focus();

--- a/src/options/views/edit/settings-update.vue
+++ b/src/options/views/edit/settings-update.vue
@@ -1,0 +1,44 @@
+<template>
+  <div>
+    <div class="form-group condensed">
+      <label>
+        <input type="checkbox" v-model="config.shouldUpdate" v-bind="{disabled}">
+        <span v-text="i18n('labelAllowUpdate')"/>
+        <span v-text="i18n('labelNotifyThisUpdated')"/>
+      </label>
+      <label class="ml-1" :key="value" v-for="([text, value]) of [
+        [i18n('genericOn'), '1'],
+        [i18n('genericOff'), '0'],
+        [i18n('genericUseGlobal'), ''],
+      ]"><!-- make sure to place the input and span on one line with a space between -->
+        <input type="radio" v-bind="{value, disabled}"
+               v-model="config.notifyUpdates"> <span v-text="text"/>
+      </label>
+    </div>
+    <label>
+      <input type="checkbox" v-model="config._editable" class="scary-switch"
+             :disabled="disabled || !config.shouldUpdate">
+      <span v-text="i18n('readonlyOpt')"/> <span v-text="i18n('readonlyOptWarn')"/>
+    </label>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['script'],
+  computed: {
+    config() {
+      return this.script.config;
+    },
+    disabled() {
+      return !this.script._remote;
+    },
+  },
+};
+</script>
+
+<style>
+.frozen-note .form-group > :nth-child(n + 2) {
+  display: none;
+}
+</style>

--- a/src/options/views/edit/settings-update.vue
+++ b/src/options/views/edit/settings-update.vue
@@ -4,9 +4,9 @@
       <label>
         <input type="checkbox" v-model="config.shouldUpdate" v-bind="{disabled}">
         <span v-text="i18n('labelAllowUpdate')"/>
-        <span v-text="i18n('labelNotifyThisUpdated')"/>
+        <span v-text="i18n('labelNotifyThisUpdated')" class="melt"/>
       </label>
-      <label class="ml-1" :key="value" v-for="([text, value]) of [
+      <label class="ml-1 melt" :key="value" v-for="([text, value]) of [
         [i18n('genericOn'), '1'],
         [i18n('genericOff'), '0'],
         [i18n('genericUseGlobal'), ''],
@@ -38,7 +38,7 @@ export default {
 </script>
 
 <style>
-.frozen-note .form-group > :nth-child(n + 2) {
+.frozen-note .melt {
   display: none;
 }
 </style>

--- a/src/options/views/edit/settings.vue
+++ b/src/options/views/edit/settings.vue
@@ -1,20 +1,7 @@
 <template>
   <div class="edit-settings" ref="container">
     <h4 v-text="i18n('editLabelSettings')"></h4>
-    <div class="form-group condensed">
-      <label>
-        <input type="checkbox" v-model="config.shouldUpdate" :disabled="readOnly">
-        <span v-text="i18n('labelAllowUpdate')"></span>
-      </label>
-      <span v-text="i18n('labelNotifyThisUpdated')"/>
-      <label class="ml-1" :key="value" v-for="([text, value]) of [
-        [i18n('genericOn'), '1'],
-        [i18n('genericOff'), '0'],
-        [i18n('genericUseGlobal'), ''],
-      ]"><!-- make sure to place the input and span on one line with a space between -->
-        <input type="radio" :value="value" v-model="config.notifyUpdates" :disabled="readOnly"> <span v-text="text"/>
-      </label>
-    </div>
+    <VMSettingsUpdate v-bind="{script}"/>
     <h4 v-text="i18n('editLabelMeta')"></h4>
     <!-- Using tables to auto-adjust width, which differs substantially between languages -->
     <table>
@@ -102,11 +89,15 @@ import { getScriptHome, i18n } from '@/common';
 import { KNOWN_INJECT_INTO } from '@/common/consts';
 import { objectGet } from '@/common/object';
 import { focusMe } from '@/common/ui';
+import VMSettingsUpdate from './settings-update';
 
 const highlightMetaKeys = str => str.match(/^(.*?)(@[-a-z]+)(.*)/)?.slice(1) || [str, '', ''];
 
 export default {
-  props: ['active', 'settings', 'value', 'readOnly'],
+  props: ['script', 'readOnly'],
+  components: {
+    VMSettingsUpdate,
+  },
   data() {
     return {
       KII: KNOWN_INJECT_INTO,
@@ -114,13 +105,13 @@ export default {
   },
   computed: {
     custom() {
-      return this.settings.custom || {};
+      return this.script.custom;
     },
     config() {
-      return this.settings.config || {};
+      return this.script.config;
     },
     placeholders() {
-      const { value } = this;
+      const value = this.script;
       return {
         name: objectGet(value, 'meta.name'),
         homepageURL: getScriptHome(value),
@@ -145,12 +136,8 @@ export default {
       ];
     },
   },
-  watch: {
-    active(val) {
-      if (val) {
-        focusMe(this.$el);
-      }
-    },
+  activated() {
+    focusMe(this.$el);
   },
 };
 </script>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -143,7 +143,8 @@ declare namespace VMScript {
   type Config = {
     enabled: NumBool;
     removed: NumBool;
-    shouldUpdate: NumBool;
+    /** 2 = allow updates and local edits */
+    shouldUpdate: NumBool | 2;
     notifyUpdates?: NumBoolNull;
   }
   type Custom = {


### PR DESCRIPTION
Fixes #1901.

Stage | pic
-|-
Editor right after opening is gray, there's a red hint, and no buttons to save | ![image](https://github.com/violentmonkey/violentmonkey/assets/1310400/46073f46-41d4-4a61-bc13-1e339b237f1f)
Editor after trying to type or clicking the red label (it's clickable only for non-removed scripts) | ![image](https://github.com/violentmonkey/violentmonkey/assets/1310400/e016d394-01ef-4e12-a43f-7f0e1499ceb7)
When enabled the option becomes red and the note stays on screen until the script is saved | ![image](https://github.com/violentmonkey/violentmonkey/assets/1310400/7e615ef3-31f2-417d-965c-f4ff657774e8)
The option in the settings tab is also red when enabled | ![image](https://github.com/violentmonkey/violentmonkey/assets/1310400/8034ff6a-487f-4c4a-aa5b-0e9fb6aa06f1)

* I've extracted the update option into a separate component, hopefully correctly - it seems to work correctly at least.
* To make everything reactive I got rid of `settings` and just used a copy of the original script.
* Added `<keep-alive>` for the tabs in the editor and switched to `v-if`
