### PR TITLE
fix: improve unicode support of  globalVars of hint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Get version and SHA
         run: node scripts/action-helper.js ci
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: 'Violentmonkey-test-webext-${{ env.GIT_DESCRIBE }}'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "violentmonkey",
   "description": "Violentmonkey",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "scripts": {
     "prepare": "husky install",
     "dev": "gulp dev",
@@ -113,6 +113,5 @@
       "./test/mock/index.js"
     ],
     "testEnvironment": "./test/mock/env.js"
-  },
-  "beta": 1
+  }
 }

--- a/src/_locales/id/messages.yml
+++ b/src/_locales/id/messages.yml
@@ -133,13 +133,17 @@ confirmUndoImport:
   description: >-
     Tooltip of the Undo button after importing a zip in settings. The same text
     is also shown as a confirmation dialog after clicking this button.
-  message: ''
+  message: >-
+    Mengembalikan semua perubahan yang dibuat pada basis data (mengimpor,
+    memperbarui, mengedit, menyesuaikan)
 descBlacklist:
   description: Description for the global injection blacklist.
-  message: URL yang cocok di dalam daftar ini tidak akan diinjeksi skrip.
+  message: Daftar hitam injeksi (skrip tidak akan berjalan di situs yang cocok)
 descBlacklistNet:
   description: Description for the global network blacklist.
-  message: ''
+  message: >-
+    Daftar hitam jaringan (skrip tidak akan terhubung ke situs yang cocok dan
+    cookie mereka)
 descCustomCSS:
   description: Description of custom CSS section.
   message: >-
@@ -160,7 +164,10 @@ descEditorOptions:
     "Gaya Khusus" di bawah.
 descEditorOptionsGeneric:
   description: Description of editor options in VM settings.
-  message: ''
+  message: >-
+    Opsi Boolean dapat dialihkan dengan mengklik dua kali pada nilai: 1true1 =
+    diaktifkan, 2false2 = dinonaktifkan. Opsi numerik yang diakhiri dengan
+    3Delay3, 4Interval4, 5Rate5, 6Time6 dalam milidetik.
 descEditorOptionsVM:
   description: Description of nonstandard editor options in VM settings.
   message: ''

--- a/src/common/ui/code.vue
+++ b/src/common/ui/code.vue
@@ -125,7 +125,7 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  mode: String,
+  mode: [String, Object],
   commands: {
     type: Object,
     default: null,
@@ -491,10 +491,10 @@ onMounted(() => {
   const internalOpts = props.cmOptions || {};
   const opts = {
     ...cmDefaults,
+    mode: props.mode || cmDefaults.mode,
     ...userOpts,
     ...theme && { theme },
     ...internalOpts, // internal options passed via `props` have the highest priority
-    mode: props.mode || cmDefaults.mode,
   };
   const cmWrapper = $cmWrapper.value;
   cm = CodeMirror(cmWrapper, opts);


### PR DESCRIPTION
when mode set to{
    "name": "javascript",
    "globalVars": true
  }, unicode support(e.g. Chinese chars) of  globalVars of hint will be improved