### PR TITLE
feat: show editor settings in script settings

### DIFF
--- a/src/options/style.css
+++ b/src/options/style.css
@@ -74,7 +74,7 @@ aside {
 }
 section {
   padding: 0 0 $tabPadY;
-  > h3 {
+  .tab-settings & > h3 {
     background: linear-gradient(to right, var(--fill-1), transparent);
     border-top: $sectionBorder;
     line-height: 2;
@@ -109,6 +109,13 @@ textarea:not([rows="1"]):not(.h100) {
   padding: $tabPadTopY $tabPadX 0;
   // overflow-y: auto;
   background: var(--bg);
+}
+.tab-settings, .edit-settings {
+  .icon {
+    width: 16px;
+    height: 16px;
+    fill: var(--fg);
+  }
 }
 
 .vl-modal {

--- a/src/options/views/edit/settings.vue
+++ b/src/options/views/edit/settings.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="edit-settings">
-    <h4 v-text="i18n('editLabelSettings')"></h4>
+    <h3 v-text="i18n('editLabelSettings')"></h3>
     <div class="mb-2">
       <label>
         <input type="checkbox" v-model="config.enabled">
@@ -16,7 +16,7 @@
         </td>
       </tr>
     </table>
-    <h4 v-text="i18n('editLabelMeta')"></h4>
+    <h3 v-text="i18n('editLabelMeta')"></h3>
     <!-- Using tables to auto-adjust width, which differs substantially between languages -->
     <table>
       <tr>
@@ -95,6 +95,7 @@
         </td>
       </tr>
     </table>
+    <vm-editor />
   </div>
 </template>
 
@@ -108,6 +109,7 @@ import {
   kDownloadURL, kExclude, kExcludeMatch, kHomepageURL, kIcon, kInclude, kMatch, kName, kOrigExclude,
   kOrigExcludeMatch, kOrigInclude, kOrigMatch, kUpdateURL,
 } from '../../utils';
+import VmEditor from '../tab-settings/vm-editor';
 
 const props = defineProps({
   script: Object,
@@ -154,8 +156,9 @@ $leftColWidth: 12rem;
     padding-left: $PAD;
     padding-right: $PAD;
   }
-  h4 {
+  h3 {
     margin: 2em 0 1em;
+    break-after: avoid-column;
   }
   table {
     border-spacing: 0 1em;
@@ -184,14 +187,9 @@ $leftColWidth: 12rem;
   tr:focus-within code {
     text-decoration: underline;
   }
-  code {
+  table code {
     background: none;
     font-weight: bold;
-  }
-  svg {
-    width: 16px;
-    height: 16px;
-    vertical-align: text-bottom;
   }
 }
 </style>

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -338,10 +338,5 @@ export default {
   ruby {
     color: var(--fill-8);
   }
-  .icon {
-    width: 16px;
-    height: 16px;
-    fill: var(--fg);
-  }
 }
 </style>


### PR DESCRIPTION
<details><summary>Screenshot</summary>

![image](https://github.com/violentmonkey/violentmonkey/assets/1310400/933b1854-d02f-4d94-bea3-453046a68a60)

</details>

I want to make these settings accessible from inside an editor so that the effect of changing them is applied to the editor without going back and forth to global settings or having a second tab with global settings.

@gera2ld, could you try the build and check if this implementation feels weird to you? Maybe it's better to add a cog wheel icon somewhere just like I did in the value editor, clicking which would open the settings panel at the top of the page?