### PR TITLE
[WIP] Add support for nativeConnect

### DIFF
--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -92,4 +92,5 @@ export default {
   valueEditor: defaultsValueEditor,
   /** @type {'' | 'dark' | 'light'} */
   uiTheme: '',
+  allowNativeMessaging: false,
 };

--- a/src/injected/web/gm-api-wrapper.js
+++ b/src/injected/web/gm-api-wrapper.js
@@ -59,9 +59,11 @@ export function makeGmApiWrapper(script) {
   }
   assign(gm, componentUtils);
   for (let name of grant) {
-    let fn, fnGm4, gmName, gm4name;
+    let fn, fnGm4, gmName, gm4name, extra;
+    if (name.startsWith('GM_nativeConnect')) [name, ...extra] = name.split(' ');
     if (name::slice(0, 3) === 'GM.' && (gm4name = name::slice(3)) && (fnGm4 = GM4_ALIAS[gm4name])
     || (fn = GM_API.bound[gmName = gm4name ? `GM_${gm4name}` : name])) {
+      if (name === 'GM_nativeConnect') fn = fn(extra);
       fn = safeBind(fnGm4 || fn,
         fnGm4 || gm4name in GM4_ASYNC
           ? contextAsync || (contextAsync = assign(createNullObj(), { async: true }, context))

--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -6,6 +6,7 @@ import { onRequestCreate, onRequestInitError } from './requests';
 import { createNotification } from './notifications';
 import { decodeValue, dumpValue, loadValues, changeHooks } from './gm-values';
 import { jsonDump } from './util';
+import {nativeConnect} from "./native";
 
 const resolveOrReturn = (context, val) => (
   context.async ? promiseResolve(val) : val
@@ -137,6 +138,16 @@ export const GM_API = {
     },
     GM_notification: createNotification,
     GM_xmlhttpRequest: gmXmlHttpRequest,
+    /**
+     * @this {GMContext}
+     * @param {String} app
+     */
+    GM_nativeConnect(apps) {
+      return function(app) {
+        if (app in apps)
+          return nativeConnect(this.id, app);
+      }
+    },
   },
   free: {
     __proto__: null,

--- a/src/injected/web/native.js
+++ b/src/injected/web/native.js
@@ -1,0 +1,64 @@
+import bridge from './bridge';
+import handlers from "@/common/handlers";
+
+const eventTargets = new Map();
+const eventTargetHandles = new WeakMap();
+
+let counter = 0;
+
+Object.assign(handlers, {
+  NativeConnectionEvent(handle, event, detail) {
+    const target = eventTargets.get(handle);
+    if (target)
+      target.dispatchEvent(new CustomEvent(event, {detail}));
+  },
+});
+
+function _post(conn, msg) {
+  const handle = eventTargetHandles.get(conn);
+  if (handle !== undefined)
+    bridge.post('NativePostMessage', {handle, msg});
+}
+
+function _disconnect(conn) {
+  const handle = eventTargetHandles.get(conn);
+  if (handle !== undefined)
+    bridge.post('NativeDisconnect', {handle});
+}
+
+class NativeConnection extends EventTarget {
+  constructor() {
+    super();
+    this.onDisconnect = {
+      addListener: cb => this.addEventListener("disconnect", cb),
+      removeListener: cb => this.removeEventListener("disconnect", cb),
+    };
+    this.onMessage = {
+      addListener: cb => this.addEventListener("message", cb),
+      removeListener: cb => this.removeEventListener("message", cb),
+    };
+  }
+
+  postMessage(msg) {
+    _post(this, msg);
+  }
+
+  disconnect() {
+    _disconnect(this);
+  }
+}
+
+export function nativeConnect(id, app) {
+  if (eventTargets.size >= Number.MAX_VALUE) throw new Error("Maximum connections exceeded");
+  const conn = new NativeConnection();
+  if (counter >= Number.MAX_VALUE) counter = Number.MIN_VALUE;
+  let handle = counter++;
+  while (eventTargets.has(handle)) {
+    if (counter >= Number.MAX_VALUE) counter = Number.MIN_VALUE;
+    handle = counter++;
+  }
+  eventTargets.set(handle, conn);
+  eventTargetHandles.set(conn, handle);
+  bridge.post('NativeConnect', {id, app, handle});
+  return conn;
+}

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -40,6 +40,8 @@ permissions:
   - clipboardWrite
   - contextMenus
   - cookies
+optional_permissions:
+  - nativeMessaging
 commands:
   _execute_browser_action: {}
   dashboard:

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -155,6 +155,13 @@
         <p v-html="i18n('descCustomCSS')"/>
         <setting-text name="customCSS"/>
       </section>
+
+      <section class="mb-1c">
+        <h3 v-text="i18n('optionSecurity')"/>
+        <div class="ml-2c flex flex-col">
+          <setting-check name="allowNativeMessaging" :label="i18n('labelNativeMessaging')" />
+        </div>
+      </section>
     </details>
   </div>
 </template>


### PR DESCRIPTION
There are a number of issues/discussions/feature requests for various mechanisms that allow accessing host resources from ViolentMonkey or other User Script managers. 

This adds the `GM_nativeConnect` API that allows a user to configure access to an application on the host to communicate with that doesn't require running a separate web server. 

It forwards the [Native Messaging](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging) API to user scripts with restrictions.

Due to how potentially dangerous this feature is I have added a global setting to allow access to GM_nativeConnect that is disabled by default. With that I have also extended the `@grant` meta data to require listing native application ids with the grant.

```
@grant GM_nativeConnect myapp1 node
```

Additionally this requires the user to configure apps with the browser by placing manifest files in the [correct locations](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#manifest_location) on their system.

```json
{
  "name": "node",
  "description": "NodeJS",
  "path": "/usr/bin/node",
  "type": "stdio",
  "allowed_extensions": ["{aecec67f-0d10-4fa7-b7c7-609a2db280cf}"]
}
```

An example script that allows reading a file from the system:

```js
// ==UserScript==
// @name        New script
// @namespace   Violentmonkey Scripts
// @match       *://example.org/*
// @grant       GM_nativeConnect node
// @version     1.0
// @author      -
// @description 20/04/2024, 14:33:18
// ==/UserScript==

const port = GM_nativeConnect("node");
port.onMessage.addListener(data=>console.log(data));
port.postMessage(`
const fs = require('fs');
console.log(fs.readFileSync('/path/to/input.txt',{ encoding: 'utf8', flag: 'r' }));
`);
```

NodeJS is just one example, any application that communicates via stdin/stdout can be used as a app.