### PR TITLE
fix #2624: read a page's blob: URL in the content realm for GM_download

### DIFF
--- a/src/background/utils/requests.js
+++ b/src/background/utils/requests.js
@@ -1,5 +1,6 @@
 import { keepAlive, noop, sendTabCmd, string2uint8array } from '@/common';
 import { CHARSET_UTF8, FORM_URLENCODED, UA_PROPS, UPLOAD } from '@/common/consts';
+import { downloadBlob } from '@/common/download';
 import { deepEqual, forEachEntry, forEachValue } from '@/common/object';
 import { kGmDownloadViaApi } from '@/common/options-defaults';
 import { initXHR } from '@/offscreen/xhr';
@@ -69,6 +70,8 @@ addPublicCommands({
     )(opts, events, id, req, src, fileName).catch(cbError);
   },
   AbortRequest: abortRequest,
+  /** Used by injected/content for a page's `blob:` URL, which only it can read */
+  DownloadBlob: __.MV3 ? callOffscreen : args => downloadBlob(args[0], args[1]),
   // TODO: check if the content script can revoke it
   RevokeBlob: __.MV3 ? callOffscreen : URL.revokeObjectURL,
 });

--- a/src/injected/content/requests.js
+++ b/src/injected/content/requests.js
@@ -1,10 +1,11 @@
 import { U8_fromBase64, UA_PROPS, UPLOAD } from '../util';
 import * as bridge from './bridge';
-import { makeSafeBlob, sendCmd } from './util';
+import { createObjectURL, makeSafeBlob, sendCmd } from './util';
 
 const CHUNKS = 'chunks';
 const LOAD = 'load';
 const LOADEND = 'loadend';
+const READYSTATECHANGE = 'readystatechange';
 /** @type {{ [id:string]: GMReq.Content }} */
 const requests = createNullObj();
 let BlobProto, getArrayBuffer, getBlob, getBlobType, getTypedArrayBuffer;
@@ -58,6 +59,10 @@ bridge.addHandlers({
   async HttpRequest(msg, realm) {
     if (IS_FIREFOX) msg = nullObjFrom(msg); // copying into our realm to set its props freely
     else setPrototypeOf(msg, null);
+    const fileName = msg[kFileName];
+    if (fileName && msg.url::slice(0, 5) === 'blob:') {
+      return downloadPageBlob(msg, fileName, realm);
+    }
     const data = !IS_FIREFOX && msg.data;
     const uaData = getUAData && navigator::getUAData();
     requests[msg.id] = {
@@ -144,6 +149,49 @@ bridge.addBackgroundHandlers({
 function sendHttpRequested(msg, realm) {
   bridge.post('HttpRequested', msg, realm);
 }
+
+/**
+ * A `blob:` URL is only valid in the context that created it, so a page's blob can't be
+ * re-fetched in bg/offscreen (Firefox fails it with status 0). Only a content script can
+ * read it, hence this shortcut for `GM_download` of such URLs.
+ * @param {GMReq.Message.Web} msg
+ * @param {string} fileName
+ * @param {VMScriptInjectInto} realm
+ * @return {Promise<void>}
+ */
+async function downloadPageBlob(msg, fileName, realm) {
+  const { id, url } = msg;
+  const events = msg.events[0];
+  let blob;
+  try {
+    blob = await importBlob(url, true);
+  } catch (err) {
+    sendHttpRequested({
+      id,
+      type: ERROR,
+      data: null,
+      [ERROR]: [err && err.message || `${err}`, err && err.name],
+    }, realm);
+    sendHttpRequested({ id, type: LOADEND, data: makeVirtualResponse(url, 0) }, realm);
+    return;
+  }
+  // download in bg to a) circumvent CSP in Firefox and b) use a single throttled download chain
+  sendCmd('DownloadBlob', [IS_FIREFOX ? blob : createObjectURL(blob), fileName]);
+  for (const type of [READYSTATECHANGE, LOAD, LOADEND]) {
+    if (!(type === LOADEND/*to forget the request*/ || events[type]))
+      continue;
+    sendHttpRequested({ id, type, data: makeVirtualResponse(url, 200) }, realm);
+  }
+}
+
+/** `response` is null to match the browser downloads API mode and the spec, see db1b5c3e */
+const makeVirtualResponse = (url, status) => ({
+  finalUrl: url,
+  readyState: 4,
+  status,
+  [kResponse]: null,
+  [kResponseHeaders]: '',
+});
 
 /**
  * Only a content script can read blobs from an extension:// URL

--- a/src/offscreen/index.js
+++ b/src/offscreen/index.js
@@ -1,5 +1,6 @@
 import { leaseBlobUrl } from '@/common';
 import setClipboard from '@/common/clipboard';
+import { downloadBlob } from '@/common/download';
 import handlers from '@/common/handlers';
 import { sendCmdToSW } from '@/common/messaging-sw';
 import { initXHR, xhrs } from './xhr';
@@ -7,6 +8,7 @@ import { initXHR, xhrs } from './xhr';
 let autoCloseTimer;
 
 Object.assign(handlers, {
+  DownloadBlob: args => downloadBlob(args[0], args[1]),
   LeaseBlob: leaseBlobUrl,
   async Fetch([url, init, get = 'text']) {
     const req = await fetch(url, init);


### PR DESCRIPTION
Fixes #2624.

## Problem

In Firefox, `GM_download` of a `blob:` URL created by the page always fails. The callback reports `status: 0`, `finalUrl: ""` and `responseText: null`, and no file reaches the disk.

```js
const url = URL.createObjectURL(new Blob(['hi'], { type: 'text/plain' }));
GM_download({ url, name: 'x.txt', onload: () => console.log('OK'), onerror: e => console.log('FAIL', e) });
```

## Cause

A `blob:` URL is valid only in the context that created it, so bg and offscreen cannot re-fetch it. b8f2f90c ("fix #2072: request local blobs in tab") read such URLs in the content realm instead. db1b5c3e ("fix #2605: reuse bg path for data/blob urls in gmxhr/gmdl") removed that code, which brought #2072 back for Firefox.

## Change

This PR restores the content-realm read, but only for a `blob:` URL that carries a `fileName`, which means `GM_download`.

`injected/content/requests.js` reads the blob with the existing `importBlob` and hands it to bg: the `Blob` itself in Firefox, a `createObjectURL` string elsewhere. It then posts `readystatechange`, `load` and `loadend`, so the script callbacks run. `response` stays `null`, which matches the browser-downloads-API mode that db1b5c3e aligned it with. If the read fails, the code posts an `error` event. Previously the request stalled with no event at all.

`background/utils/requests.js` and `offscreen/index.js` restore the `DownloadBlob` command, wired `__.MV3 ? callOffscreen : downloadBlob` next to `RevokeBlob`. The anchor click stays in bg, which circumvents CSP in Firefox and keeps the single throttled download chain.

**The scope is deliberate, not a full revert.** `data:` URIs and plain `GM_xmlhttpRequest` stay on the background path from db1b5c3e, so #2605 remains fixed. The shortcut is entered only for a URL that starts with `blob:` and has a `fileName`.

## Verification

No unit test: the project has no harness for `GM_download`, `GM_xmlhttpRequest` or the request path, and the jest setup covers neither the content realm nor the web realm.

Instead I tested this branch end to end in real browsers with real builds. geckodriver drove Firefox against the MV2 build (2.46.0) as a temporary add-on, and Playwright drove Chrome for Testing 151 against the unpacked `dist-mv3`. One userscript covers five cases.

| case | Firefox before | Firefox after | Chromium before | Chromium after |
|---|---|---|---|---|
| `GM_download` `blob:` (the bug) | **fails**, `status: 0` | OK, file saved | OK | OK |
| `GM_download` `https:` | OK | OK | OK | OK |
| `GM_download` `data:` (#2605) | OK | OK | OK | OK |
| `GM_xmlhttpRequest` GET | OK | OK | OK | OK |
| `GM_xmlhttpRequest` `blob:` | fails | fails, unchanged | OK | OK |

The tests read every downloaded file from disk and compare its bytes, rather than trusting `onload`. `pnpm lint` and `pnpm test` (48 tests) pass.

## Two related points

1. Plain `GM_xmlhttpRequest` on a page `blob:` URL fails in Firefox too, as the last table row shows. The cause is identical, and this PR does not change it. A wider fix must send the blob contents back to the web realm. db1b5c3e changed that behavior on purpose, so I left it alone rather than guess at the intended semantics.
2. `saveAs` and `conflictAction` no longer apply to a `blob:` URL, because the request never reaches `downloadViaApi`. There is no alternative: `browser.downloads.download()` cannot resolve a page `blob:` URL from bg either. `data:` URIs, the case #2605 actually reported, still route through the browser API.
