### PR TITLE
feat: HiDPI/Retina icons

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -96,10 +96,8 @@ async function createIcons() {
     .toFile(`${dist}/icon16${type}.png`);
   };
   return Promise.all([
-    handle(48),
-    handle(128),
     ...types.map(handle16),
-    ...[32, 38].flatMap(size => types.map(t => handle(size, ...t))),
+    ...[32, 38, 48, 64, 96, 128].flatMap(size => types.map(t => handle(size, ...t))),
   ]);
 }
 

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -6,7 +6,10 @@ author: Gerald
 homepage_url: 'https://violentmonkey.github.io/'
 icons:
   '16': public/images/icon16.png
+  '32': public/images/icon32.png
   '48': public/images/icon48.png
+  '64': public/images/icon64.png
+  '96': public/images/icon96.png
   '128': public/images/icon128.png
 default_locale: en
 browser_action:
@@ -14,6 +17,10 @@ browser_action:
   default_icon:
     '16': public/images/icon16b.png
     '32': public/images/icon32b.png
+    '48': public/images/icon48b.png
+    '64': public/images/icon64b.png
+    '96': public/images/icon96b.png
+    '128': public/images/icon128b.png
   default_title: __MSG_extName__
   default_popup: popup/index.html
 background:

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -19,8 +19,6 @@ browser_action:
     '32': public/images/icon32b.png
     '48': public/images/icon48b.png
     '64': public/images/icon64b.png
-    '96': public/images/icon96b.png
-    '128': public/images/icon128b.png
   default_title: __MSG_extName__
   default_popup: popup/index.html
 background:


### PR DESCRIPTION
This pull request adds HiDPI/Retina icon support for high resolution displays. The difference should be visible in the screenshots below.

before (no HiDPI support) | after (HiDPI support)
--- | ---
![before](https://github.com/user-attachments/assets/5bb48d75-ca22-47a8-988c-1b2cb3803972) | ![after](https://github.com/user-attachments/assets/acb71214-d383-476c-a63f-ea2b73396cda)