### PR TITLE
A few fixes for the mv3 branch

### DIFF
--- a/scripts/manifest-helper.js
+++ b/scripts/manifest-helper.js
@@ -26,7 +26,7 @@ function readManifest() {
     // TODO: use it when it graduates from Canary into Stable
     // message_serialization: 'structured_clone',
     host_permissions: ['<all_urls>'],
-    permissions: data.permissions.filter(p => p !== '<all_urls>').concat([
+    permissions: data.permissions.filter(p => p !== '<all_urls>' && p !== 'webRequestBlocking').concat([
       'alarms',
       'declarativeNetRequestWithHostAccess',
       !isProd && 'declarativeNetRequestFeedback',

--- a/src/background/utils/requests.js
+++ b/src/background/utils/requests.js
@@ -176,7 +176,7 @@ async function httpRequest(opts, events, src, cb) {
 
 function addDnrHeaders(req, xhrUrl, vmHeaders) {
   let ruleId = DNR_ID_XHR; while (xhrRules[++ruleId]) {/**/}
-  req.ruleId = ruleId;
+  req.ruleId = xhrRules[ruleId] = ruleId;
   updateSessionRules(ruleId, {
     tabIds: [-1/*chrome.tabs.TAB_ID_NONE*/],
     urlFilter: '|' + xhrUrl + '|',

--- a/src/background/utils/session-data.js
+++ b/src/background/utils/session-data.js
@@ -19,7 +19,7 @@ let sessionData = __.MV3 && chrome.storage.session.get().then(data => (
   sessionData = data
 ));
 
-export default sessionData;
+export { sessionData as default };
 
 export async function flushSession(key, val) {
   if (flushing) {

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -162,7 +162,7 @@ let keepAliveChain, keepAliveTimer;
 export function keepAlive(promise) {
   let res = promise;
   if (!res) ({promise, resolve: res} = Promise.withResolvers());
-  const chain = keepAliveChain = keepAliveChain ? keepAliveChain.finally(promise) : promise;
+  const chain = keepAliveChain = keepAliveChain ? keepAliveChain.finally(() => promise) : promise;
   keepAliveChain.finally(() => {
     if (keepAliveChain === chain) {
       clearInterval(keepAliveTimer);


### PR DESCRIPTION
I've been going through the mv3 branch and hit a few bugs. They're all small and unrelated, so each one is its own commit, but if I should split into multiple PRs, let me know.

- `keepAlive` lets the worker die too early. `keepAliveChain.finally(promise)` hands a promise to `finally`, which only takes a callback, so the argument is quietly ignored and the chain resolves as soon as the first keeper does. Open two tabs that each hold a value opener, close one, and the 25s ping stops while the other is still live, so the worker gets torn down mid-write. Same thing when a `GM_xhr` overlaps a short `makePause`. Wrapping it as `finally(() => promise)` makes the chain wait like it was meant to.

- Every `GM_xhr` ends up on the same DNR rule. `xhrRules` never gets written, so the id search in `addDnrHeaders` always returns `DNR_ID_XHR + 1`. Two requests spoofing headers at the same time overwrite each other's rule, and whichever finishes first deletes the one the other is still using. I marked the slot the way `blobRules` already does.

- `sessionData.init` is always undefined. `export default sessionData` copies the promise at export time, so importers keep seeing the pending promise instead of the resolved object, and the once-per-session guard in `db.js` never fires. The full vacuum and `checkRemove` then run on every wake. A live binding fixes it.

- `webRequestBlocking` is still in the mv3 manifest even though nothing registers a blocking listener anymore. CWS review tends to flag it. The permission filter already drops `<all_urls>`, so I added it there too.

Builds and tests pass on both targets, and the mv2 output doesn't change.