### PR TITLE
Ignore browser cache during sync as it can cause data loss

### DIFF
--- a/src/background/sync/base.js
+++ b/src/background/sync/base.js
@@ -2,7 +2,9 @@ import {
   debounce, normalizeKeys, request, noop, makePause, ensureArray, sendCmd,
   buffer2string, getRandomString,
 } from '@/common';
-import { TIMEOUT_HOUR } from '@/common/consts';
+import {
+  TIMEOUT_HOUR, NO_CACHE,
+} from '@/common/consts';
 import {
   forEachEntry, objectSet, objectPick,
 } from '@/common/object';
@@ -338,7 +340,7 @@ export const BaseService = serviceFactory({
     progress.total += 1;
     onStateChange();
     return lastFetch.then(() => {
-      options = Object.assign({}, options);
+      options = Object.assign({}, NO_CACHE, options);
       options.headers = Object.assign({}, this.headers, options.headers);
       let { url } = options;
       if (url.startsWith('/')) url = (options.prefix ?? this.urlPrefix) + url;


### PR DESCRIPTION
Many servers do not set a `Cache-Control` header, and since Violentmonkey also does not set `Cache-Control` on requests, the browser will fallback to ["Heuristic caching"](https://www.mnot.net/blog/2017/03/16/browser-caching#heuristic-freshness).

In some cases this can result in data loss: A user could create a script in "Browser X", and run sync. "Browser Y" could then start it's sync, but the [request for the metadata file](https://github.com/violentmonkey/violentmonkey/blob/f7e10dbbaf3cfe846a06508acf64b3bd5a70aa09/src/background/sync/base.js#L313-L321) ( `/Violentmonkey/Violentmonkey`) might be served from the browser's cache. In such a case, "Browser Y" Violentmonkey would remove the newly added script from cloud storage as it didn't see the script in the metadata file.

Unfortunately, due to the nature of heuristic caching, I have found it difficult to create a simple reproducer for this issue, but I must assure you that it sadly does occur (don't worry, had backups so I didn't lose any files).

You might also consider `cache: "no-store"` instead of `cache: "no-cache"` as the latter still allows reverse proxies to return cached content in some cases (some users might be syncing to self-hosted Nextcloud/WebDAV instances with incorrectly configured reverse proxies). It's probably not that common though so I'll leave this up to you!