### PR TITLE
chore: update to marceloprado/has-changed-path@v1.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload to Transifex - check src
         if: github.event_name == 'push' || github.event.pull_request.merged == true
-        uses: marceloprado/has-changed-path@v1
+        uses: marceloprado/has-changed-path@v1.0.1
         id: changed-path-src
         with:
           paths: src


### PR DESCRIPTION
`marceloprado/has-changed-path@v1` is the old version which is running with node12.
`marceloprado/has-changed-path@v1.0.1` is the latest version which is running with node16.

## `marceloprado/has-changed-path`

<img width="473" alt="Screen Shot 2023-11-30 at 21 00 29" src="https://github.com/violentmonkey/violentmonkey/assets/44498510/fb451c9d-8a5f-47b4-9aa9-a03d395d39c1">

<img width="1309" alt="Screen Shot 2023-11-30 at 21 00 39" src="https://github.com/violentmonkey/violentmonkey/assets/44498510/87d2bd34-632e-4593-9063-9b2691dfee99">

The updated `marceloprado/has-changed-path@v1.0.1` shall be used instead.

## What it resolves?

Omit this in every CI build. (Example [here](https://github.com/violentmonkey/violentmonkey/actions/runs/6999663021))

<img width="1129" alt="Screen Shot 2023-11-30 at 21 06 17" src="https://github.com/violentmonkey/violentmonkey/assets/44498510/3cd4a3d3-6c5d-4601-b8e0-f87f4983f6f1">

Cc:  @gera2ld 