### PR TITLE
Fix editor style by using largest possible viewport

### DIFF
--- a/src/options/style.css
+++ b/src/options/style.css
@@ -181,12 +181,4 @@ textarea:not([rows="1"]):not(.h100) {
       white-space: normal;
     }
   }
-
-  .edit-open {
-    // hide other components when edit is open to avoid scroll glitches in Firefox Android
-    .page-options {
-      height: 0;
-      overflow: hidden;
-    }
-  }
 }

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -448,7 +448,6 @@ function setupSavePosition({ id: curWndId, tabs }) {
   }
   &-body {
     padding: .5rem 1rem;
-    // overflow: auto;
     background: var(--bg);
     flex: 1;
   }
@@ -516,10 +515,13 @@ function setupSavePosition({ id: curWndId, tabs }) {
   }
 }
 
-.touch .edit {
-  // fixed/absolute doesn't work well with scroll in Firefox Android
-  position: static;
-  // larger than 100vh to force overflow so that the toolbar can be hidden in Firefox Android
+.touch body {
+  position: relative;
+  /*
+   * Set height to 1px larger than screen height to force overflow so that the toolbar can be hidden in Firefox Android.
+   * Use `100vh` (largest possible viewport) to avoid flashing caused by URL bar resizing.
+   * See https://developer.chrome.com/blog/url-bar-resizing
+   */
   min-height: calc(100vh + 1px);
 }
 

--- a/src/options/views/tab-installed.vue
+++ b/src/options/views/tab-installed.vue
@@ -94,7 +94,7 @@
         </Dropdown>
         <!-- form and id are required for the built-in autocomplete using entered values -->
         <form class="filter-search hidden-xs" @submit.prevent
-              :style="{ 'max-width': 5 + Math.max(20, state.search.value.length) + 'ex' }">
+              :style="{ 'min-width': '10em', 'max-width': 5 + Math.max(20, state.search.value.length) + 'ex' }">
           <label>
             <input
               type="search"
@@ -804,6 +804,8 @@ $iconSize: 2rem; // from .icon in ui/style.css
     align-items: center;
     line-height: 1;
     border-bottom: 1px solid var(--fill-5);
+    overflow-x: auto;
+    overflow-y: hidden;
     .btn-ghost, select {
       height: $iconSize;
     }


### PR DESCRIPTION
Fix #2088

The current implementation is broken on a large screen because `.editor-open .page-options` is only hidden on a small screen while `position: static` is always set for a touch screen.

I try to use the same behavior for both desktop and mobile in this PR for easier debugging.