### PR TITLE
feat: add setting to change CM editor keymap (vim/emacs)

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -482,6 +482,9 @@ labelInstall:
 labelKeepOriginal:
   description: Option to keep the original match or ignore rules.
   message: Keep original
+labelKeyMap:
+  description: Option to change the editor keymap.
+  message: 'Keymap: '
 labelLastUpdatedAt:
   description: Label shown on last updated time.
   message: Last updated at $1

--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -80,6 +80,7 @@ export default {
     hideDisabled: '',
   },
   editor: defaultsEditor,
+  editorKeyMap: 'sublime',
   editorTheme: '',
   editorThemeName: null,
   editorWindow: false, // whether popup opens editor in a new window

--- a/src/common/ui/code-defaults.js
+++ b/src/common/ui/code-defaults.js
@@ -9,7 +9,6 @@ export default {
   matchBrackets: true,
   autoCloseBrackets: true,
   highlightSelectionMatches: true,
-  keyMap: 'sublime',
   /* Limiting the max length to avoid delays while CodeMirror tries to make sense of a long line.
    * 100kB is fast enough for the main editor (moreover such long lines are rare in the main script),
    * and is big enough to include most of popular minified libraries for the `@resource/@require` viewer. */

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -68,6 +68,8 @@ import 'codemirror/addon/search/match-highlighter';
 import 'codemirror/addon/search/searchcursor';
 import 'codemirror/addon/selection/active-line';
 import 'codemirror/keymap/sublime';
+import 'codemirror/keymap/vim';
+import 'codemirror/keymap/emacs';
 import 'codemirror/addon/hint/show-hint.css';
 import 'codemirror/addon/hint/show-hint';
 import 'codemirror/addon/hint/javascript-hint';
@@ -488,10 +490,12 @@ watch(() => props.value, updateValue);
 onMounted(() => {
   let userOpts = options.get('editor');
   const theme = options.get('editorThemeName');
+  const keyMap = options.get('editorKeyMap');
   const internalOpts = props.cmOptions || {};
   const opts = {
     ...cmDefaults,
     ...userOpts,
+    ...{ keyMap: keyMap },
     ...theme && { theme },
     ...internalOpts, // internal options passed via `props` have the highest priority
     mode: props.mode || cmDefaults.mode,

--- a/src/options/views/tab-settings/vm-editor.vue
+++ b/src/options/views/tab-settings/vm-editor.vue
@@ -11,6 +11,14 @@
       <a :href="ghURL" target="_blank">&nearr;</a>
       <p v-text="error"/>
     </div>
+    <div class="mb-1 mr-1c flex center-items">
+      <span v-text="i18n('labelKeyMap')"/>
+      <select v-model="keyMap" :disabled="busy" :title="keyMap">
+        <option value="sublime" v-text="i18n('labelRunAtDefault')"/>
+        <option value="vim" v-text="'vim'"/>
+        <option value="emacs" v-text="'emacs'"/>
+      </select>
+    </div>
     <p class="my-1" v-html="i18n('descEditorOptions')"/>
     <setting-text name="editor" json has-reset @dblclick="toggleBoolean">
       <a class="ml-1" tabindex="0" @click="info = !info">
@@ -32,6 +40,7 @@
 <script>
 const keyThemeCSS = 'editorTheme';
 const keyThemeNAME = 'editorThemeName';
+const keyEditorKeyMap = 'editorKeyMap';
 const THEMES = process.env.CODEMIRROR_THEMES;
 const gh = 'github.com';
 const ghREPO = 'codemirror/CodeMirror';
@@ -72,6 +81,7 @@ const busy = ref();
 const error = ref();
 const themeCss = ref();
 const theme = ref();
+const keyMap = ref();
 
 onMounted(async () => {
   await options.ready; // Waiting for hookSetting to set the value before watching for changes
@@ -96,6 +106,12 @@ onMounted(async () => {
   });
   hookSetting(keyThemeCSS, val => {
     themeCss.value = makeTextPreview(val);
+  });
+  watch(keyMap, val => {
+    options.set(keyEditorKeyMap, val);
+  });
+  hookSetting(keyEditorKeyMap, val => {
+    keyMap.value = val;
   });
 });
 
@@ -131,6 +147,7 @@ async function toggleStateHint(curValue) {
     Object.entries({
       ...(await import('codemirror')).default.defaults,
       ...cmDefaults,
+      ...options.get('editorKeyMap'),
       ...options.get('editor'),
     })
     // sort by keys alphabetically to make it more readable


### PR DESCRIPTION
This uses the keymaps already included with CM 5:
https://codemirror.net/5/keymap/