### PR TITLE
perf: improve `tldts.getDomain` speed

### DIFF
--- a/src/common/tld.js
+++ b/src/common/tld.js
@@ -4,7 +4,19 @@ import { getDomain as getDomain_, getPublicSuffix as getPublicSuffix_ } from 'tl
  * tldts does not respect the public suffix list by default, but can be opt in manually
  * with the option `allowPrivateDomains`. Hoist the `sharedOpts` can also help avoid
  * re-creating the object every time.
+ *
+ * Note `extractHostname` and `validateHostname` are set to false because the inputs are
+ * from `new URL(url).hostname` and are known to be valid
  */
-const sharedOpts = { allowPrivateDomains: true };
-export const getDomain = url => getDomain_(url, sharedOpts);
-export const getPublicSuffix = url => getPublicSuffix_(url, sharedOpts);
+const getDomainSharedOpts = {
+  allowPrivateDomains: true,
+  extractHostname: false, // inputs are already hostnames
+  validateHostname: false, // inputs are already valid, no need to perform extra validation
+};
+
+const getPublicSuffixSharedOpts = {
+  allowPrivateDomains: true
+};
+
+export const getDomain = url => getDomain_(url, getDomainSharedOpts);
+export const getPublicSuffix = url => getPublicSuffix_(url, getPublicSuffixSharedOpts);


### PR DESCRIPTION
Address suggestions from @remusao (https://github.com/violentmonkey/violentmonkey/pull/1883#discussion_r1359305249).

Update `getDomainSharedOpts` for `getDomain` as inputs are known to be valid hostnames.

The `getPublicSuffix` still uses the old options, as `getPublicSuffix` is only used in unit test cases and inputs can be invalid.