### PR TITLE
feat: add `Enable` option in editor settings

### DIFF
--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -274,6 +274,7 @@ async function save() {
       id,
       code: $codeComp.getRealContent(),
       config: {
+        enabled: +config.enabled,
         notifyUpdates: notifyUpdates ? +notifyUpdates : null, // 0, 1, null
         shouldUpdate: collectShouldUpdate(config), // 0, 1, 2
       },
@@ -343,6 +344,7 @@ function onScript(scr) {
   const { shouldUpdate } = config;
   // Matching Vue model types, so deepEqual can work properly
   config._editable = shouldUpdate === 2;
+  config.enabled = !!config.enabled;
   config.shouldUpdate = !!shouldUpdate;
   config.notifyUpdates = nullBool2string(config.notifyUpdates);
   custom.noframes = nullBool2string(custom.noframes);

--- a/src/options/views/edit/settings.vue
+++ b/src/options/views/edit/settings.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="edit-settings">
     <h4 v-text="i18n('editLabelSettings')"></h4>
+    <div class="mb-2">
+      <label>
+        <input type="checkbox" v-model="config.enabled">
+        <span v-text="i18n('buttonEnable')"/>
+      </label>
+    </div>
     <VMSettingsUpdate v-bind="{script}"/>
     <h4 v-text="i18n('editLabelMeta')"></h4>
     <!-- Using tables to auto-adjust width, which differs substantially between languages -->
@@ -101,6 +107,7 @@ const props = defineProps({
 const KII = shallowRef(KNOWN_INJECT_INTO);
 
 const highlightMetaKeys = str => str.match(/^(.*?)(@[-a-z]+)(.*)/)?.slice(1) || [str, '', ''];
+const config = computed(() => props.script.config);
 const custom = computed(() => props.script.custom);
 const placeholders = computed(() => {
   const { script } = props;


### PR DESCRIPTION
I've used an existing translatable string `Enable`:

![image](https://github.com/violentmonkey/violentmonkey/assets/1310400/997e8ced-390e-4bfd-a1b8-b8161c44662c)

fixes #1953