### PR TITLE
Add GM_messageExtension allowing userscript to trigger other WebExtension

### DIFF
--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -4,6 +4,7 @@ import { injectPageSandbox, injectScripts } from './inject';
 import './notifications';
 import './requests';
 import './tabs';
+import './webext-send-message';
 import { sendCmd } from './util';
 import { isEmpty } from '../util';
 import { Run, finish } from './cmd-run';

--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -4,7 +4,7 @@ import { injectPageSandbox, injectScripts } from './inject';
 import './notifications';
 import './requests';
 import './tabs';
-import './webext-send-message';
+import './message-extension';
 import { sendCmd } from './util';
 import { isEmpty } from '../util';
 import { Run, finish } from './cmd-run';

--- a/src/injected/content/message-extension.js
+++ b/src/injected/content/message-extension.js
@@ -2,7 +2,7 @@ import bridge, { addHandlers } from './bridge';
 import { browser } from '../util';
 
 addHandlers({
-  async WebextSendMessage(options, realm) {
+  async MessageExtension(options, realm) {
     let response;
     let ok = true;
     try {

--- a/src/injected/content/webext-send-message.js
+++ b/src/injected/content/webext-send-message.js
@@ -1,8 +1,20 @@
-import { addHandlers } from './bridge';
+import bridge, { addHandlers } from './bridge';
 import { browser } from '../util';
 
 addHandlers({
-  WebextSendMessage(options) {
-      browser.runtime.sendMessage(options.id, options.message, null);
+  async WebextSendMessage(options, realm) {
+    let response;
+    let ok = true;
+    try {
+      response = await browser.runtime.sendMessage(
+        options.extId, options.message, null
+      );
+    }
+    catch (error) {
+      ok = false;
+      response = error;
+    }
+    const data = { ok, response };
+    bridge.post('Callback', { id: options.cbId, data }, realm);
   },
 });

--- a/src/injected/content/webext-send-message.js
+++ b/src/injected/content/webext-send-message.js
@@ -1,0 +1,8 @@
+import { addHandlers } from './bridge';
+import { browser } from '../util';
+
+addHandlers({
+  WebextSendMessage(options) {
+      browser.runtime.sendMessage(options.id, options.message, null);
+  },
+});

--- a/src/injected/web/gm-api-wrapper.js
+++ b/src/injected/web/gm-api-wrapper.js
@@ -28,6 +28,7 @@ export function makeGmApiWrapper(script) {
     resCache: createNullObj(),
     async: false,
   }, script, COPY_SCRIPT_PROPS);
+  context.connect = (meta.connect || []).slice();
   const gmInfo = makeGmInfo(script.gmi, meta, resources);
   const gm4 = {
     __proto__: null,

--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -52,15 +52,16 @@ export const GM_API_CTX_GM4ASYNC = {
   GM_setValues(obj) {
     return dumpValue(this, true, obj);
   },
-  GM_webextSendMessage(id, message) {
+  /** @this {GMContext} */
+  GM_messageExtension(id, message) {
+    const p = 'web-extension://';
     for (const u of this.connect) {
-      const p = 'web-extension://';
       if (u.slice(0, p.length) != p) continue;
       const name = u.slice(p.length);
       if (name != id && name != '*') continue;
       return new Promise((resolve, reject) => {
         bridge.call(
-          'WebextSendMessage', { extId: id, message }, null,
+          'MessageExtension', { extId: id, message }, null,
           ({ ok, response }) => (ok ? resolve : reject)(response),
           'cbId'
         );

--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -53,7 +53,14 @@ export const GM_API_CTX_GM4ASYNC = {
     return dumpValue(this, true, obj);
   },
   GM_webextSendMessage(id, message) {
-    return bridge.post('WebextSendMessage', {id, message});
+    for (const u of this.connect) {
+      const p = 'web-extension://';
+      if (u.slice(0, p.length) != p) continue;
+      const name = u.slice(p.length);
+      if (name != id && name != '*') continue;
+      return bridge.post('WebextSendMessage', {id, message});
+    }
+    throw new Error(`this userscript is not allowed to connect to ${id}`);
   },
   /**
    * @this {GMContext}

--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -52,6 +52,9 @@ export const GM_API_CTX_GM4ASYNC = {
   GM_setValues(obj) {
     return dumpValue(this, true, obj);
   },
+  GM_webextSendMessage(id, message) {
+    return bridge.post('WebextSendMessage', {id, message});
+  },
   /**
    * @this {GMContext}
    * @param {VMScriptGMDownloadOptions|string} opts

--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -58,9 +58,17 @@ export const GM_API_CTX_GM4ASYNC = {
       if (u.slice(0, p.length) != p) continue;
       const name = u.slice(p.length);
       if (name != id && name != '*') continue;
-      return bridge.post('WebextSendMessage', {id, message});
+      return new Promise((resolve, reject) => {
+        bridge.call(
+          'WebextSendMessage', { extId: id, message }, null,
+          ({ ok, response }) => (ok ? resolve : reject)(response),
+          'cbId'
+        );
+      });
     }
-    throw new Error(`this userscript is not allowed to connect to ${id}`);
+    return Promise.reject(
+      new Error(`this userscript is not allowed to connect to ${id}`)
+    );
   },
   /**
    * @this {GMContext}


### PR DESCRIPTION
This API allow userscript to communicate with other extensions
if they do listen on the (browser.runtime.on)MessageExternal event.

The script should also declare the extension id it want to communicate with
in the `@connect` metadata block.

Different from [Tampermonkey's connect field][tmc],
the ajax will not restricted to the URL in the connect field.
These commits only check the connect field with `web-extension://` prefix
and restrict the GM_webextSendMessage's destination id.

[tmc]: https://www.tampermonkey.net/documentation.php#meta:connect

I am not very familiar with this project,
any advice or improvement is wellcome!

## future work
 1. Maybe we should prevent userscript use this API to send message to violent monkey itself?
   Even if they declare `web-extension://*` or violentmonkey's id.
 2. include the userscript's information (namespace and name?) in the payload?
     so the other will not only see the sender is violent monkey.