### PR TITLE
Move Drive from offscreen to service worker with custom XML parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@usync/oauth2": "^0.1.7",
     "@usync/sync": "^0.1.1",
     "@violentmonkey/shortcut": "^1.4.4",
+    "@violentmonkey/xml-parser": "^1.0.0",
     "codemirror": "^5.65.20",
     "fflate": "^0.8.3",
     "tldts": "^7.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@violentmonkey/shortcut':
         specifier: ^1.4.4
         version: 1.4.4
+      '@violentmonkey/xml-parser':
+        specifier: ^1.0.0
+        version: 1.0.0
       codemirror:
         specifier: ^5.65.20
         version: 5.65.20
@@ -2097,6 +2100,9 @@ packages:
 
   '@violentmonkey/types@0.3.3':
     resolution: {integrity: sha512-ISaLOU7tBR8WiSgHAzrYj5GHU99YP+ZAB0YNwaN7vvK9TZLm4LjxOLHnqy9O7dd0LAEVAa60r8jLd6VSZfsjLA==}
+
+  '@violentmonkey/xml-parser@1.0.0':
+    resolution: {integrity: sha512-b85soSVIrN23l2WXeMUSsUiHQr7GFUgbmbYOuKDQEgM+uRmHf/gCY+P49IhzmnGO0ME0wTaAVRvlkksxcfZ+kA==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -8004,6 +8010,8 @@ snapshots:
   '@violentmonkey/types@0.3.3':
     dependencies:
       user-agent-data-types: 0.4.2
+
+  '@violentmonkey/xml-parser@1.0.0': {}
 
   '@volar/language-core@2.4.28':
     dependencies:

--- a/src/background/sync/sync-engine.js
+++ b/src/background/sync/sync-engine.js
@@ -7,12 +7,12 @@ import {
   USER_CONFIG,
 } from '@/common/consts-sync';
 import { forEachEntry, objectPick, objectSet } from '@/common/object';
-import { addOwnCommands, getOption, setOption } from '../utils';
+import { getOption, setOption } from '../utils';
 import broadcast from '../utils/broadcast';
 import { sortScripts, updateScriptInfo } from '../utils/db';
 import { DNR_ID_IDENTITY, updateSessionRules } from '../utils/dnr';
-import callOffscreen from '../utils/offscreen';
 import { script as pluginScript } from '../plugin';
+import { parseXml } from '@violentmonkey/xml-parser';
 import sessionData from '../utils/session-data';
 import {
   events,
@@ -43,23 +43,10 @@ const serviceNames = [];
 const serviceClasses = [];
 const services = {};
 const syncLater = !__.MV3 && debounce(autoSync, TIMEOUT_HOUR);
-const getDrive = (...init) =>
-  !__.MV3
-    ? new DriveProviders[init.shift()](...init)
-    : Object.create(new Proxy({}, {
-        get: (dummy, cmd, obj) => (obj[cmd] = (...args) => callOffscreen('Drive', [
-          cmd,
-          args,
-          init.splice(0) /*emptying*/,
-        ])),
-      }));
+const xmlParser = { parse: str => parseXml(str, { removeNSPrefix: true }).node };
+const getDrive = (provider, opts, ctx) => new DriveProviders[provider](opts, { ...ctx, xmlParser });
 let syncConfig;
 let syncMode = SYNC_MERGE;
-
-if (__.MV3)
-  addOwnCommands({
-    DriveAuth: ([cmd, args]) => getService().authorizer?.[cmd](...args),
-  });
 
 // --- Logging ---
 
@@ -381,13 +368,11 @@ export function createSyncService({
     try {
       const batches = drive.list();
       // eslint-disable-next-line no-unused-vars
-      for await (const batch of __.MV3
-        ? getListFromPort(await batches)
-        : batches) {
+      for await (const batch of batches) {
         break;
       }
     } catch (err) {
-      if ((__.MV3 ? err.cause : err.response?.status) === 404 && driveProvider === 'webdav') {
+      if ((err.response?.status) === 404 && driveProvider === 'webdav') {
         await drive.mkdir(VIOLENTMONKEY);
       } else {
         prepareError = err;
@@ -487,10 +472,7 @@ export function createSyncService({
     const files = [];
     const batches = drive.list();
     progress.total += 1;
-    for await (const batch of __.MV3
-      ? getListFromPort(await batches)
-      : batches) {
-      if (__.MV3 && !batch) break; // the last item is a dummy end marker
+    for await (const batch of batches) {
       files.push(...batch);
     }
     progress.finished += 1;
@@ -536,24 +518,6 @@ export function createSyncService({
       scripts,
       await pluginScript.list(),
     ];
-  }
-
-  /** @param {MessagePort} port */
-  function* getListFromPort(port) {
-    let resolver, done;
-    port.onmessage = ({ data }) => {
-      done = !data;
-      if (!done) {
-        done = data.err;
-        data = done ? Promise.reject(done) : data.res;
-      }
-      resolver(data);
-    };
-    try {
-      while (!done) yield new Promise((resolve) => (resolver = resolve));
-    } finally {
-      port.onmessage = null;
-    }
   }
 
   // --- Sync algorithm ---
@@ -865,7 +829,7 @@ export function createSyncService({
       drive = getDrive(
         driveProvider,
         { authProvider, user: '' },
-        __.MV3 ? 'auth' : { authorizer },
+        { authorizer },
       );
     } else {
       initPassword();

--- a/src/background/utils/offscreen.js
+++ b/src/background/utils/offscreen.js
@@ -17,7 +17,7 @@ async function init() {
     await chrome.offscreen.createDocument({
       url: URL,
       justification: 'MV3 requirement',
-      reasons: ['BLOBS', 'CLIPBOARD', 'DOM_PARSER', 'WORKERS'],
+      reasons: ['BLOBS', 'CLIPBOARD', 'WORKERS'],
     });
   } catch (err) {
     if (!err.message.startsWith('Only a single offscreen')) {

--- a/src/offscreen/index.js
+++ b/src/offscreen/index.js
@@ -2,20 +2,12 @@ import { leaseBlobUrl } from '@/common';
 import setClipboard from '@/common/clipboard';
 import handlers from '@/common/handlers';
 import { sendCmdToSW } from '@/common/messaging-sw';
-import { DriveProviders } from '@usync/drive';
 import { initXHR, xhrs } from './xhr';
 
-let drive;
 let autoCloseTimer;
 
 Object.assign(handlers, {
   LeaseBlob: leaseBlobUrl,
-  Drive: ([cmd, args, init], src, transfer) => (
-    init.length && initDrive(...init),
-    cmd === 'list'
-      ? (listDrive(cmd, args, transfer), transfer[0])
-      : drive[cmd](...args)
-  ),
   async Fetch([url, init, get = 'text']) {
     const req = await fetch(url, init);
     return {
@@ -44,30 +36,4 @@ chrome.runtime.onConnect.addListener(port => {
 
 function autoClose() {
   autoCloseTimer ||= setTimeout(close, 15 * 60e3);
-}
-
-function initDrive(provider, opts, context) {
-  drive = new DriveProviders[provider](opts, context !== 'auth' ? context : {
-    authorizer: Object.create(new Proxy({}, {
-      get: (dummy, cmd, obj) => (obj[cmd] =
-        (...args) => sendCmdToSW('DriveAuth', [cmd, args])
-      ),
-    })),
-  });
-}
-
-async function listDrive(cmd, args, transfer) {
-  const mc = new MessageChannel();
-  const port = mc.port1;
-  transfer[0] = mc.port2; // must be before async work as it's used by the caller
-  try {
-    for await (const item of drive[cmd](...args)) {
-      port.postMessage({ res: item });
-    }
-    port.postMessage(null);
-  } catch (err) {
-    // `cause` is a standard property that can be sent via messaging.
-    err.cause = err.response?.status;
-    port.postMessage({ err });
-  }
 }


### PR DESCRIPTION
This is a follow-up to #2548, addressing https://github.com/violentmonkey/violentmonkey/pull/2548#issuecomment-4870796717.

DOMParser is unavailable in service workers, so Drive had to run in the offscreen document. This required a proxy layer that routed every method call, async iterator, and authorizer interaction through the offscreen bridge — adding complexity and a failure point.

This PR replaces DOMParser with [@violentmonkey/xml-parser](https://github.com/violentmonkey/xml-parser), which works natively in the service worker. With that, Drive can run directly in the SW.