### PR TITLE
feat: Add button to publish to Greasy Fork

### DIFF
--- a/_locales/en/messages.yml
+++ b/_locales/en/messages.yml
@@ -45,6 +45,9 @@ buttonFilter:
   description: Button to show filters menu.
   message: Filters
   touched: false
+buttonGreasyForkPublish:
+  description: Button to upload the current userscript, creating a new one on Greasy Fork
+  message: Publish
 buttonHome:
   description: Button to open homepage.
   message: Homepage
@@ -64,6 +67,9 @@ buttonNew:
 buttonOK:
   description: OK button on dialog.
   message: OK
+buttonPushUpdate:
+  descrption: Button to upload the current code to replace a userscript's contents on Greasy Fork or etc.
+  message: Push update
 buttonRecycleBin:
   description: Button to list scripts in recycle bin.
   message: Recycle Bin

--- a/src/background/utils/db.js
+++ b/src/background/utils/db.js
@@ -26,6 +26,7 @@ import storage, {
 import { storageCacheHas } from './storage-cache';
 import { reloadTabForScript } from './tabs';
 import { vetUrl } from './url';
+import { kDownloadURL, kPublishedByMe, kUpdateURL } from '@/options/utils';
 
 let maxScriptId = 0;
 let maxScriptPosition = 0;
@@ -42,15 +43,53 @@ export const sizesPrefixRe = RegExp(
 /** @type {{ [type: 'cache' | 'require']: { [url: string]: Promise<?> } }} */
 const pendingDeps = { [S_CACHE]: {}, [S_REQUIRE]: {} };
 const depsPorts = {};
+let listenForPublishScriptId = 0;
 
 addPublicCommands({
   GetScriptVer(opts) {
-    const script = getScript(opts);
-    return script
-      ? script.meta.version
-      : null;
+    try {
+      const script = getScript(opts);
+      if (!script) return null;
+      if (script.props.id === listenForPublishScriptId) void onScriptPublished(opts, script);
+      return script.meta.version;
+    } finally {
+      listenForPublishScriptId = 0;
+    }
   },
 });
+
+/**
+ * Adds @downloadURL after going through "Publish userscript" button
+ */
+async function onScriptPublished(opts, script) {
+  // For security, validate meta and edit local code, instead of fetching the downloadURL
+  const url = opts.meta.publishDownloadURL;
+  if (opts?.meta?.name !== script.meta.name || opts.meta.namespace !== script.meta.namespace
+  || opts.meta.publishVersion !== script.meta.version || script.custom[kUpdateURL] || script.meta[kUpdateURL]
+  || script.custom[kDownloadURL] || script.meta[kDownloadURL] || script.custom.lastInstallURL
+  || !url.startsWith('https://update.greasyfork.org/scripts/') || !url.endsWith('.user.js')
+  || url.includes('\n')) throw new Error;
+  const id = script.props.id;
+  const [ head, tail, ...excess ] = (await GetScriptCode(id)).split('\n// ==/UserScript==\n');
+  if (excess.length || head.includes('@downloadURL') || head.includes('@updateURL')) throw new Error;
+  await parseScript({
+    bumpDate: true,
+    code: `${head}
+// @downloadURL ${url}
+// @updateURL ${url.substr(0, url.length - 8)}.meta.js
+// ==/UserScript==
+${tail}`,
+    config: { ...script.config, shouldUpdate: 0 },
+    custom: { ...script.custom, [kPublishedByMe]: true },
+    id,
+    isNew: false,
+    message: '',
+  });
+}
+
+function GetScriptCode(id) {
+  return storage[S_CODE][Array.isArray(id) ? 'getMulti' : 'getOne'](id);
+}
 
 addOwnCommands({
   CheckPosition: sortScripts,
@@ -74,10 +113,9 @@ addOwnCommands({
     };
   },
   /** @return {Promise<string>} */
-  GetScriptCode(id) {
-    return storage[S_CODE][Array.isArray(id) ? 'getMulti' : 'getOne'](id);
-  },
+  GetScriptCode,
   GetTags: () => getScriptsTags(aliveScripts),
+  ListenForPublish: ({ id }) => void (listenForPublishScriptId = id),
   /** @return {Promise<void>} */
   async MarkRemoved({ id, removed }) {
     if (!removed) {

--- a/src/injected/content/index.js
+++ b/src/injected/content/index.js
@@ -4,7 +4,7 @@ import { injectPageSandbox, injectScripts } from './inject';
 import './notifications';
 import './requests';
 import './tabs';
-import { sendCmd } from './util';
+import { getAttribute, querySelector, sendCmd } from './util';
 import { isEmpty, XHR_COOKIE_RE } from '../util';
 import { Run, finish } from './cmd-run';
 
@@ -41,7 +41,18 @@ async function init() {
     IS_FIREFOX = parseFloat(info.ua.browserVersion); // eslint-disable-line no-global-assign
   }
   if (data[EXPOSE] != null && !isXml && injectPageSandbox(data)) {
-    addHandlers({ GetScriptVer: true });
+    addHandlers({
+      GetScriptVer({ meta }) {
+        setPrototypeOf(meta, null);
+        const el = document::querySelector('a.install-link');
+        if (el && el::getAttribute('data-script-name') === meta.name
+        && el::getAttribute('data-script-namespace') === meta.namespace) {
+          meta.publishVersion = el::getAttribute('data-script-version');
+          meta.publishDownloadURL = el::getAttribute('href');
+        }
+        return sendCmd('GetScriptVer', { meta });
+      },
+    });
     bridge.post('Expose', data[EXPOSE]);
   }
   if (objectKeys(ids).length) {

--- a/src/injected/content/inject.js
+++ b/src/injected/content/inject.js
@@ -1,5 +1,7 @@
 import bridge, { addHandlers, grantless } from './bridge';
-import { elemByTag, makeElem, nextTask, onElement, sendCmd } from './util';
+import {
+  elemByTag, getAttribute, makeElem, nextTask, onElement, querySelector, sendCmd,
+} from './util';
 import { bindEvents, CONSOLE_METHODS, fireBridgeEvent, META_STR } from '../util';
 import { Run } from './cmd-run';
 
@@ -16,8 +18,6 @@ let frameEventWnd;
 let injectedRoot;
 let invokeContent;
 let nonce;
-let getAttribute;
-let querySelector;
 
 // https://bugzil.la/1408996
 let VMInitInjection = window[INIT_FUNC_NAME];
@@ -157,10 +157,6 @@ export async function injectScripts(data, info, isXml) {
   const getReadyState = more && describeProperty(Document[PROTO], 'readyState').get;
   const wasInjectableFF = IS_FIREFOX && !nonce && pageInjectable;
   const pageBodyScripts = pageLists?.[BODY];
-  if (wasInjectableFF) {
-    getAttribute = Element[PROTO].getAttribute;
-    querySelector = document.querySelector;
-  }
   tardyQueue = createNullObj();
   // Using a callback to avoid a microtask tick when the root element exists or appears.
   await onElement('*', injectAll, 'start');

--- a/src/injected/content/util.js
+++ b/src/injected/content/util.js
@@ -8,6 +8,8 @@ export * from './util-task';
  * Note that we avoid spoofed prototype getters by using hasOwnProperty, and not using `length`
  * as it searches for ALL matching nodes when this tag wasn't cached internally. */
 export const elemByTag = (tag, i) => getOwnProp(document::getElementsByTagName(tag), i || 0);
+export const getAttribute = Element[PROTO].getAttribute;
+export const querySelector = document.querySelector;
 const {
   TextDecoder: SafeTextDecoder,
 } = global;

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -119,11 +119,20 @@ addHandlers({
     const obj = window[key];
     (isObject(obj) ? obj : (window[key] = {}))[VIOLENTMONKEY] = {
       version: process.env.VM_VER,
-      isInstalled: (name, namespace) => (
-        allowGetScriptVer
-          ? bridge.promise('GetScriptVer', { meta: { name, namespace } })
-          : promiseResolve()
-      ),
+      isInstalled: (name, namespace) => {
+        const meta = { name, namespace };
+        if (window.location.hostname === 'greasyfork.org') {
+          const installLink = window.document.querySelector('a.install-link');
+          const ds = installLink?.dataset;
+          if (ds?.scriptName === meta.name && ds.scriptNamespace === meta.namespace) {
+            meta.publishVersion = ds.scriptVersion;
+            meta.publishDownloadURL = installLink.href;
+          }
+        }
+        return allowGetScriptVer
+          ? bridge.promise('GetScriptVer', {meta})
+          : promiseResolve();
+      },
     };
   },
 });

--- a/src/injected/web/index.js
+++ b/src/injected/web/index.js
@@ -119,20 +119,11 @@ addHandlers({
     const obj = window[key];
     (isObject(obj) ? obj : (window[key] = {}))[VIOLENTMONKEY] = {
       version: process.env.VM_VER,
-      isInstalled: (name, namespace) => {
-        const meta = { name, namespace };
-        if (window.location.hostname === 'greasyfork.org') {
-          const installLink = window.document.querySelector('a.install-link');
-          const ds = installLink?.dataset;
-          if (ds?.scriptName === meta.name && ds.scriptNamespace === meta.namespace) {
-            meta.publishVersion = ds.scriptVersion;
-            meta.publishDownloadURL = installLink.href;
-          }
-        }
-        return allowGetScriptVer
-          ? bridge.promise('GetScriptVer', {meta})
-          : promiseResolve();
-      },
+      isInstalled: (name, namespace) => (
+        allowGetScriptVer
+          ? bridge.promise('GetScriptVer', { meta: { name, namespace } })
+          : promiseResolve()
+      ),
     };
   },
 });

--- a/src/options/utils/index.js
+++ b/src/options/utils/index.js
@@ -23,6 +23,7 @@ export const store = reactive({
   title: null,
 });
 
+export const kPublishedByMe = 'publishedByMe';
 export const kComment = 'comment';
 export const kInclude = 'include';
 export const kMatch = 'match';

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -33,9 +33,6 @@
         <button v-if="!isNaN(greasyForkId)"
                 v-text="i18n(greasyForkId ? 'buttonPushUpdate' : 'buttonGreasyForkPublish')"
                 @click="greasyForkPublish"/>
-        <form style="display:none" method="post" ref="greasyForkForm" target="_blank">
-          <textarea name="script_version[code]" ref="greasyForkTextarea"></textarea>
-        </form>
         <button v-text="i18n('buttonSave')" @click="save"
                 v-show="canSave || !frozen" :disabled="!canSave"
                 :class="{'has-error': $fe = fatal || errors}" :title="$fe"/>
@@ -246,8 +243,6 @@ const hashPattern = computed(() => { // eslint-disable-line vue/return-in-comput
 const fatal = ref();
 const frozen = ref(false);
 const frozenNote = ref(false);
-const greasyForkForm = ref();
-const greasyForkTextarea = ref();
 
 const navItems = computed(() => {
   const { meta, props: { id }, $cache = {} } = script.value;
@@ -523,12 +518,24 @@ const greasyForkId = computed(() => {
 });
 
 function greasyForkPublish() {
-  const id = greasyForkId.value;
-  const form = greasyForkForm.value;
   // API: https://github.com/greasyfork-org/greasyfork/commit/5b973bf68ffb9c4d684c357770680dcfa6b2bd4a
-  form.action = `https://greasyfork.org/en/script${id ? `s/${id}/` : '_'}versions/prefill`;
-  greasyForkTextarea.value.value = $codeComp.getRealContent();
-  form.submit();
+  const id = greasyForkId.value;
+  const url = `https://greasyfork.org/en/script${id ? `s/${id}/` : '_'}versions/prefill`;
+
+  const doc = window.open('', '', `width=${screen.width / 2},height=${screen.height / 2}`).document;
+  doc.body.style.display = process.env.DEBUG ? 'block' : 'none';
+
+  const form = doc.createElement('form');
+  form.method = 'post';
+  form.action = url;
+  doc.body.appendChild(form);
+
+  const textarea = doc.createElement('textarea');
+  textarea.name = 'script_version[code]';
+  textarea.value = $codeComp.getRealContent();
+  form.appendChild(textarea);
+
+  setTimeout(() => form.submit(), process.env.DEBUG ? 3000 : 0);
   sendCmdDirectly('ListenForPublish', { id: script.value.props.id });
   if (!id) {
     // Like the (Re)install button, the editor must be closed and reopened after finishing the Publish

--- a/src/options/views/edit/index.vue
+++ b/src/options/views/edit/index.vue
@@ -30,6 +30,12 @@
         <a class="btn-ghost" @click="clipboardPaste" tabindex="0" v-if="!frozen"><IconPaste/></a>
       </div>
       <div class="mr-1">
+        <button v-if="!isNaN(greasyForkId)"
+                v-text="i18n(greasyForkId ? 'buttonPushUpdate' : 'buttonGreasyForkPublish')"
+                @click="greasyForkPublish"/>
+        <form style="display:none" method="post" ref="greasyForkForm" target="_blank">
+          <textarea name="script_version[code]" ref="greasyForkTextarea"></textarea>
+        </form>
         <button v-text="i18n('buttonSave')" @click="save"
                 v-show="canSave || !frozen" :disabled="!canSave"
                 :class="{'has-error': $fe = fatal || errors}" :title="$fe"/>
@@ -118,7 +124,7 @@ import { getUnloadSentry } from '@/common/router';
 import { EXTERNAL_LINK_PROPS } from '@/common/ui';
 import {
   kDownloadURL, kExclude, kExcludeMatch, kHomepageURL, kIcon, kInclude, kMatch, kName, kOrigExclude, kOrigExcludeMatch,
-  kOrigInclude, kOrigMatch, kUpdateURL, kComment,
+  kOrigInclude, kOrigMatch, kUpdateURL, kComment, kPublishedByMe
 } from '../../utils';
 
 const EXTERNALS = 'externals';
@@ -129,6 +135,7 @@ const CUSTOM_PROPS = {
   [kUpdateURL]: '',
   [kDownloadURL]: '',
   [kIcon]: '',
+  [kPublishedByMe]: null,
   [kOrigInclude]: true,
   [kOrigExclude]: true,
   [kOrigMatch]: true,
@@ -239,6 +246,8 @@ const hashPattern = computed(() => { // eslint-disable-line vue/return-in-comput
 const fatal = ref();
 const frozen = ref(false);
 const frozenNote = ref(false);
+const greasyForkForm = ref();
+const greasyForkTextarea = ref();
 
 const navItems = computed(() => {
   const { meta, props: { id }, $cache = {} } = script.value;
@@ -497,6 +506,34 @@ function setupSavePosition({ id: curWndId, tabs }) {
       addEventListener('resize', debounce(savePosition.bind(null, null), 100));
       shouldSavePositionOnSave = true;
     }
+  }
+}
+
+const greasyForkId = computed(() => {
+  const { custom, meta, props } = script.value;
+  if (canSave.value || frozen.value || !props.id || custom[kDownloadURL] || custom[kUpdateURL]) return NaN;
+  const url = meta[kDownloadURL];
+  if (!url) {
+    if (custom.lastInstallURL) return NaN;
+    return 0; // Yet unpublished
+  }
+  if (!custom[kPublishedByMe]) return NaN; // Don't suggest updating others' scripts
+  const match = /^https:\/\/update\.greasyfork\.org\/scripts\/(\d+)\/.+\.user\.js$/.exec(url) || [];
+  return +match[1]; // Potentially updateable when type is integral. Not Greasy Fork when NaN
+});
+
+function greasyForkPublish() {
+  const id = greasyForkId.value;
+  const form = greasyForkForm.value;
+  // API: https://github.com/greasyfork-org/greasyfork/commit/5b973bf68ffb9c4d684c357770680dcfa6b2bd4a
+  form.action = `https://greasyfork.org/en/script${id ? `s/${id}/` : '_'}versions/prefill`;
+  greasyForkTextarea.value.value = $codeComp.getRealContent();
+  form.submit();
+  sendCmdDirectly('ListenForPublish', { id: script.value.props.id });
+  if (!id) {
+    // Like the (Re)install button, the editor must be closed and reopened after finishing the Publish
+    // to refresh `code` and `updateURL`
+    close(true);
   }
 }
 </script>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -189,6 +189,7 @@ declare interface VMScript {
     origMatch: boolean;
     origTag: boolean;
     pathMap?: StringMap;
+    publishedByMe?: boolean;
     runAt?: VMScriptRunAt;
     /** @since v2.36 */
     tag?: string[];


### PR DESCRIPTION
See #2425


### Screenshots

#### Before publish: Publish userscript button appears

<img width="2814" height="1264" alt="publish userscript button appears above editor" src="https://github.com/user-attachments/assets/8eab50fd-f1d2-462f-a274-272a46f5d454" />

#### After successful publish: Push update button appears

<img width="2814" height="1264" alt="push update button appears above editor" src="https://github.com/user-attachments/assets/9d0a2c03-1b9f-46d4-b4be-4baa2dfd9ae3" />

#### 3rd-party read-only: No button added

<img width="2814" height="1264" alt="no extra button next to READ-ONLY" src="https://github.com/user-attachments/assets/78415e28-7cb4-4102-9d9a-11ae4acf5cfd" />

#### 3rd-party modified: No button added

Anything that didn't go through my workflow is considered 3rd-party.

<img width="2814" height="1264" alt="no extra button when we didn't go through my process" src="https://github.com/user-attachments/assets/050f193b-000f-4069-9dbd-c08a4f6c3468" />

If you want to have it recognize a userscript as 1st-party:

1. Remove `@updateURL` and `@downloadURL`
1. Click "Publish userscript"
1. Close the tab that appears
1. Refresh the Greasy Fork tab that contains the green "Reinstall version" button

This way, upon reopening, the "Push update" button should appear