### PR TITLE
Implement syncing of extension settings

### DIFF
--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -619,6 +619,9 @@ labelSyncServerUrl:
 labelSyncService:
   description: Label for sync service select.
   message: Sync to
+labelSyncSettings:
+  description: Label for option to sync settings.
+  message: Sync settings
 labelSyncUsername:
   description: Label for input to hold username.
   message: 'Username: '

--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -51,6 +51,7 @@ export default {
   features: null,
   syncScriptStatus: true,
   syncAutomatically: true,
+  syncSettings: true,
   sync: null,
   customCSS: '',
   importScriptData: true,

--- a/src/common/ui/setting-text.vue
+++ b/src/common/ui/setting-text.vue
@@ -78,8 +78,12 @@ const toggleUnloadSentry = getUnloadSentry(() => {
   text.value = handle(savedValue);
 });
 const revoke = hookSetting(props.name, val => {
-  savedValue = val;
-  text.value = savedValueText = handle(val);
+  const base = props.json && savedValue
+    ? savedValue: defaultValue;
+  const merged = props.json && base
+    ? {...base,...val } : val;
+  savedValue = merged;
+  text.value = savedValueText = handle(merged);
 });
 
 defineExpose({

--- a/src/options/views/tab-settings/vm-export.vue
+++ b/src/options/views/tab-settings/vm-export.vue
@@ -96,6 +96,7 @@ async function exportData() {
     settings: options.get(),
   };
   delete vm.settings.sync;
+  delete vm.settings.modified;
   if (withValues) vm.values = {};
   const files = (objectGet(data, 'items') || []).map(({ script, code }) => {
     let name = normalizeFilename(getScriptName(script));

--- a/src/options/views/tab-settings/vm-sync.vue
+++ b/src/options/views/tab-settings/vm-sync.vue
@@ -116,6 +116,10 @@
         name="syncScriptStatus"
         :label="i18n('labelSyncScriptStatus')"
       />
+      <setting-check
+        name="syncSettings"
+        :label="i18n('labelSyncSettings')"
+      />
     </div>
   </section>
 </template>


### PR DESCRIPTION
This PR implements syncing of extension settings.

Changes to individual options are tracked by recording their keys with a timestamp in the new field `options.modified` whenever they change. This is used to build option diffs that are merged during sync using a per-key last-write-wins strategy, so concurrent changes to different options on multiple devices are synchronized in both directions and all devices should end up in the same consistent state.

I have tested this as well as I can, but of course there may still be problems or edge cases that I haven't thought of.