### PR TITLE
fix: add 64px icon to `gulpfile.js` and `manifest.yml`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,7 +101,7 @@ async function createIcons() {
     // 32px dashboard icon (recycled) + 2xDPI browser_action desktop
     // 38px dashboard icon (normal) + 1.5xDPI browser_action Android
     // 48px 2xDPI browser_action Android
-    ...[32, 38, 48].flatMap(size => types.map(t => handle(size, ...t))),
+    ...[32, 38, 48, 64].flatMap(size => types.map(t => handle(size, ...t))),
   ]);
 }
 

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -16,6 +16,7 @@ browser_action:
     '32': public/images/icon32b.png
     '38': public/images/icon38b.png # for Android 1.5xDPI
     '48': public/images/icon48b.png # for Android 2xDPI
+    '64': public/images/icon64b.png
   default_title: __MSG_extName__
   default_popup: popup/index.html
 background:


### PR DESCRIPTION
It's me again, the 64px icon has to be built so it can show up in the panel (see #2240, <https://github.com/violentmonkey/violentmonkey/commit/82895bfb5895763dc7e17e4f2aaebace9bad125e>).