### PR TITLE
add native browser downloads api support

### DIFF
--- a/_locales/en/messages.yml
+++ b/_locales/en/messages.yml
@@ -701,6 +701,19 @@ labelXhrInjectHint:
 labelXhrInjectNote:
   description: Shown to the right of "synchronous page mode" in options.
   message: (except incognito and sites with disabled cookies)
+labelGmDownloadModeBrowser:
+  description: Option in Advanced settings to use the browser download API for GM_download.
+  message: Use browser download API
+labelGmDownloadModeBrowserHint:
+  description: Tooltip for the browser download option in Advanced settings.
+  message: Allows scripts to save files into subfolders inside your downloads
+    directory and shows download progress in the browser's download bar.
+labelGmDownloadModeBrowserPermissionRequired:
+  description: Shown after the browser download option label.
+  message: (requires "downloads" permission)
+labelGmDownloadModeBrowserGrantPerm:
+  description: Button to request the downloads permission.
+  message: Grant permission
 lastSync:
   description: Label for last sync timestamp.
   message: Last sync at $1

--- a/_locales/es/messages.yml
+++ b/_locales/es/messages.yml
@@ -725,6 +725,20 @@ labelXhrInjectHint:
 labelXhrInjectNote:
   description: Shown to the right of "synchronous page mode" in options.
   message: (excepto en modo incógnito y en sitios con cookies deshabilitadas)
+labelGmDownloadModeBrowser:
+  description: Opción en configuración avanzada para usar la API de descargas del navegador para GM_download.
+  message: Usar API de descargas del navegador
+labelGmDownloadModeBrowserHint:
+  description: Información sobre la opción de descargas del navegador en configuración avanzada.
+  message: Permite a los scripts guardar archivos en subcarpetas dentro del
+    directorio de descargas y muestra el progreso en la barra de descargas
+    del navegador.
+labelGmDownloadModeBrowserPermissionRequired:
+  description: Se muestra después de la etiqueta de la opción de descargas del navegador.
+  message: (requiere permiso "descargas")
+labelGmDownloadModeBrowserGrantPerm:
+  description: Botón para solicitar el permiso de descargas.
+  message: Conceder permiso
 lastSync:
   description: Label for last sync timestamp.
   message: Última sincronización el $1

--- a/src/background/utils/preinject-prepare.js
+++ b/src/background/utils/preinject-prepare.js
@@ -12,6 +12,7 @@ import {
   makeXhrHeader, propsToClear, registerScriptData, xhrInject,
 } from './preinject-core';
 import { S_CACHE, S_CODE, S_REQUIRE, S_SCRIPT_PRE, S_VALUE } from './storage';
+import { getOption } from './options';
 import { ua } from './ua';
 
 const sessionId = getUniqId();
@@ -101,7 +102,7 @@ async function prepareBag(cacheKey, url, isTop, env, inject, errors) {
     [MORE]: moreKey,
     [kSessionId]: sessionId,
     [IDS]: allIds,
-    info: { ua, gmi: { isIncognito } },
+    info: { ua, gmi: { isIncognito }, gmDownloadModeBrowser: getOption('gmDownloadModeBrowser') },
     errors: errors.filter(err => allIds[err.split('#').pop()]).join('\n'),
   }, objectPick(env, [
     S_CACHE,
@@ -246,6 +247,7 @@ function prepareScript(script, env) {
     gmi: {
       scriptWillUpdate: shouldUpdate,
       uuid: props.uuid,
+      downloadMode: getOption('gmDownloadModeBrowser') ? 'browser' : 'native',
     },
     id,
     key: plantKey,

--- a/src/background/utils/preinject.js
+++ b/src/background/utils/preinject.js
@@ -190,6 +190,8 @@ function setBaggedScriptValues(bag, id, val) {
   }
 }
 
+
+
 function clearFrameData(tabId, frameId, tabRemoved) {
   clearRequestsByTabId(tabId, frameId);
   clearValueOpener(tabId, frameId);

--- a/src/background/utils/requests.js
+++ b/src/background/utils/requests.js
@@ -10,6 +10,7 @@ import {
   FORBIDDEN_HEADER_RE, kCookie, kSetCookie, requests, toggleHeaderInjector, verify,
 } from './requests-core';
 import { getFrameDocIdAsObj, getFrameDocIdFromSrc } from './tabs';
+import { getOption } from './options';
 import { navUA, navUAD } from './ua';
 import { vetUrl } from './url';
 
@@ -49,6 +50,27 @@ addPublicCommands({
       __.MV3 && req.url && res.data && (res.data.finalUrl = req.url), // from onBeforeSendHeaders
       sendTabCmd(tabId, 'HttpRequested', res, req.frame)
     );
+    if (getOption('gmDownloadModeBrowser') && opts[kFileName]) {
+      const downloadOpts = { url: opts.url, filename: opts[kFileName] };
+      if (opts.headers) {
+        downloadOpts.headers = Object.entries(opts.headers).map(
+          ([n, v]) => ({ name: n, value: v }),
+        );
+      }
+      if (opts.saveAs != null) downloadOpts.saveAs = opts.saveAs;
+      if (opts.conflictAction) downloadOpts.conflictAction = opts.conflictAction;
+      if (opts.method) downloadOpts.method = opts.method;
+      browser.downloads.download(downloadOpts)
+        .then(() => {
+          cb({ id, type: 'load', data: { finalUrl: opts.url, readyState: 4, status: 200, response: null, responseHeaders: null } });
+          cb({ id, type: 'loadend', data: null });
+        })
+        .catch(err => {
+          cb({ id, [ERROR]: [err.message || `${err}`, 'DownloadError'], data: null });
+          cb({ id, type: 'loadend', data: null });
+        });
+      return;
+    }
     return httpRequest(opts, events, src, cb)
     .catch(err => cb({
       id,

--- a/src/common/options-defaults.js
+++ b/src/common/options-defaults.js
@@ -67,6 +67,7 @@ export default {
   defaultInjectInto: AUTO,
   ffInject: true,
   xhrInject: false,
+  gmDownloadModeBrowser: false,
   filters: {
     /** @type {boolean} */
     showOrder: false,

--- a/src/injected/web/gm-api.js
+++ b/src/injected/web/gm-api.js
@@ -71,10 +71,10 @@ export const GM_API_CTX_GM4ASYNC = {
     }
     assign(opts, {
       [kResponseType]: 'blob',
-      data: null,
-      method: 'GET',
       overrideMimeType: 'application/octet-stream',
     });
+    if (opts.data == null) opts.data = null;
+    if (opts.method == null) opts.method = 'GET';
     return onRequestCreate(opts, this, name);
   },
 };

--- a/src/injected/web/requests.js
+++ b/src/injected/web/requests.js
@@ -29,6 +29,8 @@ const OPTS_TO_PASS = [
   'method',
   'overrideMimeType',
   'password',
+  'saveAs',
+  'conflictAction',
   'timeout',
   'user',
 ];

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -43,6 +43,8 @@ permissions:
   - clipboardWrite
   - contextMenus
   - cookies
+optional_permissions:
+  - downloads
 commands:
   _execute_browser_action: {}
   toggleInjection:

--- a/src/options/views/tab-settings/index.vue
+++ b/src/options/views/tab-settings/index.vue
@@ -82,6 +82,16 @@
           </locale-group>
         </div>
         <setting-check name="helpForLocalFile" :label="i18n('helpForLocalFile')"/>
+        <div class="ml-2c">
+          <tooltip :content="i18n('labelGmDownloadModeBrowserHint')">
+            <setting-check name="gmDownloadModeBrowser">
+              {{ i18n('labelGmDownloadModeBrowser') }} <ruby v-text="i18n('labelGmDownloadModeBrowserPermissionRequired')" />
+            </setting-check>
+          </tooltip>
+          <button class="btn-ghost" :disabled="permGranted"
+                  @click="requestDlPerm"
+                  v-text="i18n('labelGmDownloadModeBrowserGrantPerm')" />
+        </div>
       </section>
 
       <section>
@@ -136,6 +146,7 @@ const items = {
     light: i18n('optionUiThemeLight'),
   },
   xhrInject: value => value,
+  gmDownloadModeBrowser: value => value,
 };
 </script>
 
@@ -154,6 +165,13 @@ import VmEditor from './vm-editor';
 import VmBlacklist from './vm-blacklist';
 import VmDateInfo from './vm-date-info';
 import { kbdTypable } from '@/common/keyboard';
+import browser from '@/common/browser';
+
+const permGranted = ref(false);
+
+async function requestDlPerm() {
+  permGranted.value = await browser.permissions.request({ permissions: ['downloads'] });
+}
 
 const $el = ref();
 const settings = reactive({});
@@ -168,6 +186,7 @@ onActivated(() => {
     ...hookSettingsForUI(items, settings, watch, 50),
   ];
   expose.value = Object.keys(options.get(EXPOSE)).map(k => [k, decodeURIComponent(k)]);
+  browser.permissions.contains({ permissions: ['downloads'] }).then(r => { permGranted.value = r; });
 });
 
 onDeactivated(() => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -364,6 +364,7 @@ declare namespace VMInjection {
     };
     ua: VMScriptGMInfoPlatform;
     uad?: true;
+    gmDownloadModeBrowser?: boolean;
   }
   /**
    * Script prepared for injection
@@ -448,23 +449,35 @@ declare type VMMessageTargetFrame = { frameId?: number } | { documentId?: string
 declare type VMTopRenderMode = 0 | 1 | 2 | 3 | 4;
 
 declare var __: {
-  CODEMIRROR_THEMES: string;
-  DEBUG: boolean,
-  DEV: boolean,
-  /** An extension context with full access to chrome API i.e. not offscreen, content */
-  EXT: boolean,
-  MV3: boolean;
-  INIT_FUNC_NAME: string;
-  INJECTED: string | false;
-  SW: boolean;
-  SW_CLIENT: boolean;
-  SYNC_DROPBOX_CLIENT_ID: string,
-  SYNC_GOOGLE_DESKTOP_ID: string,
-  SYNC_GOOGLE_DESKTOP_SECRET: string,
-  SYNC_ONEDRIVE_ACCOUNT_TYPE: string,
-  SYNC_ONEDRIVE_CLIENT_ID: string,
-  TEST: boolean,
-  VM_VER: string,
+ CODEMIRROR_THEMES: string;
+ DEBUG: boolean,
+ DEV: boolean,
+ /** An extension context with full access to chrome API i.e. not offscreen, content */
+ EXT: boolean,
+ MV3: boolean;
+ INIT_FUNC_NAME: string;
+ INJECTED: string | false;
+ SW: boolean;
+ SW_CLIENT: boolean;
+ SYNC_DROPBOX_CLIENT_ID: string,
+ SYNC_GOOGLE_DESKTOP_ID: string,
+ SYNC_GOOGLE_DESKTOP_SECRET: string,
+ SYNC_ONEDRIVE_ACCOUNT_TYPE: string,
+ SYNC_ONEDRIVE_CLIENT_ID: string,
+ TEST: boolean,
+ VM_VER: string,
 };
+
+/**
+ * The download mode for the current script: `"native"` or `"browser"`.
+ *
+ * - `"native"` — downloads use XMLHttpRequest.
+ * - `"browser"` — downloads are delegated to the browser's native download manager
+ *   (`browser.downloads.download`), controlled by the "Use browser download API"
+ *   setting in Violentmonkey's Advanced settings.
+ */
+declare interface VMScriptGMInfoObject {
+  downloadMode: 'native' | 'browser';
+}
 
 //#endregion Generic

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -449,23 +449,23 @@ declare type VMMessageTargetFrame = { frameId?: number } | { documentId?: string
 declare type VMTopRenderMode = 0 | 1 | 2 | 3 | 4;
 
 declare var __: {
- CODEMIRROR_THEMES: string;
- DEBUG: boolean,
- DEV: boolean,
- /** An extension context with full access to chrome API i.e. not offscreen, content */
- EXT: boolean,
- MV3: boolean;
- INIT_FUNC_NAME: string;
- INJECTED: string | false;
- SW: boolean;
- SW_CLIENT: boolean;
- SYNC_DROPBOX_CLIENT_ID: string,
- SYNC_GOOGLE_DESKTOP_ID: string,
- SYNC_GOOGLE_DESKTOP_SECRET: string,
- SYNC_ONEDRIVE_ACCOUNT_TYPE: string,
- SYNC_ONEDRIVE_CLIENT_ID: string,
- TEST: boolean,
- VM_VER: string,
+  CODEMIRROR_THEMES: string;
+  DEBUG: boolean,
+  DEV: boolean,
+  /** An extension context with full access to chrome API i.e. not offscreen, content */
+  EXT: boolean,
+  MV3: boolean;
+  INIT_FUNC_NAME: string;
+  INJECTED: string | false;
+  SW: boolean;
+  SW_CLIENT: boolean;
+  SYNC_DROPBOX_CLIENT_ID: string,
+  SYNC_GOOGLE_DESKTOP_ID: string,
+  SYNC_GOOGLE_DESKTOP_SECRET: string,
+  SYNC_ONEDRIVE_ACCOUNT_TYPE: string,
+  SYNC_ONEDRIVE_CLIENT_ID: string,
+  TEST: boolean,
+  VM_VER: string,
 };
 
 /**


### PR DESCRIPTION
Added the option in advanced settings to have `GM_download` use the [browser download api](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/downloads/download).

You can pass the arguments to `GM_download` and they will be forwarded to the browser downloads api. The previous behavior with XML http request should be unchanged, but now the extension also needs an optional `downloads` permission.

I have tested that it works on firefox (152.0).

Closes #1349.