### PR TITLE
fix: update MDN links to new URL structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Microsoft Edge Add-on](https://img.shields.io/badge/dynamic/json?label=microsoft%20edge%20add-on&query=%24.version&url=https%3A%2F%2Fmicrosoftedge.microsoft.com%2Faddons%2Fgetproductdetailsbycrxid%2Feeagobfjdenkkddmbclomhiblgggliao)](https://microsoftedge.microsoft.com/addons/detail/eeagobfjdenkkddmbclomhiblgggliao)
 
 Violentmonkey provides userscripts support for browsers.
-It works on browsers with [WebExtensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions) support.
+It works on browsers with [WebExtensions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions) support.
 
 More details can be found [here](https://violentmonkey.github.io/).
 


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths. This PR updates outdated MDN links to the new URL structure.

Changed:
- developer.mozilla.org/en-US/Add-ons/WebExtensions → developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*