### PR TITLE
feat: add "Reset settings" and "Remove all scripts"

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -78,6 +78,9 @@ buttonReplaceAll:
 buttonReset:
   description: Button to reset to default values.
   message: Reset
+buttonResetSettings:
+  description: Button in settings page to reset all settings
+  message: Reset settings
 buttonRestore:
   description: Button to restore a removed script.
   message: Restore
@@ -306,6 +309,10 @@ labelAutoUpdate:
 labelBackup:
   description: Label of the import/export section in settings.
   message: Backup
+  touched: false
+labelBackupMaintenance:
+  description: Label of the import/export/maintenance section in settings.
+  message: Backup and maintenance
 labelBadge:
   description: Label for option to show number on badge.
   message: 'Display on badge: '
@@ -853,6 +860,16 @@ reloadTabTrackHint:
   message: >-
     If enabled, the active tab will be reloaded when changes are detected and
     this script matches the tab's URL.
+removeAllScripts:
+  description: Button to remove all scripts
+  message: Remove all scripts
+removeAllScriptsConfirm:
+  description: Confirmation shown after clicking the `Remove all scripts` button.
+  message: >-
+    Move all scripts to "Recycle Bin"?
+
+    It will be emptied automatically after a while. You can also open it and
+    empty it explicitly.
 searchCaseSensitive:
   description: Option to perform a case-sensitive search
   message: Case sensitive

--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -127,6 +127,13 @@ confirmNotSaved:
   message: |-
     Modifications are not saved!
     Click OK to discard them or cancel to stay.
+confirmUndoImport:
+  description: >-
+    Tooltip of the Undo button after importing a zip in settings. The same text
+    is also shown as a confirmation dialog after clicking this button.
+  message: >-
+    Revert all changes made to the database (importing, updating, editing,
+    customizing)
 descBlacklist:
   description: HTML Description for the global blacklist.
   message: URL matched in this list will not be injected by scripts.

--- a/src/background/utils/options.js
+++ b/src/background/utils/options.js
@@ -1,4 +1,4 @@
-import { debounce, ensureArray, initHooks, normalizeKeys, sendCmd } from '@/common';
+import { debounce, initHooks, normalizeKeys, sendCmd } from '@/common';
 import { deepCopy, deepEqual, objectGet, objectSet } from '@/common/object';
 import defaults from '@/common/options-defaults';
 import { addOwnCommands, init } from './init';
@@ -12,13 +12,11 @@ addOwnCommands({
     return Object.assign({}, defaults, options); // eslint-disable-line no-use-before-define
   },
   /**
-   * @param {{key:string, value?:PlainJSONValue, reply?:boolean}|Array} data
+   * @param {{ [key:string]: PlainJSONValue }} data
    * @return {void}
    * @throws {?} hooks can throw after the option was set */
   SetOptions(data) {
-    for (const { key, value, reply } of ensureArray(data)) {
-      setOption(key, value, reply);
-    }
+    for (const key in data) setOption(key, data[key], true);
     callHooks(); // exceptions will be sent to the caller
   },
 });

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -20,7 +20,7 @@ export default {
     // the updated options object will be propagated from the background script after a pause
     // so meanwhile the local code should be able to see the new value using options.get()
     objectSet(options, key, value);
-    return sendCmdDirectly('SetOptions', { key, value, reply: true });
+    return sendCmdDirectly('SetOptions', { [key]: value });
   },
   update(data) {
     // Keys in `data` may be { flattened.like.this: 'foo' }

--- a/src/options/utils/index.js
+++ b/src/options/utils/index.js
@@ -1,4 +1,5 @@
 import { reactive } from 'vue';
+import { sendCmdDirectly } from '@/common';
 import { route } from '@/common/router';
 
 export const store = reactive({
@@ -15,3 +16,10 @@ export const store = reactive({
   sync: [],
   title: null,
 });
+
+export function markRemove(script, removed) {
+  return sendCmdDirectly('MarkRemoved', {
+    id: script.props.id,
+    removed,
+  });
+}

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -156,7 +156,7 @@ import SettingCheck from '@/common/ui/setting-check';
 import Icon from '@/common/ui/icon';
 import LocaleGroup from '@/common/ui/locale-group';
 import { customCssElem, findStyleSheetRules } from '@/common/ui/style';
-import { store } from '../utils';
+import { markRemove, store } from '../utils';
 import toggleDragging from '../utils/dragging';
 import ScriptItem from './script-item';
 import Edit from './edit';
@@ -469,12 +469,6 @@ function selectScript(index) {
   if (index !== state.focusedIndex) {
     state.focusedIndex = index;
   }
-}
-function markRemove(script, removed) {
-  return sendCmdDirectly('MarkRemoved', {
-    id: script.props.id,
-    removed,
-  });
 }
 function handleActionRemove(script) {
   if (!script.config.removed) {

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -74,9 +74,11 @@
       </div>
     </section>
     <section class="mb-2c">
-      <h3 v-text="i18n('labelBackup')" />
+      <h3 v-text="i18n('labelBackupMaintenance')" />
       <vm-import></vm-import>
       <vm-export></vm-export>
+      <hr>
+      <vm-maintenance/>
     </section>
     <vm-sync></vm-sync>
     <details v-for="(obj, key) in {showAdvanced: settings}" :key="key" :open="obj[key]">
@@ -173,6 +175,7 @@ import LocaleGroup from '@/common/ui/locale-group';
 import SettingText from '@/common/ui/setting-text';
 import VmImport from './vm-import';
 import VmExport from './vm-export';
+import VmMaintenance from './vm-maintenance';
 import VmSync from './vm-sync';
 import VmEditor from './vm-editor';
 import VmBlacklist from './vm-blacklist';
@@ -249,6 +252,7 @@ export default {
   components: {
     VmImport,
     VmExport,
+    VmMaintenance,
     VmSync,
     VmEditor,
     VmBlacklist,

--- a/src/options/views/tab-settings/vm-import.vue
+++ b/src/options/views/tab-settings/vm-import.vue
@@ -2,9 +2,6 @@
   <div>
     <button v-text="i18n('buttonImportData')" @click="pickBackup" ref="buttonImport"
             :disabled="store.importing"/>
-    <tooltip :content="i18n('hintVacuum')">
-      <button @click="vacuum" :disabled="vacuuming" v-text="labelVacuum" />
-    </tooltip>
     <div class="mt-1">
       <setting-check name="importScriptData" :label="labelImportScriptData" />
       <br>
@@ -21,7 +18,6 @@
 
 <script setup>
 import { onMounted, reactive, ref } from 'vue';
-import Tooltip from 'vueleton/lib/tooltip';
 import { ensureArray, i18n, isEmpty, sendCmdDirectly, trueJoin } from '@/common';
 import { RUN_AT_RE } from '@/common/consts';
 import options from '@/common/options';
@@ -32,10 +28,8 @@ import { store } from '../../utils';
 
 const reports = reactive([]);
 const buttonImport = ref();
-const vacuuming = ref(false);
 const labelImportScriptData = i18n('labelImportScriptData');
 const labelImportSettings = i18n('labelImportSettings');
-const labelVacuum = ref(i18n('buttonVacuum'));
 
 onMounted(() => {
   const toggleDragDrop = initDragDrop(buttonImport.value);
@@ -49,18 +43,6 @@ function pickBackup() {
   input.accept = '.zip';
   input.onchange = () => importBackup(input.files?.[0]);
   input.click();
-}
-
-async function vacuum() {
-  vacuuming.value = true;
-  labelVacuum.value = i18n('buttonVacuuming');
-  const { fixes, errors } = await sendCmdDirectly('Vacuum');
-  const errorText = errors?.join('\n');
-  vacuuming.value = false;
-  labelVacuum.value = i18n('buttonVacuumed') + (fixes ? ` (${fixes})` : '');
-  if (errorText) {
-    showConfirmation(i18n('msgErrorFetchingResource') + '\n\n' + errorText, { cancel: false });
-  }
 }
 
 async function importBackup(file) {
@@ -98,8 +80,7 @@ async function doImportBackup(file) {
     sendCmdDirectly('SetValueStores', values);
   }
   if (importSettings) {
-    sendCmdDirectly('SetOptions',
-      toObjectArray(vm.settings, ([key, value]) => key !== 'sync' && { key, value }));
+    sendCmdDirectly('SetOptions', vm.settings);
   }
   sendCmdDirectly('CheckPosition');
   await reader.close();

--- a/src/options/views/tab-settings/vm-import.vue
+++ b/src/options/views/tab-settings/vm-import.vue
@@ -80,7 +80,7 @@ async function doImportBackup(file) {
   const values = vm.values || {};
   let now;
   if (!undoPort) {
-    now = ' => ' + new Date().toLocaleTimeString();
+    now = ' ⯈ ' + new Date().toLocaleTimeString();
     undoPort = chrome.runtime.connect({ name: 'undoImport' });
     await new Promise(resolveOnUndoMessage);
   }

--- a/src/options/views/tab-settings/vm-maintenance.vue
+++ b/src/options/views/tab-settings/vm-maintenance.vue
@@ -57,7 +57,6 @@ function resetSettings() {
     'lastModified',
     'lastUpdate',
     'sync',
-    'version',
   ];
   const diff = defaults::mapEntry(null, (key, defVal) => !ignoredKeys.includes(key)
     && !deepEqual(defVal, options.get(key))

--- a/src/options/views/tab-settings/vm-maintenance.vue
+++ b/src/options/views/tab-settings/vm-maintenance.vue
@@ -36,7 +36,7 @@ function setBusy(val) {
 }
 
 async function confirmDanger(fn, title) {
-  if (!await showConfirmation(title, {ok: {className: 'has-error'}})) {
+  if (!await showConfirmation(title, { ok: { className: 'has-error' } })) {
     return;
   }
   try {

--- a/src/options/views/tab-settings/vm-maintenance.vue
+++ b/src/options/views/tab-settings/vm-maintenance.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="mr-1c">
+    <tooltip :content="i18n('hintVacuum')">
+      <button @click="vacuum" :disabled="busy" v-text="labelVacuum" />
+    </tooltip>
+    <button @click="confirmDanger(removeAllScripts, i18nRemoveAllTitle)"
+            :disabled="busy || !store.scripts.length"
+            v-text="i18n('removeAllScripts')" />
+    <button @click="confirmDanger(resetSettings, i18nResetSettings)"
+            :disabled="busy"
+            :title="resetHint"
+            v-text="resetText" />
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import Tooltip from 'vueleton/lib/tooltip';
+import { i18n, sendCmdDirectly } from '@/common';
+import options from '@/common/options';
+import defaults from '@/common/options-defaults';
+import { deepEqual, mapEntry } from '@/common/object';
+import { showConfirmation } from '@/common/ui';
+import { markRemove, store } from '../../utils';
+
+const labelVacuum = ref(i18n('buttonVacuum'));
+const i18nRemoveAllTitle = i18n('removeAllScriptsConfirm').replace(/\n+/, '\n\n');
+const i18nResetSettings = i18n('buttonResetSettings');
+const busy = ref(false);
+const resetHint = ref('');
+const resetText = ref(i18nResetSettings);
+
+function setBusy(val) {
+  busy.value = val;
+  store.importing = val || null;
+}
+
+async function confirmDanger(fn, title) {
+  if (!await showConfirmation(title, {ok: {className: 'has-error'}})) {
+    return;
+  }
+  try {
+    setBusy(true);
+    await fn();
+  } finally {
+    setBusy(false);
+  }
+}
+
+async function removeAllScripts() {
+  await Promise.all(store.scripts.map(s => markRemove(s, true)));
+  store.scripts = []; // nuking the ghosts because the user's intent was already confirmed
+}
+
+function resetSettings() {
+  const ignoredKeys = [
+    'lastModified',
+    'lastUpdate',
+    'sync',
+    'version',
+  ];
+  const diff = defaults::mapEntry(null, (key, defVal) => !ignoredKeys.includes(key)
+    && !deepEqual(defVal, options.get(key))
+    && key);
+  resetHint.value = JSON.stringify(diff, null, 2)
+    .slice(1, -1).replace(/^\s{2}/gm, '');
+  resetText.value = `${i18nResetSettings} (${Object.keys(diff).length})`;
+  return sendCmdDirectly('SetOptions', diff);
+}
+
+async function vacuum() {
+  setBusy(true);
+  labelVacuum.value = i18n('buttonVacuuming');
+  const { fixes, errors } = await sendCmdDirectly('Vacuum');
+  const errorText = errors?.join('\n');
+  setBusy(false);
+  labelVacuum.value = i18n('buttonVacuumed') + (fixes ? ` (${fixes})` : '');
+  if (errorText) {
+    showConfirmation(i18n('msgErrorFetchingResource') + '\n\n' + errorText, { cancel: false });
+  }
+}
+</script>


### PR DESCRIPTION
* fixes #1995: add `Reset settings` and `Remove all scripts` buttons in VM settings page.
   * Both show a confirmation first
   * Resetting, like vacuuming, shows the number of changes in the button's text + json values in the tooltip
   * Removing uses Recycle bin to make it harder to shoot oneself in the leg by accident

* show `Undo` as a button next to `Import` button after importing instead of a post-import confirmation, which was both redundant and inconvenient as closing it would lose the button so the users had to open a new tab for Violentmonkey dashboard or settings if they wanted to test something and possibly undo it.

@gera2ld, WDYT? Also, editing+saving a locale doesn't run `copyI18n` in gulpfile anymore (even though it has gulp.watch for the paths) while running `gulp dev`, probably after updating gulp to v4.