### PR TITLE
fix: correct typoed documentation key and comments

### DIFF
--- a/src/_locales/ar/messages.yml
+++ b/src/_locales/ar/messages.yml
@@ -198,7 +198,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: عرض
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: >-
     الوثائق الخاصة بكتلة البيانات الوصفية للسكربتات وواجهة برمجة

--- a/src/_locales/cs/messages.yml
+++ b/src/_locales/cs/messages.yml
@@ -173,7 +173,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: ''
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: ''
 editHelpKeyboard:

--- a/src/_locales/de/messages.yml
+++ b/src/_locales/de/messages.yml
@@ -197,7 +197,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: anzeigen
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: >-
     Dokumentation des Benutzerskript-Metadatenblocks und der

--- a/src/_locales/el/messages.yml
+++ b/src/_locales/el/messages.yml
@@ -207,7 +207,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: εμφάνιση
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: Οδηγίες για τα μεταδεδομένα και τεκμηρίωση για το <code>GM</code> API
 editHelpKeyboard:

--- a/src/_locales/en/messages.yml
+++ b/src/_locales/en/messages.yml
@@ -196,7 +196,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: show
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: 'Documentation on userscript metadata block and <code>GM</code> API:'
 editHelpKeyboard:

--- a/src/_locales/es/messages.yml
+++ b/src/_locales/es/messages.yml
@@ -201,7 +201,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: mostrar
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: >-
     Documentación sobre el bloque de metadatos de userscript y la API de

--- a/src/_locales/es_419/messages.yml
+++ b/src/_locales/es_419/messages.yml
@@ -201,7 +201,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: mostrar
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: >-
     Documentación sobre el bloque de metadatos de userscript y la API de

--- a/src/_locales/fi/messages.yml
+++ b/src/_locales/fi/messages.yml
@@ -173,7 +173,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: ''
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: ''
 editHelpKeyboard:

--- a/src/_locales/fr/messages.yml
+++ b/src/_locales/fr/messages.yml
@@ -208,7 +208,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: montrer
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: 'Documentation on userscript metadata block and <code>GM</code> API:'
 editHelpKeyboard:

--- a/src/_locales/hr/messages.yml
+++ b/src/_locales/hr/messages.yml
@@ -173,7 +173,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: ''
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: ''
 editHelpKeyboard:

--- a/src/_locales/hu/messages.yml
+++ b/src/_locales/hu/messages.yml
@@ -191,7 +191,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: ''
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: 'Dokumentáció a userscript metaadat blokkjához és a <code>GM</code> API-hoz:'
 editHelpKeyboard:

--- a/src/_locales/id/messages.yml
+++ b/src/_locales/id/messages.yml
@@ -195,7 +195,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: ''
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: 'Dokumentasi tentang blok data meta skrip dan API <code>GM</code>:'
 editHelpKeyboard:

--- a/src/_locales/it/messages.yml
+++ b/src/_locales/it/messages.yml
@@ -204,7 +204,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: mostra
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: 'Documentazione sul blocco di metadati userscript e API <code>GM</code>:'
 editHelpKeyboard:

--- a/src/_locales/ja/messages.yml
+++ b/src/_locales/ja/messages.yml
@@ -185,7 +185,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: 表示
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: 'ユーザースクリプトのメタデータ部分と <code>GM</code> API の説明文書:'
 editHelpKeyboard:

--- a/src/_locales/ko/messages.yml
+++ b/src/_locales/ko/messages.yml
@@ -186,7 +186,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: 보기
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: '유저스크립트의 메타데이터와 <code>GM</code> API 문서:'
 editHelpKeyboard:

--- a/src/_locales/lv/messages.yml
+++ b/src/_locales/lv/messages.yml
@@ -169,7 +169,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: ''
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: ''
 editHelpKeyboard:

--- a/src/_locales/nl/messages.yml
+++ b/src/_locales/nl/messages.yml
@@ -197,7 +197,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: tonen
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: 'Documentatie over gebruikersscript metagegevensblok en <code>GM</code> API:'
 editHelpKeyboard:

--- a/src/_locales/no/messages.yml
+++ b/src/_locales/no/messages.yml
@@ -169,7 +169,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: ''
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: ''
 editHelpKeyboard:

--- a/src/_locales/pl/messages.yml
+++ b/src/_locales/pl/messages.yml
@@ -197,7 +197,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: pokaż
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: >-
     Dokumentacja dotycząca bloku metadanych skryptu użytkownika i API

--- a/src/_locales/pt_BR/messages.yml
+++ b/src/_locales/pt_BR/messages.yml
@@ -199,7 +199,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: mostre
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: >-
     Documentação sobre bloco de metadados de script do usuário e API

--- a/src/_locales/pt_PT/messages.yml
+++ b/src/_locales/pt_PT/messages.yml
@@ -177,7 +177,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: ''
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: >-
     Documentação sobre o bloco de metadados do script de utilizador e a API

--- a/src/_locales/ro/messages.yml
+++ b/src/_locales/ro/messages.yml
@@ -200,7 +200,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: afișează-le
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: >-
     Documentație cu privire la blockurile metadatelor usescripturilor și

--- a/src/_locales/ru/messages.yml
+++ b/src/_locales/ru/messages.yml
@@ -196,7 +196,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: показать
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: 'Документация по блоку метаданных скриптов и <code>GM</code> API:'
 editHelpKeyboard:

--- a/src/_locales/sk/messages.yml
+++ b/src/_locales/sk/messages.yml
@@ -198,7 +198,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: zobraziť
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: 'Dokumentácia k bloku metadát požívateľského skriptu a <code>GM</code> API:'
 editHelpKeyboard:

--- a/src/_locales/sr/messages.yml
+++ b/src/_locales/sr/messages.yml
@@ -192,7 +192,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: ''
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: ''
 editHelpKeyboard:

--- a/src/_locales/sv/messages.yml
+++ b/src/_locales/sv/messages.yml
@@ -197,7 +197,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: visa
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: 'Dokumentation om användarskriptmetadatablock och <code>GM</code> API:'
 editHelpKeyboard:

--- a/src/_locales/th/messages.yml
+++ b/src/_locales/th/messages.yml
@@ -169,7 +169,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: ''
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: ''
 editHelpKeyboard:

--- a/src/_locales/tr/messages.yml
+++ b/src/_locales/tr/messages.yml
@@ -199,7 +199,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: göster
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: 'Kullanıcı betiği meta veri bloku ve <code>GM</code> API belgeleri:'
 editHelpKeyboard:

--- a/src/_locales/uk/messages.yml
+++ b/src/_locales/uk/messages.yml
@@ -198,7 +198,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: показати
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: 'Документація по блоку метаданих скриптів та <code>GM</code> API:'
 editHelpKeyboard:

--- a/src/_locales/vi/messages.yml
+++ b/src/_locales/vi/messages.yml
@@ -196,7 +196,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: Hiện
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: 'Các tài liệu về API đọc ở đây:'
 editHelpKeyboard:

--- a/src/_locales/zh_CN/messages.yml
+++ b/src/_locales/zh_CN/messages.yml
@@ -186,7 +186,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: 显示
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: 用户脚本 metadata 区域和 <code>GM</code> API 的相关文档：
 editHelpKeyboard:

--- a/src/_locales/zh_TW/messages.yml
+++ b/src/_locales/zh_TW/messages.yml
@@ -185,7 +185,7 @@ disabledScriptsSelector:
 disabledScriptsShow:
   description: 'Used as "Disabled scripts: show"'
   message: 顯示
-editHelpDocumention:
+editHelpDocumentation:
   description: Label in the editor help tab for the documentation link.
   message: 使用者腳本中繼資料區塊和 <code>GM</code> API 的文件：
 editHelpKeyboard:

--- a/src/background/sync/base.js
+++ b/src/background/sync/base.js
@@ -68,9 +68,9 @@ export function setSyncOnceMode(mode) {
 }
 
 export function getItemFilename({ name, uri }) {
-  // When get or remove, current name should be prefered
+  // When get or remove, current name should be preferred
   if (name) return name;
-  // otherwise uri derived name should be prefered
+  // otherwise uri derived name should be preferred
   // uri is already encoded by `encodeFilename`
   return `vm@2-${uri}`;
 }

--- a/src/options/views/edit/help.vue
+++ b/src/options/views/edit/help.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="edit-help mb-2c">
     <div>
-      <h3 v-html="i18n('editHelpDocumention')"/>
+      <h3 v-html="i18n('editHelpDocumentation')"/>
       <a :href="API_URL" v-bind="EXTERNAL_LINK_PROPS" v-text="API_TEXT"/>
     </div>
     <div class="keyboard">


### PR DESCRIPTION
Closes #2525.

## Summary
- rename `editHelpDocumention` to `editHelpDocumentation`
- update the editor help view to use the corrected i18n key
- fix `prefered` -> `preferred` in sync comments

## Verification
- ran `typos src/_locales/en/messages.yml src/options/views/edit/help.vue src/background/sync/base.js`
